### PR TITLE
NP-272 - Running BackstopJS on Jenkins

### DIFF
--- a/bin/docker/lint
+++ b/bin/docker/lint
@@ -3,5 +3,6 @@
 set -e
 
 source bin/docker/compose_files
+source bin/docker/network
 
 docker-compose ${COMPOSE_FILES[@]} run --rm --no-deps ca-styleguide bin/lint

--- a/bin/docker/network
+++ b/bin/docker/network
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -e
+set -o pipefail
+
+DEFAULT_DOCKER_NETWORK='cita'
+
+if [[ -z "$(docker network ls | grep "${DEFAULT_DOCKER_NETWORK}")" ]]; then
+  docker network create "${DEFAULT_DOCKER_NETWORK}"
+fi

--- a/bin/docker/start_debug
+++ b/bin/docker/start_debug
@@ -3,9 +3,8 @@
 set -e
 
 source bin/docker/stop_if_compose_changed
-source bin/docker/network
 source bin/docker/compose_files
 
 echo "$(date) - Starting application..."
-docker-compose ${COMPOSE_FILES[@]} up --no-recreate -d ca-styleguide
+docker-compose ${COMPOSE_FILES[@]} run --rm --service-ports ca-styleguide
 echo "$(date) - Application started..."

--- a/bin/docker/test
+++ b/bin/docker/test
@@ -3,5 +3,6 @@
 set -e
 
 source bin/docker/compose_files
+source bin/docker/network
 
-docker-compose ${COMPOSE_FILES[@]} run --rm -u 500 ca-styleguide bin/test
+docker-compose ${COMPOSE_FILES[@]} run --rm -u 500 visual-tests

--- a/bin/jenkins/fix_visual_test_report
+++ b/bin/jenkins/fix_visual_test_report
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -e
+
+cp -R testing/backstop_data/bitmaps_reference testing/backstop_data/html_report/bitmaps_reference/
+cp -R testing/backstop_data/bitmaps_test testing/backstop_data/html_report/bitmaps_test/
+
+sed -i -e 's/\.\.\/bitmaps_reference\//bitmaps_reference\//g' testing/backstop_data/html_report/config.js
+sed -i -e 's/\.\.\/bitmaps_test\//bitmaps_test\//g' testing/backstop_data/html_report/config.js

--- a/bin/test
+++ b/bin/test
@@ -2,6 +2,6 @@
 
 set -e
 
-echo 'Running jest'
-# npm run test:coverage || (err=$?; echo "Jest failed" && (exit "$err"))
-echo 'Jest completed'
+echo 'Running BackstopJS'
+npm run vr-test:install && npm run vr-test:ci || (err=$?; echo "BackstopJS failed" && (exit "$err"))
+echo 'BackstopJS completed'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     container_name: ca-styleguide.test
     command: npm run styleguide:ci
     ports:
-      - "6006:6006"
+      - 6006
     tmpfs: /app/tmp
     user: root
     volumes:
@@ -15,6 +15,42 @@ services:
       - app-node_modules:/app/node_modules
     environment:
       - NODE_ENV=development
+    networks:
+      - cita
+    labels:
+      - "traefik.port=6006"
+      - "traefik.backend=ca-styleguide"
+      - "traefik.frontend.rule=Host: ca-styleguide.test"
+      - "traefik.enable=true"
+    links:
+      - styleguide_proxy
+
+  visual-tests:
+    image: backstopjs/backstopjs
+    container_name: visual-tests.test
+    command: test --config=backstop-ci.json
+    volumes:
+      - ./testing:/src
+    networks:
+      - cita
+
+  styleguide_proxy:
+    image: traefik:alpine
+    command: --configFile=/traefik.toml
+    container_name: styleguide_proxy.test
+    ports:
+      - "6006:6006"
+      - "8082:8082"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - ./traefik.toml:/traefik.toml
+    networks:
+      - cita
 
 volumes:
   app-node_modules: {}
+
+networks:
+  cita:
+    external:
+      name: cita

--- a/scripts/vr-test.js
+++ b/scripts/vr-test.js
@@ -76,7 +76,7 @@ storyBook.stdout.on('data', data => {
     if (!started && /^webpack built/.test(data)) {
         started = true;
         log(chalk.green('Storybook started'));
-        log(chalk.black('Running BackstopJS visual regression tests'));
+        log(chalk.green('Running BackstopJS visual regression tests'));
 
         const backstop = childProcess.exec(`cd testing; ${command}`);
 

--- a/testing/backstop-ci.json
+++ b/testing/backstop-ci.json
@@ -28,8 +28,8 @@
         {
             "label": "2_Design_Foundations_COLOUR_LANGUAGE",
             "cookiePath": "backstop_data/engine_scripts/cookies.json",
-            "url": "http://host.docker.internal:6006/iframe.html?id=2-design-foundations--colour-language",
-            "referenceUrl": "http://host.docker.internal:6006/iframe.html?id=2-design-foundations--colour-language",
+            "url": "http://ca-styleguide.test:6006/iframe.html?id=2-design-foundations--colour-language",
+            "referenceUrl": "http://ca-styleguide.test:6006/iframe.html?id=2-design-foundations--colour-language",
             "readyEvent": "",
             "readySelector": ".cads-styleguide__wrapper",
             "delay": 0,
@@ -42,18 +42,19 @@
             "hoverSelector": "",
             "clickSelector": "",
             "postInteractionWait": 0,
-            "selectors": [".cads-styleguide__wrapper"],
+            "selectors": [
+                ".cads-styleguide__wrapper"
+            ],
             "selectorExpansion": true,
             "expect": 0,
             "misMatchThreshold": 0.1,
             "requireSameDimensions": true
         },
-
         {
             "label": "2_Design_Foundations_COLOUR_PALETTE",
             "cookiePath": "backstop_data/engine_scripts/cookies.json",
-            "url": "http://host.docker.internal:6006/iframe.html?id=2-design-foundations--colour-palette",
-            "referenceUrl": "http://host.docker.internal:6006/iframe.html?id=2-design-foundations--colour-palette",
+            "url": "http://ca-styleguide.test:6006/iframe.html?id=2-design-foundations--colour-palette",
+            "referenceUrl": "http://ca-styleguide.test:6006/iframe.html?id=2-design-foundations--colour-palette",
             "readyEvent": "",
             "readySelector": ".cads-styleguide__wrapper",
             "delay": 0,
@@ -66,18 +67,19 @@
             "hoverSelector": "",
             "clickSelector": "",
             "postInteractionWait": 0,
-            "selectors": [".cads-styleguide__wrapper"],
+            "selectors": [
+                ".cads-styleguide__wrapper"
+            ],
             "selectorExpansion": true,
             "expect": 0,
             "misMatchThreshold": 0.1,
             "requireSameDimensions": true
         },
-
         {
             "label": "3_Components_BREADCRUMBS",
             "cookiePath": "backstop_data/engine_scripts/cookies.json",
-            "url": "http://host.docker.internal:6006/iframe.html?id=3-components--breadcrumb",
-            "referenceUrl": "http://host.docker.internal:6006/iframe.html?id=3-components--breadcrumb",
+            "url": "http://ca-styleguide.test:6006/iframe.html?id=3-components--breadcrumb",
+            "referenceUrl": "http://ca-styleguide.test:6006/iframe.html?id=3-components--breadcrumb",
             "readyEvent": "",
             "readySelector": "#a11yComponentToTest",
             "delay": 0,
@@ -89,18 +91,19 @@
             "hoverSelector": "",
             "clickSelector": "",
             "postInteractionWait": 0,
-            "selectors": ["#a11yComponentToTest"],
+            "selectors": [
+                "#a11yComponentToTest"
+            ],
             "selectorExpansion": true,
             "expect": 0,
             "misMatchThreshold": 0.1,
             "requireSameDimensions": true
         },
-
         {
             "label": "3_Components_BUTTONS",
             "cookiePath": "backstop_data/engine_scripts/cookies.json",
-            "url": "http://host.docker.internal:6006/iframe.html?id=3-components--buttons",
-            "referenceUrl": "http://host.docker.internal:6006/iframe.html?id=3-components--buttons",
+            "url": "http://ca-styleguide.test:6006/iframe.html?id=3-components--buttons",
+            "referenceUrl": "http://ca-styleguide.test:6006/iframe.html?id=3-components--buttons",
             "readyEvent": "",
             "readySelector": "#a11yComponentToTest",
             "delay": 0,
@@ -112,18 +115,19 @@
             "hoverSelector": "",
             "clickSelector": "",
             "postInteractionWait": 0,
-            "selectors": ["#a11yComponentToTest"],
+            "selectors": [
+                "#a11yComponentToTest"
+            ],
             "selectorExpansion": true,
             "expect": 0,
             "misMatchThreshold": 0.1,
             "requireSameDimensions": true
         },
-
         {
             "label": "3_Components_CALLOUTS",
             "cookiePath": "backstop_data/engine_scripts/cookies.json",
-            "url": "http://host.docker.internal:6006/iframe.html?id=3-components--callout",
-            "referenceUrl": "http://host.docker.internal:6006/iframe.html?id=3-components--callout",
+            "url": "http://ca-styleguide.test:6006/iframe.html?id=3-components--callout",
+            "referenceUrl": "http://ca-styleguide.test:6006/iframe.html?id=3-components--callout",
             "readyEvent": "",
             "readySelector": "#a11yComponentToTest",
             "delay": 0,
@@ -135,18 +139,19 @@
             "hoverSelector": "",
             "clickSelector": "",
             "postInteractionWait": 0,
-            "selectors": ["#a11yComponentToTest"],
+            "selectors": [
+                "#a11yComponentToTest"
+            ],
             "selectorExpansion": true,
             "expect": 0,
             "misMatchThreshold": 0.1,
             "requireSameDimensions": true
         },
-
         {
             "label": "3_Components_CONTACT_DETAILS",
             "cookiePath": "backstop_data/engine_scripts/cookies.json",
-            "url": "http://host.docker.internal:6006/iframe.html?id=3-components--contact-details",
-            "referenceUrl": "http://host.docker.internal:6006/iframe.html?id=3-components--contact-details",
+            "url": "http://ca-styleguide.test:6006/iframe.html?id=3-components--contact-details",
+            "referenceUrl": "http://ca-styleguide.test:6006/iframe.html?id=3-components--contact-details",
             "readyEvent": "",
             "readySelector": "#a11yComponentToTest",
             "delay": 0,
@@ -158,18 +163,19 @@
             "hoverSelector": "",
             "clickSelector": "",
             "postInteractionWait": 0,
-            "selectors": ["#a11yComponentToTest"],
+            "selectors": [
+                "#a11yComponentToTest"
+            ],
             "selectorExpansion": true,
             "expect": 0,
             "misMatchThreshold": 0.1,
             "requireSameDimensions": true
         },
-
         {
             "label": "3_Components_FOOTER",
             "cookiePath": "backstop_data/engine_scripts/cookies.json",
-            "url": "http://host.docker.internal:6006/iframe.html?id=3-components--footer",
-            "referenceUrl": "http://host.docker.internal:6006/iframe.html?id=3-components--footer",
+            "url": "http://ca-styleguide.test:6006/iframe.html?id=3-components--footer",
+            "referenceUrl": "http://ca-styleguide.test:6006/iframe.html?id=3-components--footer",
             "readyEvent": "",
             "readySelector": "#a11yComponentToTest",
             "delay": 0,
@@ -181,18 +187,19 @@
             "hoverSelector": "",
             "clickSelector": "",
             "postInteractionWait": 0,
-            "selectors": ["#a11yComponentToTest"],
+            "selectors": [
+                "#a11yComponentToTest"
+            ],
             "selectorExpansion": true,
             "expect": 0,
             "misMatchThreshold": 0.1,
             "requireSameDimensions": true
         },
-
         {
             "label": "3_Components_HEADER",
             "cookiePath": "backstop_data/engine_scripts/cookies.json",
-            "url": "http://host.docker.internal:6006/iframe.html?id=3-components--header",
-            "referenceUrl": "http://host.docker.internal:6006/iframe.html?id=3-components--header",
+            "url": "http://ca-styleguide.test:6006/iframe.html?id=3-components--header",
+            "referenceUrl": "http://ca-styleguide.test:6006/iframe.html?id=3-components--header",
             "readyEvent": "",
             "readySelector": "#a11yComponentToTest",
             "delay": 0,
@@ -204,18 +211,19 @@
             "hoverSelector": "",
             "clickSelector": "",
             "postInteractionWait": 0,
-            "selectors": ["#a11yComponentToTest"],
+            "selectors": [
+                "#a11yComponentToTest"
+            ],
             "selectorExpansion": true,
             "expect": 0,
             "misMatchThreshold": 0.1,
             "requireSameDimensions": true
         },
-
         {
             "label": "3_Components_INPUT",
             "cookiePath": "backstop_data/engine_scripts/cookies.json",
-            "url": "http://host.docker.internal:6006/iframe.html?id=3-components--input",
-            "referenceUrl": "http://host.docker.internal:6006/iframe.html?id=3-components--input",
+            "url": "http://ca-styleguide.test:6006/iframe.html?id=3-components--input",
+            "referenceUrl": "http://ca-styleguide.test:6006/iframe.html?id=3-components--input",
             "readyEvent": "",
             "readySelector": "#a11yComponentToTest",
             "delay": 0,
@@ -227,18 +235,19 @@
             "hoverSelector": "",
             "clickSelector": "",
             "postInteractionWait": 0,
-            "selectors": ["#a11yComponentToTest"],
+            "selectors": [
+                "#a11yComponentToTest"
+            ],
             "selectorExpansion": true,
             "expect": 0,
             "misMatchThreshold": 0.1,
             "requireSameDimensions": true
         },
-
         {
             "label": "3_Components_LOGO",
             "cookiePath": "backstop_data/engine_scripts/cookies.json",
-            "url": "http://host.docker.internal:6006/iframe.html?id=3-components--logo",
-            "referenceUrl": "http://host.docker.internal:6006/iframe.html?id=3-components--logo",
+            "url": "http://ca-styleguide.test:6006/iframe.html?id=3-components--logo",
+            "referenceUrl": "http://ca-styleguide.test:6006/iframe.html?id=3-components--logo",
             "readyEvent": "",
             "readySelector": "#a11yComponentToTest",
             "delay": 0,
@@ -250,18 +259,19 @@
             "hoverSelector": "",
             "clickSelector": "",
             "postInteractionWait": 0,
-            "selectors": ["#a11yComponentToTest"],
+            "selectors": [
+                "#a11yComponentToTest"
+            ],
             "selectorExpansion": true,
             "expect": 0,
             "misMatchThreshold": 0.1,
             "requireSameDimensions": true
         },
-
         {
             "label": "3_Components_NAVIGATION",
             "cookiePath": "backstop_data/engine_scripts/cookies.json",
-            "url": "http://host.docker.internal:6006/iframe.html?id=3-components--navigation",
-            "referenceUrl": "http://host.docker.internal:6006/iframe.html?id=3-components--navigation",
+            "url": "http://ca-styleguide.test:6006/iframe.html?id=3-components--navigation",
+            "referenceUrl": "http://ca-styleguide.test:6006/iframe.html?id=3-components--navigation",
             "readyEvent": "",
             "readySelector": "#a11yComponentToTest",
             "delay": 0,
@@ -273,18 +283,19 @@
             "hoverSelector": "",
             "clickSelector": "",
             "postInteractionWait": 0,
-            "selectors": ["#a11yComponentToTest"],
+            "selectors": [
+                "#a11yComponentToTest"
+            ],
             "selectorExpansion": true,
             "expect": 0,
             "misMatchThreshold": 0.1,
             "requireSameDimensions": true
         },
-
         {
             "label": "3_Components_NOTICE_BANNER",
             "cookiePath": "backstop_data/engine_scripts/cookies.json",
-            "url": "http://host.docker.internal:6006/iframe.html?id=3-components--notice-banner",
-            "referenceUrl": "http://host.docker.internal:6006/iframe.html?id=3-components--notice-banner",
+            "url": "http://ca-styleguide.test:6006/iframe.html?id=3-components--notice-banner",
+            "referenceUrl": "http://ca-styleguide.test:6006/iframe.html?id=3-components--notice-banner",
             "readyEvent": "",
             "readySelector": "#a11yComponentToTest",
             "delay": 0,
@@ -296,18 +307,19 @@
             "hoverSelector": "",
             "clickSelector": "",
             "postInteractionWait": 0,
-            "selectors": ["#a11yComponentToTest"],
+            "selectors": [
+                "#a11yComponentToTest"
+            ],
             "selectorExpansion": true,
             "expect": 0,
             "misMatchThreshold": 0.1,
             "requireSameDimensions": true
         },
-
         {
             "label": "3_Components_PAGE_REVIEW",
             "cookiePath": "backstop_data/engine_scripts/cookies.json",
-            "url": "http://host.docker.internal:6006/iframe.html?id=3-components--page-review",
-            "referenceUrl": "http://host.docker.internal:6006/iframe.html?id=3-components--page-review",
+            "url": "http://ca-styleguide.test:6006/iframe.html?id=3-components--page-review",
+            "referenceUrl": "http://ca-styleguide.test:6006/iframe.html?id=3-components--page-review",
             "readyEvent": "",
             "readySelector": "#a11yComponentToTest",
             "delay": 0,
@@ -319,18 +331,19 @@
             "hoverSelector": "",
             "clickSelector": "",
             "postInteractionWait": 0,
-            "selectors": ["#a11yComponentToTest"],
+            "selectors": [
+                "#a11yComponentToTest"
+            ],
             "selectorExpansion": true,
             "expect": 0,
             "misMatchThreshold": 0.1,
             "requireSameDimensions": true
         },
-
         {
             "label": "3_Components_RADIO_GROUP",
             "cookiePath": "backstop_data/engine_scripts/cookies.json",
-            "url": "http://host.docker.internal:6006/iframe.html?id=3-components--radio-group",
-            "referenceUrl": "http://host.docker.internal:6006/iframe.html?id=3-components--radio-group",
+            "url": "http://ca-styleguide.test:6006/iframe.html?id=3-components--radio-group",
+            "referenceUrl": "http://ca-styleguide.test:6006/iframe.html?id=3-components--radio-group",
             "readyEvent": "",
             "readySelector": "#a11yComponentToTest",
             "delay": 0,
@@ -342,18 +355,19 @@
             "hoverSelector": "",
             "clickSelector": "",
             "postInteractionWait": 0,
-            "selectors": ["#a11yComponentToTest"],
+            "selectors": [
+                "#a11yComponentToTest"
+            ],
             "selectorExpansion": true,
             "expect": 0,
             "misMatchThreshold": 0.1,
             "requireSameDimensions": true
         },
-
         {
             "label": "3_Components_RADIO_GROUP_small",
             "cookiePath": "backstop_data/engine_scripts/cookies.json",
-            "url": "http://host.docker.internal:6006/iframe.html?id=3-components--radio-group-small",
-            "referenceUrl": "http://host.docker.internal:6006/iframe.html?id=3-components--radio-group-small",
+            "url": "http://ca-styleguide.test:6006/iframe.html?id=3-components--radio-group-small",
+            "referenceUrl": "http://ca-styleguide.test:6006/iframe.html?id=3-components--radio-group-small",
             "readyEvent": "",
             "readySelector": "#a11yComponentToTest",
             "delay": 0,
@@ -365,18 +379,19 @@
             "hoverSelector": "",
             "clickSelector": "",
             "postInteractionWait": 0,
-            "selectors": ["#a11yComponentToTest"],
+            "selectors": [
+                "#a11yComponentToTest"
+            ],
             "selectorExpansion": true,
             "expect": 0,
             "misMatchThreshold": 0.1,
             "requireSameDimensions": true
         },
-
         {
             "label": "3_Components_SEARCH",
             "cookiePath": "backstop_data/engine_scripts/cookies.json",
-            "url": "http://host.docker.internal:6006/iframe.html?id=3-components--search",
-            "referenceUrl": "http://host.docker.internal:6006/iframe.html?id=3-components--search",
+            "url": "http://ca-styleguide.test:6006/iframe.html?id=3-components--search",
+            "referenceUrl": "http://ca-styleguide.test:6006/iframe.html?id=3-components--search",
             "readyEvent": "",
             "readySelector": "#a11yComponentToTest",
             "delay": 0,
@@ -388,18 +403,19 @@
             "hoverSelector": "",
             "clickSelector": "",
             "postInteractionWait": 0,
-            "selectors": ["#a11yComponentToTest"],
+            "selectors": [
+                "#a11yComponentToTest"
+            ],
             "selectorExpansion": true,
             "expect": 0,
             "misMatchThreshold": 0.1,
             "requireSameDimensions": true
         },
-
         {
             "label": "3_Components_TARGED_CONTENT",
             "cookiePath": "backstop_data/engine_scripts/cookies.json",
-            "url": "http://host.docker.internal:6006/iframe.html?id=3-components--targeted-content",
-            "referenceUrl": "http://host.docker.internal:6006/iframe.html?id=3-components--targeted-content",
+            "url": "http://ca-styleguide.test:6006/iframe.html?id=3-components--targeted-content",
+            "referenceUrl": "http://ca-styleguide.test:6006/iframe.html?id=3-components--targeted-content",
             "readyEvent": "",
             "readySelector": "#a11yComponentToTest",
             "delay": 0,
@@ -411,7 +427,9 @@
             "hoverSelector": "",
             "clickSelector": "",
             "postInteractionWait": 0,
-            "selectors": ["#a11yComponentToTest"],
+            "selectors": [
+                "#a11yComponentToTest"
+            ],
             "selectorExpansion": true,
             "expect": 0,
             "misMatchThreshold": 0.1,
@@ -420,8 +438,8 @@
         {
             "label": "3_Components_WEBSITE-FEEDBACK",
             "cookiePath": "backstop_data/engine_scripts/cookies.json",
-            "url": "http://host.docker.internal:6006/iframe.html?id=3-components--website-feedback",
-            "referenceUrl": "http://host.docker.internal:6006/iframe.html?id=3-components--website-feedback",
+            "url": "http://ca-styleguide.test:6006/iframe.html?id=3-components--website-feedback",
+            "referenceUrl": "http://ca-styleguide.test:6006/iframe.html?id=3-components--website-feedback",
             "readyEvent": "",
             "readySelector": "#a11yComponentToTest",
             "delay": 0,
@@ -433,7 +451,9 @@
             "hoverSelector": "",
             "clickSelector": "",
             "postInteractionWait": 0,
-            "selectors": ["#a11yComponentToTest"],
+            "selectors": [
+                "#a11yComponentToTest"
+            ],
             "selectorExpansion": true,
             "expect": 0,
             "misMatchThreshold": 0.1,
@@ -448,10 +468,16 @@
         "html_report": "backstop_data/html_report",
         "ci_report": "backstop_data/ci_report"
     },
-    "report": ["browser"],
+    "report": [
+        "browser",
+        "CI"
+    ],
+    "openReport": false,
     "engine": "puppeteer",
     "engineOptions": {
-        "args": ["--no-sandbox"]
+        "args": [
+            "--no-sandbox"
+        ]
     },
     "asyncCaptureLimit": 5,
     "asyncCompareLimit": 50,

--- a/traefik.toml
+++ b/traefik.toml
@@ -1,0 +1,155 @@
+################################################################
+# Global configuration
+################################################################
+
+# Enable debug mode
+#
+# Optional
+# Default: false
+#
+# debug = true
+
+# Log level
+#
+# Optional
+# Default: "ERROR"
+#
+# logLevel = "DEBUG"
+
+# Entrypoints to be used by frontends that do not specify any entrypoint.
+# Each frontend can specify its own entrypoints.
+#
+# Optional
+# Default: ["http"]
+#
+# defaultEntryPoints = ["http", "https"]
+
+################################################################
+# Entrypoints configuration
+################################################################
+
+# Entrypoints definition
+#
+# Optional
+# Default:
+[entryPoints]
+    [entryPoints.http]
+    address = ":6006"
+
+################################################################
+# Traefik logs configuration
+################################################################
+
+# Traefik logs
+# Enabled by default and log to stdout
+#
+# Optional
+#
+[traefikLog]
+
+# Sets the filepath for the traefik log. If not specified, stdout will be used.
+# Intermediate directories are created if necessary.
+#
+# Optional
+# Default: os.Stdout
+#
+# filePath = "log/traefik.log"
+
+# Format is either "json" or "common".
+#
+# Optional
+# Default: "common"
+#
+format = "json"
+
+################################################################
+# Access logs configuration
+################################################################
+
+# Enable access logs
+# By default it will write to stdout and produce logs in the textual
+# Common Log Format (CLF), extended with additional fields.
+#
+# Optional
+#
+[accessLog]
+
+# Sets the file path for the access log. If not specified, stdout will be used.
+# Intermediate directories are created if necessary.
+#
+# Optional
+# Default: os.Stdout
+#
+# filePath = "/path/to/log/log.txt"
+
+# Format is either "json" or "common".
+#
+# Optional
+# Default: "common"
+#
+format = "json"
+
+################################################################
+# API and dashboard configuration
+################################################################
+
+# Enable API and dashboard
+[api]
+
+  # Name of the related entry point
+  #
+  # Optional
+  # Default: "traefik"
+  #
+  # entryPoint = "traefik"
+
+  # Enabled Dashboard
+  #
+  # Optional
+  # Default: true
+  #
+  # dashboard = false
+
+################################################################
+# Ping configuration
+################################################################
+
+# Enable ping
+[ping]
+
+  # Name of the related entry point
+  #
+  # Optional
+  # Default: "traefik"
+  #
+  # entryPoint = "traefik"
+
+################################################################
+# Docker configuration backend
+################################################################
+
+# Enable Docker configuration backend
+[docker]
+
+# Docker server endpoint. Can be a tcp or a unix socket endpoint.
+#
+# Required
+# Default: "unix:///var/run/docker.sock"
+#
+# endpoint = "tcp://10.10.10.10:2375"
+
+# Default domain used.
+# Can be overridden by setting the "traefik.domain" label on a container.
+#
+# Optional
+# Default: ""
+#
+# domain = "docker.localhost"
+domain = "test"
+
+# Expose containers by default in traefik
+#
+# Optional
+# Default: true
+#
+exposedByDefault = false


### PR DESCRIPTION
This adds backstopjs html report to jenkins builds. Viewable on jenkins against the job, for example:
https://jenkins.devops.citizensadvice.org.uk/job/design-system/view/change-requests/job/PR-86/BackstopJS_20Report/