### PR TITLE
Feature/vr-test-sync

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,6 +48,11 @@ After a test run is complete you can `npm run vr-test vr-test:open-report` to vi
 
 If you are working in a QA role you can npm run vr-test:approve' the changes.
 
+#### Writing test scenarios
+
+It's important that both backstop files are kept in sync. Write you test scenarios in `./testing/backstop.json` and run `npm run vr-test:sync` to bring the files up to date. Any differences will be printed to the console.
+
+If you want to check the files are in sync you can run `npm run vr-test:check` - this is also run as part of the CI process. If the scenarios are not in sync then the build will fail.
 
 #### Low-level Usage
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,9 +50,9 @@ If you are working in a QA role you can npm run vr-test:approve' the changes.
 
 #### Writing test scenarios
 
-It's important that both backstop files are kept in sync. Write you test scenarios in `./testing/backstop.json` and run `npm run vr-test:sync` to bring the files up to date. Any differences will be printed to the console.
+It's important that both backstop config files are kept in sync. Write your test scenarios in `./testing/backstop.json` and run `npm run vr-test:sync` to bring `./testing/backstop-ci.json` up to date. Any differences will be printed to the console.
 
-If you want to check the files are in sync you can run `npm run vr-test:check` - this is also run as part of the CI process. If the scenarios are not in sync then the build will fail.
+If you want to check that the files are in sync you can run `npm run vr-test:check` - this is also run as part of the CI process. If the scenarios do not match or any are missing then the build will fail.
 
 #### Low-level Usage
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,15 +17,15 @@ pipeline {
         }
         stage ('Lint') {
             steps {
-                withDockerSandbox(["ca-styleguide_${CA_STYLEGUIDE_VERSION_TAG}"]) {
+                withDockerSandbox(["ca-styleguide${CA_STYLEGUIDE_VERSION_TAG}"]) {
                     sh './bin/jenkins/lint'
                 }
             }
         }
         stage('Test') {
             steps {
-                withDockerSandbox(["ca-styleguide_${CA_STYLEGUIDE_VERSION_TAG}",
-                    "ca-backstop_${CA_STYLEGUIDE_VERSION_TAG}"]) {
+                withDockerSandbox(["ca-styleguide${CA_STYLEGUIDE_VERSION_TAG}",
+                    "ca-backstop${CA_STYLEGUIDE_VERSION_TAG}"]) {
                     sh './bin/jenkins/check'
                     sh './bin/jenkins/test'
                 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -26,7 +26,7 @@ pipeline {
             steps {
                 withDockerSandbox(["ca-styleguide${CA_STYLEGUIDE_VERSION_TAG}",
                     "ca-backstop${CA_STYLEGUIDE_VERSION_TAG}"]) {
-                    sh './bin/jenkins/check'
+                    sh './bin/jenkins/check-config'
                     sh './bin/jenkins/test'
                 }
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -26,6 +26,7 @@ pipeline {
             steps {
                 withDockerSandbox(["ca-styleguide_${CA_STYLEGUIDE_VERSION_TAG}",
                     "ca-backstop_${CA_STYLEGUIDE_VERSION_TAG}"]) {
+                    sh './bin/jenkins/check'
                     sh './bin/jenkins/test'
                 }
             }

--- a/bin/docker/check-config
+++ b/bin/docker/check-config
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -ex
+
+#check files are in sync
+docker-compose run \
+    -v $(pwd)/testing/backstop.json:/app/testing/backstop.json \
+    -v $(pwd)/testing/backstop-ci.json:/app/testing/backstop-ci.json \
+    ca-styleguide npm run vr-test:check

--- a/bin/docker/test
+++ b/bin/docker/test
@@ -2,8 +2,6 @@
 
 set -e
 
-source bin/docker/network
-
 # start styleguide in background
 docker-compose up -d ca-styleguide
 # run tests - will check that

--- a/bin/jenkins/check-config
+++ b/bin/jenkins/check-config
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+set -e
+
+PRODUCTION="true"
+NODE_ENV="test"
+
+source bin/docker/check-config

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,9 @@
-version: "3"
+version: '3'
 
 services:
     ca-styleguide:
         build: .
-        image: "ca-styleguide_${CA_STYLEGUIDE_VERSION_TAG}"
+        image: 'ca-styleguide${CA_STYLEGUIDE_VERSION_TAG}'
         container_name: ca-styleguide.test
         command: npm run styleguide:ci -- --quiet
         hostname: ca-styleguide.test
@@ -16,7 +16,7 @@ services:
         build:
             dockerfile: ./testing/Dockerfile
             context: ./
-        image: "ca-backstop_${CA_STYLEGUIDE_VERSION_TAG}"
+        image: 'ca-backstop${CA_STYLEGUIDE_VERSION_TAG}'
         container_name: visual-tests.test
         command: wait-for-it --timeout=120 --strict ca-styleguide.test:6006 -- backstop test --config=backstop-ci.json
         volumes:

--- a/package.json
+++ b/package.json
@@ -29,7 +29,9 @@
         "vr-test:ci": "./bin/jenkins/test && docker-compose down",
         "vr-test:standalone": "cd testing && npx backstop test --docker",
         "vr-test:approve": "cd testing && npx backstop approve",
-        "vr-test:open-report": "cd testing && npx backstop openReport"
+        "vr-test:open-report": "cd testing && npx backstop openReport",
+        "vr-test:sync": "node scripts/vr-test-sync.js",
+        "vr-test:check": "node scripts/vr-test-sync.js -- --check"
     },
     "repository": {
         "type": "git",

--- a/scripts/vr-test-sync.js
+++ b/scripts/vr-test-sync.js
@@ -1,0 +1,86 @@
+/* eslint-disable no-restricted-syntax */
+/* eslint-disable no-console */
+/* eslint-disable import/no-extraneous-dependencies */
+const assert = require('assert').strict;
+const chalk = require('chalk');
+const fs = require('fs');
+
+const localScenarios = require('../testing/backstop.json').scenarios;
+const ciConfig = require('../testing/backstop-ci.json');
+
+const onlyCheck = process.argv.some(arg => arg === '--check');
+
+const localHost = 'http://host.docker.internal:6006';
+const ciHost = 'http://ca-styleguide.test:6006';
+
+const ciScenarios = ciConfig.scenarios;
+
+const stripUrls = scenarios => {
+    const acc = [];
+    for (const scenario of scenarios) {
+        const { url, referenceUrl, ...rest } = scenario;
+        acc.push(rest);
+    }
+    return acc;
+};
+
+const fixUrl = url => url.replace(localHost, ciHost);
+
+const checkSync = () => {
+    try {
+        assert.deepStrictEqual(
+            stripUrls(localScenarios),
+            stripUrls(ciScenarios)
+        );
+    } catch (e) {
+        console.error(
+            chalk.red(
+                './testing/backstop.json and ./testing/backstop-ci.json are out of sync'
+            )
+        );
+        console.debug(e.message);
+
+        return false;
+    }
+
+    console.info(
+        chalk.green(
+            './testing/backstop.json and ./testing/backstop-ci.json are in sync'
+        )
+    );
+    return true;
+};
+
+const syncScenarios = () => {
+    const scenarios = [];
+
+    for (const scenario of localScenarios) {
+        const { url, referenceUrl, label, ...rest } = scenario;
+        scenarios.push({
+            label,
+            url: fixUrl(url),
+            referenceUrl: fixUrl(url),
+            ...rest
+        });
+    }
+
+    ciConfig.scenarios = scenarios;
+    console.info('Writing backstop.json scenarios to backstop-ci.json');
+    fs.writeFileSync(
+        './testing/backstop-ci.json',
+        JSON.stringify(ciConfig, null, 4)
+    );
+    console.info(chalk.green('Scenarios updated successfully.'));
+
+    process.exit(0);
+};
+
+if (!onlyCheck) {
+    if (checkSync()) {
+        process.exit(0);
+    } else {
+        process.exit(1);
+    }
+} else if (!checkSync()) {
+    syncScenarios();
+}


### PR DESCRIPTION
# Writing test scenarios

It's important that both backstop files are kept in sync. Write you test scenarios in `./testing/backstop.json` and run `npm run vr-test:sync` to bring the files up to date. Any differences will be printed to the console.

If you want to check the files are in sync you can run `npm run vr-test:check` - this is also run as part of the CI process. If the scenarios are not in sync then the build will fail.