### PR TITLE
NP-325 Remove H4 from contact details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
  * NP-350 switch priority-nav to @citizensadvice owned package
+ * NP-325 Remove H4 from Contact Details
  * NP-334 Bug Stroke on active links is too heavy
  * NP-333 Error summary component
  * NP-238 Callout headings restructure

--- a/haml/_contact_details.html.haml
+++ b/haml/_contact_details.html.haml
@@ -1,3 +1,3 @@
 .cads-contact-details
-  %h4= contact_details[:title]
+  %p.cads-heading-small= contact_details[:title]
   = contact_details[:body]


### PR DESCRIPTION
Replaced H4 with P tag and appropriate styling from Contact Details as H4 tags should not be used.