### PR TITLE
NP-241 copy fonts to dist folder

### DIFF
--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -10,6 +10,18 @@ module.exports = async ({ config, mode }) => {
             use: ['style-loader', 'css-loader', 'sass-loader']
         },
         {
+            test: /\.(woff|ttf|eot|svg).*$/,
+            use: [
+                {
+                    loader: 'file-loader',
+                    options: {
+                        name: '[name].[ext]',
+                        outputPath: 'fonts/'
+                    }
+                }
+            ]
+        },
+        {
             test: /\.md$/,
             use: ['markdown-loader']
         },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* NP-241 Copy fonts to dist folder
+
 ## <sub>v0.5.1</sub>
 
 #### _Mar. 25, 2020_
@@ -51,7 +53,7 @@
 
 #### _Mar. 5, 2020_
 
-* NP-91: Amend callout 
+* NP-91: Amend callout
 
 ## <sub>v0.3.0</sub>
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@citizensadvice/design-system",
-    "version": "0.5.0",
+    "version": "0.5.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -10637,6 +10637,12 @@
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
             "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+            "dev": true
+        },
+        "ncp": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/ncp/-/ncp-2.0.0.tgz",
+            "integrity": "sha1-GVoh1sRuNh0vsSgbo4uR6d9727M=",
             "dev": true
         },
         "negotiator": {

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -4,6 +4,7 @@ const autoprefixer = require('autoprefixer');
 const cssnano = require('cssnano');
 const postcss = require('postcss');
 const fs = require('fs-extra');
+const { ncp } = require('ncp');
 const path = require('path');
 const chalk = require('chalk');
 
@@ -42,6 +43,14 @@ function compileSass() {
     );
 }
 
+function copyFonts() {
+    ncp(
+        `${PATH}/fonts/`,
+        `${OUTPUT_DIR}/fonts`,
+        err => err && log(chalk.red(`Error copying fonts: ${err}`))
+    );
+}
+
 // Only run if the -r param is given
 if (process.argv[2] === '-r') {
     // Make sure the output dir exists
@@ -49,6 +58,7 @@ if (process.argv[2] === '-r') {
         fs.mkdirSync(OUTPUT_DIR);
     }
     compileSass();
+    copyFonts();
 }
 
 module.exports = {


### PR DESCRIPTION
When trying to consume the build `dist/lib.css` file in `public-website` the build fails as references to fonts are incorrect.

This is one way to fix this problem (at least I think it will) by copying the fonts into `dist/fonts`.

Another option would be to re-write the urls - this doesn't appear to be a feature of sass. Maybe we can explore using webpack to do this?