### PR TITLE
NP-352 Targeted content integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,4 @@
-## <sub>v0.11.1-alpha.0</sub>
-
-#### _May. 6, 2020_
-
+* NP-352 Targeted content integration
 * NP-239 Advice Feedback
 * NP-380 Release script update
 

--- a/js/targeted-content.js
+++ b/js/targeted-content.js
@@ -3,7 +3,8 @@ const initTargetedContent = () => {
         const content = document.getElementsByClassName(
             'cads-targeted-content'
         );
-        content.forEach(item => {
+        for (let i = 0; i < content.length; i++) {
+            const item = content[i];
             const summary = item.getElementsByClassName(
                 'cads-targeted-content__summary'
             )[0];
@@ -24,7 +25,7 @@ const initTargetedContent = () => {
                 summary.ariaExpanded = false;
                 item.open = false;
             });
-        });
+        }
     } catch (e) {
         console.warn(`Could not initialise targeted content ${e}`);
     }

--- a/styleguide/component.stories.js
+++ b/styleguide/component.stories.js
@@ -132,7 +132,7 @@ export const navigation = () =>
         'navigation',
         `The navigation component uses javascript to display options in a dropdown menu that would otherwise appear off screen.
         \n\n
-        <code>import { initNavigation } from @citizensadvice/design-system/js/navigation</code> and execute that function after the navigation components html has loaded into the DOM.`,
+        <pre><code>import { initNavigation } from '@citizensadvice/design-system/js/navigation'</code></pre> and execute that function after the navigation components html has loaded into the DOM.`,
         null,
         () =>
             priorityNav.init({
@@ -149,7 +149,7 @@ export const callout = () =>
         'callout',
         `The callout component uses javascript to rearrange the heading level of the first callout on the screen (H2 vs H3 heading).
         \n\n
-        <code>import { initCallouts } from @citizensadvice/design-system/js/callout</code> and execute that function after the the page has finished loading.`,
+        <pre><code>import initCallouts from '@citizensadvice/design-system/js/callout'</code></pre> and execute that function after the the page has finished loading.`,
         null,
         initCallouts
     );
@@ -166,7 +166,9 @@ export const targetedContent = () =>
         'Targeted Content',
         tTargetedContent,
         'targeted-content',
-        null,
+        `The targeted component uses javascript to initialise the click handlers for the collapse/expand behaviour.
+        \n\n
+        <pre><code>import initTargetedContent from '@citizensadvice/design-system/js/targeted-content'</code></pre> and execute that function after the the page has finished loading.`,
         null,
         () => initTargetedContent()
     );


### PR DESCRIPTION
Use a normal for loop vs forEach to avoid need for polyfill. The consumer should in theory transpile it but this may not happen given that the package is in node_modules.
