### PR TITLE
NP-394 breadcrumb title field rename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 * NP-388 Callout type naming
+* NP-394 Breadcrumb title field rename
 
 ## <sub>v0.13.0</sub>
 

--- a/haml/_breadcrumb.html.haml
+++ b/haml/_breadcrumb.html.haml
@@ -4,5 +4,5 @@
       %a.cads-breadcrumb{:href => "/"} Home
     - breadcrumb_links.each do |link|
       %li
-        %a.cads-breadcrumb{:href => link[:url], :title => link[:label]}
-          = link[:label]
+        %a.cads-breadcrumb{:href => link[:url], :title => link[:title]}
+          = link[:title]

--- a/styleguide/haml_locals.rb
+++ b/styleguide/haml_locals.rb
@@ -4,15 +4,15 @@
   breadcrumb_links: [
     {
       url: 'https://www.citizensadvice.org.uk/benefits/',
-      label: 'Benefits'
+      title: 'Benefits'
     },
     {
       url: 'https://www.citizensadvice.org.uk/benefits/benefits-introduction/',
-      label: 'Benefits - introduction'
+      title: 'Benefits - introduction'
     },
     {
       url: 'https://www.citizensadvice.org.uk/benefits/benefits-introduction/what-benefits-can-i-get/',
-      label: 'Benefit calculators: what benefits can you get'
+      title: 'Benefit calculators: what benefits can you get'
     }
   ],
 


### PR DESCRIPTION
Renamed the breadcrumb title prop from `label` to `title` to match the API.