### PR TITLE
NP-200, NP-205 fix: update priority-nav fixing tabbing and resize bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 * NP-16 Design System Automation Framework
 
+* NP-200, NP-205 Update priority-nav to latest, fixing tabbing and resizing bugs
+
 ## <sub>v0.4.0</sub>
 
 #### _Mar. 12, 2020_

--- a/package-lock.json
+++ b/package-lock.json
@@ -957,9 +957,9 @@
             }
         },
         "@baseonmars/priority-nav": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/@baseonmars/priority-nav/-/priority-nav-1.2.0.tgz",
-            "integrity": "sha512-K4PjD81cCEZetc2zpZ343/N6xrICc6Xz78MThsmUYCb4KqLr2MmAlVy/2B7JOZ7azRYRbzgS470Rs9FU8gu0vw=="
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/@baseonmars/priority-nav/-/priority-nav-1.3.0.tgz",
+            "integrity": "sha512-oZY6ve3CdbGpM6iRglVbwTmCYfLBYbfNajJxj+2q5lTAbdjLvAAtHjEv4eFqJyDpZmI4xJycY1N4+9OuEepivQ=="
         },
         "@emotion/cache": {
             "version": "10.0.29",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
         "webdriverio": "^5.18.6"
     },
     "dependencies": {
-        "@baseonmars/priority-nav": "^1.2.0"
+        "@baseonmars/priority-nav": "^1.3.0"
     },
     "browserslist": [
         "IE 11",


### PR DESCRIPTION
Fixes:
NP-200: Greedy nav behaviour breaking on Safari when user restore the screen
NP-205: Greedy navigation needs to close after the last item o menu loses the focus