### PR TITLE
NP-214: feat: change Benefits link to point to live website

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* NP-214 Link benefits to the fully qualified URL of the public website.
+
 ## <sub>v0.9.0</sub>
 
 #### _Apr. 14, 2020_

--- a/haml/_navigation.html.haml
+++ b/haml/_navigation.html.haml
@@ -3,7 +3,7 @@
     %ul.cads-list-unordered
       -# should be fed by a loop and local in production version.
       %li
-        %a.cads-nav-link{href: "/benefits" } Benefits 
+        %a.cads-nav-link{href: "https://www.citizensadvice.org.uk/benefits/" } Benefits
       %li
         %a.cads-nav-link{href: "https://www.citizensadvice.org.uk/work/"} Work
       %li


### PR DESCRIPTION
When I click on Benefits on the navigation bar It redirects to https://www.citizensadvice.org.uk/benefits/