### PR TITLE
Updating button styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## <sub>v0.6.1</sub>
+
+#### _Apr. 1, 2020_
+
+* Update design of buttons
+
 ## <sub>v0.6.0</sub>
 
 #### _Mar. 27, 2020_

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,3 @@
-## <sub>v0.6.1</sub>
-
-#### _Apr. 1, 2020_
-
 * Update design of buttons
 
 ## <sub>v0.6.0</sub>

--- a/scss/1-settings/_colour-language.scss
+++ b/scss/1-settings/_colour-language.scss
@@ -18,7 +18,7 @@ $cads-language__error-colour: $cads-palette__red;
 $cads-language__primary-button-colour: $cads-palette__teal;
 $cads-language__primary-button-hover-colour: $cads-palette__teal-dark;
 $cads-language__secondary-button-hover-colour: $cads-language__hover-background-colour;
-$cads-language__button-shadow-colour: $cads-palette__mid-grey;
+$cads-language__button-shadow-colour: $cads-palette__teal-dark;
 $cads-language__warning-colour: $cads-palette__red;
 
 // The following map is only used to provide a loop for displaying the colours in Storybook.

--- a/scss/4-elements/_buttons.scss
+++ b/scss/4-elements/_buttons.scss
@@ -13,7 +13,7 @@ button,
     padding: (rem-to-px($cads-spacing-3) - 1px) $cads-spacing-3;
     display: inline-block;
     cursor: pointer;
-    box-shadow: 1px 1px 0 0 $cads-language__button-shadow-colour;
+    box-shadow: 0 2px 0 0 $cads-language__button-shadow-colour;
     outline: none !important;
     margin: 0 0 $cads-spacing-5 0;
 
@@ -31,11 +31,13 @@ button,
 
     &__secondary {
         background-color: $cads-palette__white;
-        color: $cads-palette__black;
+        color: $cads-language__primary-button-colour;
+        box-shadow: 0 2px 0 0 $cads-language__primary-button-colour;
 
         &:hover {
-            color: $cads-palette__black;
             background-color: $cads-language__secondary-button-hover-colour;
+            color: $cads-language__primary-button-hover-colour;
+            box-shadow: 0 2px 0 0 $cads-language__button-shadow-colour;
         }
     }
 
@@ -45,6 +47,6 @@ button,
         color: $cads-language__focus-text-colour;
         border-color: $cads-language__focus-border-colour;
         background-color: $cads-language__focus-colour;
-        box-shadow: 1px 1px 0 0 $cads-language__button-shadow-colour;
+        box-shadow: 0 2px 0 0 $cads-language__focus-border-colour;
     }
 }


### PR DESCRIPTION
The mid grey box-shadow looked a bit fuzzy once we saw it in code. 
![Screenshot 2020-04-01 at 12 24 45](https://user-images.githubusercontent.com/19776089/78131995-e0075900-7413-11ea-992f-b19068a68f43.png)


Sonia and Shakira worked on some small design updates which keeps the box-shadow for affordance. 
![Screenshot 2020-04-01 at 12 26 11](https://user-images.githubusercontent.com/19776089/78132078-00371800-7414-11ea-88e4-d6058c583859.png)


There are changes to hover and focus styles as well.