### PR TITLE
NP-229: navigation VoiceOver improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* NP-229 Navigation voiceover improvements
+
 ## <sub>v0.8.0</sub>
 
 #### _Apr. 9, 2020_

--- a/js/navigation.js
+++ b/js/navigation.js
@@ -5,8 +5,6 @@ export default priorityNav;
 export const initNavigation = options => {
     priorityNav.init({
         ...options,
-        breakPoint: 0,
-        navDropdownLabel:
-            '<span class="cads-navigation-toggle-label">More navigation items</span>'
+        breakPoint: 0
     });
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -986,9 +986,9 @@
             }
         },
         "@baseonmars/priority-nav": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/@baseonmars/priority-nav/-/priority-nav-1.3.1.tgz",
-            "integrity": "sha512-VhlXR255KTrErPsomw+9E20TF/IYHEDsjW1H/ncFU890CyRnvE0bDz2fwX0yqKT4fPjnoMRgMFigxSFK8veOBQ=="
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/@baseonmars/priority-nav/-/priority-nav-1.4.0.tgz",
+            "integrity": "sha512-1Q+NHqXM/8vaJcBYtOLqz6fYtFksGumA/bgm8NvqA5t3RfEkLuW/z62Q9G5sqxdS4210XdqtLn+2l3Z7S4z9eQ=="
         },
         "@emotion/cache": {
             "version": "10.0.29",

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
         "webdriverio": "^5.22.4"
     },
     "dependencies": {
-        "@baseonmars/priority-nav": "^1.3.1"
+        "@baseonmars/priority-nav": "^1.4.0"
     },
     "browserslist": [
         "IE 11",

--- a/scss/6-components/_navigation.scss
+++ b/scss/6-components/_navigation.scss
@@ -49,12 +49,6 @@ nav,
             padding: calc(1em - 2px);
         }
 
-        &::before {
-            content: 'More';
-            speak: none;
-            position: relative;
-        }
-
         &::after {
             /* Copied from the icon font setup */
             /* stylelint-disable-next-line */
@@ -79,10 +73,6 @@ nav,
         }
 
         &.is-open {
-            &::before {
-                content: 'Close';
-            }
-
             &::after {
                 transform: rotate(90deg);
             }

--- a/styleguide/component.stories.js
+++ b/styleguide/component.stories.js
@@ -116,9 +116,7 @@ export const navigation = () =>
         null,
         () =>
             priorityNav.init({
-                breakPoint: 0,
-                navDropdownLabel:
-                    '<span class="cads-navigation-toggle-label">More navigation items</span>'
+                breakPoint: 0
             })
     );
 


### PR DESCRIPTION
Updates the priority nav package to 1.4.0 which brings in VoiceOver improvements.

The approach taken is slightly different from the one outlined in the ticket - this is due to a previous feature request from @shakiradamji to display the menu as the users tabs through the menu options without the need to activate the sub menu.