### PR TITLE
NP-11 greedy navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* Update navigation with Greedy/Priority+ UI pattern [NP-11]
+
 ## <sub>v0.2.0</sub>
 
 #### _Mar. 2, 2020_

--- a/haml/_navigation.html.haml
+++ b/haml/_navigation.html.haml
@@ -1,2 +1,21 @@
-.cads-navigation
-  = react_component('GlobalNav', {}, { prerender: true })
+%nav.cads-navigation
+  %ul.cads-list-unordered
+    -# should be fed by a loop and local in production version.
+    %li
+      %a.cads-nav-link{href: "/benefits" } Benefits 
+    %li
+      %a.cads-nav-link{href: "https://www.citizensadvice.org.uk/work/"} Work
+    %li
+      %a.cads-nav-link{href: "https://www.citizensadvice.org.uk/debt-and-money/"} Debt and money
+    %li
+      %a.cads-nav-link{href: "https://www.citizensadvice.org.uk/consumer/"} Consumer
+    %li
+      %a.cads-nav-link{href: "https://www.citizensadvice.org.uk/housing/"} Housing
+    %li
+      %a.cads-nav-link{href: "https://www.citizensadvice.org.uk/family/"} Family
+    %li
+      %a.cads-nav-link{href: "https://www.citizensadvice.org.uk/law-and-courts/"} Law and courts
+    %li
+      %a.cads-nav-link{href: "/immigration"} Immigration
+    %li
+      %a.cads-nav-link{href: "https://www.citizensadvice.org.uk/health/"} Health

--- a/js/navigation.js
+++ b/js/navigation.js
@@ -1,0 +1,1 @@
+export * from '@baseonmars/priority-nav';

--- a/package.json
+++ b/package.json
@@ -71,7 +71,9 @@
         "stylelint-selector-bem-pattern": "^2.1.0",
         "webdriverio": "^5.18.6"
     },
-    "dependencies": {},
+    "dependencies": {
+        "@baseonmars/priority-nav": "^1.1.0"
+    },
     "browserslist": [
         "IE 11",
         "last 2 Edge versions",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
         "webdriverio": "^5.18.6"
     },
     "dependencies": {
-        "@baseonmars/priority-nav": "^1.1.0"
+        "@baseonmars/priority-nav": "^1.2.0"
     },
     "browserslist": [
         "IE 11",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
     "description": "Citizens Advice Design System",
     "files": [
         "scss",
+        "js",
         "lib",
         "dist",
         "haml",

--- a/scss/6-components/_navigation.scss
+++ b/scss/6-components/_navigation.scss
@@ -1,4 +1,4 @@
-@import '~@baseonmars/priority-nav/dist/priority-nav-core';
+@import '~@baseonmars/priority-nav/dist/priority-nav-core.css';
 
 nav,
 .cads-navigation {

--- a/scss/6-components/_navigation.scss
+++ b/scss/6-components/_navigation.scss
@@ -17,7 +17,8 @@ nav,
         font-weight: $cads-font-weight__bold;
     }
 
-    .nav__dropdown-toggle.priority-nav__dropdown-toggle {
+    .nav__dropdown-toggle.priority-nav__dropdown-toggle,
+    .nav__dropdown-toggle.priority-nav__dropdown-toggle:hover {
         height: 100%;
         font-weight: bold;
         border-left: 1px solid $cads-palette__white;
@@ -55,6 +56,7 @@ nav,
 
     .priority-nav__dropdown {
         background-color: $cads-palette__heritage-blue;
+        border-top: 1px solid $cads-palette__white;
         right: 0;
         top: 100%;
 

--- a/scss/6-components/_navigation.scss
+++ b/scss/6-components/_navigation.scss
@@ -1,17 +1,30 @@
+@import '~@baseonmars/priority-nav/dist/priority-nav-core';
+
 nav,
 .cads-navigation {
+    display: flex;
+    justify-content: space-between;
     background-color: $cads-palette__heritage-blue;
     width: 100%;
-    overflow: hidden;
     height: 3em;
+
+    ul {
+        display: inline-block;
+    }
 
     li,
     .cads-list-item {
-        display: inline-block;
         font-weight: $cads-font-weight__bold;
     }
 
-    .cads-nav-link {
+    .nav__dropdown-toggle.priority-nav__dropdown-toggle {
+        height: 100%;
+        font-weight: bold;
+        border-left: 1px solid $cads-palette__white;
+    }
+
+    .cads-nav-link,
+    .priority-nav__dropdown-toggle {
         color: $cads-palette__white;
         padding: calc(1em - 1px);
         display: inline-block;
@@ -24,17 +37,34 @@ nav,
         line-height: 1em;
 
         &:hover {
-            background-color: $cads-language__hover-background-colour;
-            border-color: $cads-palette__heritage-blue;
-            color: $cads-palette__heritage-blue;
+            background-color: $cads-language__link-hover-colour;
+            border-color: $cads-language__link-hover-colour;
+            color: $cads-palette__white;
         }
 
         /* stylelint-disable */
-        &:active {
+        &:active,
+        &:focus {
             /* stylelint-enable */
-            border-color: $cads-palette__heritage-yellow;
             background-color: $cads-palette__white;
             color: $cads-palette__heritage-blue;
+            border: 2px solid $cads-palette__heritage-yellow;
+            padding: calc(1em - 2px);
+        }
+    }
+
+    .priority-nav__dropdown {
+        background-color: $cads-palette__heritage-blue;
+        right: 0;
+        top: 100%;
+
+        li {
+            margin-bottom: 0;
+        }
+
+        a {
+            display: block;
+            transition-property: none;
         }
     }
 }

--- a/styleguide/component-wrapper.js
+++ b/styleguide/component-wrapper.js
@@ -2,12 +2,16 @@ import hljs from 'highlight.js'; // eslint-disable-line
 import beautify from 'js-beautify'; // eslint-disable-line
 
 const a11yid = 'a11yComponentToTest';
-const wrapper = (title, component, usage) => {
+const wrapper = (title, component, usage, js) => {
     const source = hljs.highlightAuto(
         beautify.html_beautify(component, {
             indent_size: 2
         })
     ).value;
+
+    if (js && js) {
+        setTimeout(js);
+    }
 
     return `
 <h1 aria-hidden="true">${title}</h1>

--- a/styleguide/component-wrapper.js
+++ b/styleguide/component-wrapper.js
@@ -9,7 +9,7 @@ const wrapper = (title, component, usage, js) => {
         })
     ).value;
 
-    if (js && js) {
+    if (js) {
         setTimeout(js);
     }
 

--- a/styleguide/components.stories.js
+++ b/styleguide/components.stories.js
@@ -8,7 +8,6 @@ import './styles.scss';
 import Breadcrumbs from './components/breadcrumbs';
 import Buttons from './components/buttons';
 import Callout from './components/callout';
-import Navigation from './components/navigation';
 
 // Storybook section setup
 export default {
@@ -30,6 +29,5 @@ export default {
 };
 
 export const callout = () => Callout();
-export const navigation = () => Navigation();
 export const buttons = () => Buttons();
 export const breadcrumbs = () => Breadcrumbs();

--- a/styleguide/haml.stories.js
+++ b/styleguide/haml.stories.js
@@ -84,7 +84,7 @@ export const navigation = () =>
         'navigation',
         `The navigation component uses javascript to display options in a dropdown menu that would otherwise appear off screen.
         \n\n
-        To activate this you should load javascript from <kbd>design_system_path>/js/navigation.js</kbd> then initialise it using <code>priorityNav.init({breakPoint: 0})</code>`,
+        To activate this you should load javascript from <kbd>design_system_path>/js/navigation.js</kbd> then initialise it using <code>priorityNav.init({breakPoint: 0, dropDownLabel: "More"})</code>`,
         null,
         () =>
             priorityNav.init({

--- a/styleguide/haml.stories.js
+++ b/styleguide/haml.stories.js
@@ -6,6 +6,7 @@ import { text } from '@storybook/addon-knobs'; // eslint-disable-line
 // The styles
 import './styles.scss';
 
+import priorityNav from '@baseonmars/priority-nav';
 import wrapper from './component-wrapper';
 
 // Haml setup
@@ -15,9 +16,11 @@ import * as haml from '../scripts/haml';
 import tFooter from '../haml/_footer.html.haml';
 import tHeader from '../haml/_header.html.haml';
 import tLogo from '../haml/_logo_clickable.html.haml';
+import tNavigation from '../haml/_navigation.html.haml';
 import tSearch from '../haml/_search.html.haml';
 import tNoticeBanner from '../haml/_notice_banner.html.haml';
 import tBreadcrumb from '../haml/_breadcrumb.html.haml';
+
 // ...then queue in memory partials that are used by other partials
 haml.queueTemplate('logo_clickable', tLogo);
 haml.queueTemplate('search', tSearch);
@@ -28,14 +31,16 @@ function renderHamlTemplate(
     template,
     hamlLocation,
     usage,
-    optionalProps
+    optionalProps,
+    optionalJS
 ) {
     return wrapper(
         templateName,
         haml.render(template, { ...hamlProps, ...optionalProps }),
         `The partial is available in:
 <pre><code>haml/_${hamlLocation}.html.haml</code></pre>
-${usage || ''}`
+${usage || ''}`,
+        optionalJS
     );
 }
 
@@ -72,6 +77,22 @@ export const logo = () =>
         `You can use the <code>cads-logo</code> class on anything to display the logo.
 Make sure that an accessible title/etc is available.`
     );
+export const navigation = () =>
+    renderHamlTemplate(
+        'Navigation',
+        tNavigation,
+        'navigation',
+        `The navigation component uses javascript to display options in a dropdown menu that would otherwise appear off screen.
+        \n\n
+        To activate this you should load javascript from <kbd>design_system_path>/js/navigation.js</kbd> then initialise it using <code>priorityNav.init({breakPoint: 0})</code>`,
+        null,
+        () =>
+            priorityNav.init({
+                breakPoint: 0,
+                navDropdownLabel: 'More'
+            })
+    );
+
 export const noticeBanner = () => {
     const notice_banner_content = text(
         'Banner content',

--- a/yarn.lock
+++ b/yarn.lock
@@ -752,10 +752,10 @@
     lodash "^4.17.13"
     to-fast-properties "^2.0.0"
 
-"@baseonmars/priority-nav@^1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@baseonmars/priority-nav/-/priority-nav-1.1.0.tgz#3eff5b1ba0039415e3a02d9539da551e279053c7"
-  integrity sha512-/x1rESD4WmaLn2D04G46N6jR3PIlVtqi8VK9UGu4veUNWrO0gRfTk3apTNxBQNEQskPsBhLYRkxEX5Dku2U7zQ==
+"@baseonmars/priority-nav@^1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@baseonmars/priority-nav/-/priority-nav-1.2.0.tgz#a30f8e0eaeb24ef0bf2f9cf33adc4e1a49de31ed"
+  integrity sha512-K4PjD81cCEZetc2zpZ343/N6xrICc6Xz78MThsmUYCb4KqLr2MmAlVy/2B7JOZ7azRYRbzgS470Rs9FU8gu0vw==
 
 "@chromaui/localtunnel@1.10.1":
   version "1.10.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -752,6 +752,11 @@
     lodash "^4.17.13"
     to-fast-properties "^2.0.0"
 
+"@baseonmars/priority-nav@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@baseonmars/priority-nav/-/priority-nav-1.1.0.tgz#3eff5b1ba0039415e3a02d9539da551e279053c7"
+  integrity sha512-/x1rESD4WmaLn2D04G46N6jR3PIlVtqi8VK9UGu4veUNWrO0gRfTk3apTNxBQNEQskPsBhLYRkxEX5Dku2U7zQ==
+
 "@chromaui/localtunnel@1.10.1":
   version "1.10.1"
   resolved "https://registry.yarnpkg.com/@chromaui/localtunnel/-/localtunnel-1.10.1.tgz#34da7dab7055a16b1b9034a9eb7e3054ebec4b98"


### PR DESCRIPTION
Stand alone JS/CSS version of greedy nav. 

This version does not use React - thinking behind this is that navigation should be available as soon as possible and load as few resources as possible.

Not yet tested with rails so may require some revision to integrate smoothly.

Design: https://www.figma.com/file/IZY9uqY9RPjhIUv8ol1qjf/DS_Work-In-Progress?node-id=159%3A474

Ticket: https://citizensadvice.atlassian.net/browse/NP-11

Preview:
![menu](https://user-images.githubusercontent.com/45935/75800007-d6d19080-5d70-11ea-98f9-f5116bba5bf7.gif)
