### PR TITLE
NP-401 haml hash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 * NP-401 Replace symbol hash access syntax for string
+* NP-381 Changelog
 
 ## <sub>v0.13.1</sub>
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* NP-401 Replace symbol hash access syntax for string
+
 ## <sub>v0.13.1</sub>
 
 #### _May. 13, 2020_

--- a/haml/_advice_feedback.html.haml
+++ b/haml/_advice_feedback.html.haml
@@ -7,8 +7,8 @@
     .cads-advice-feedback__close
       %button.cads-linkbutton{'aria-label': 'Close advice feedback form'} Close
     = render partial: "@citizensadvice/design-system/haml/error_summary"
-    = render partial: "@citizensadvice/design-system/haml/radio_group", locals: { radio: { error_message: 'Select a feedback option', name: 'radiogroup-advice-feedback-step2', label: 'Why wasn\'t this advice helpful?', options: [{value: '1', label: 'It isn\'t relevant to my situation'}, {value: '2', label: 'It doesn\'t have enough detail'}, {value: '3', label: 'I can\'t work out what I should do next'}, {value: '4', label: 'I don\'t understand'}] } }
-    = render partial: "@citizensadvice/design-system/haml/textarea", locals: { input: { name: 'advice-feedback-optional', label: 'Is there anything else you\'d like to tell us?', has_error: false, optional: true } }
+    = render partial: "@citizensadvice/design-system/haml/radio_group", locals: { 'radio' => { 'error_message' => 'Select a feedback option', 'name' => 'radiogroup-advice-feedback-step2', 'label' => 'Why wasn\'t this advice helpful?', 'options' => [{'value' => '1', 'label' => 'It isn\'t relevant to my situation'}, {'value' => '2', 'label' => 'It doesn\'t have enough detail'}, {'value' => '3', 'label' => 'I can\'t work out what I should do next'}, {'value' => '4', 'label' => 'I don\'t understand'}] } }
+    = render partial: "@citizensadvice/design-system/haml/textarea", locals: { 'input' => { 'name' => 'advice-feedback-optional', 'label' => 'Is there anything else you\'d like to tell us?', 'has_error' => 'false', 'optional' => 'true' } }
     %button.cads-button__primary{type: "submit", value: "Submit", form: 'cads-advice-feedback', 'aria-label': 'Submit feedback'}
       Submit
       %span.cads-icon-arrow-right

--- a/haml/_advice_feedback.html.haml
+++ b/haml/_advice_feedback.html.haml
@@ -8,7 +8,7 @@
       %button.cads-linkbutton{'aria-label': 'Close advice feedback form'} Close
     = render partial: "@citizensadvice/design-system/haml/error_summary"
     = render partial: "@citizensadvice/design-system/haml/radio_group", locals: { 'radio' => { 'error_message' => 'Select a feedback option', 'name' => 'radiogroup-advice-feedback-step2', 'label' => 'Why wasn\'t this advice helpful?', 'options' => [{'value' => '1', 'label' => 'It isn\'t relevant to my situation'}, {'value' => '2', 'label' => 'It doesn\'t have enough detail'}, {'value' => '3', 'label' => 'I can\'t work out what I should do next'}, {'value' => '4', 'label' => 'I don\'t understand'}] } }
-    = render partial: "@citizensadvice/design-system/haml/textarea", locals: { 'input' => { 'name' => 'advice-feedback-optional', 'label' => 'Is there anything else you\'d like to tell us?', 'has_error' => 'false', 'optional' => 'true' } }
+    = render partial: "@citizensadvice/design-system/haml/textarea", locals: { 'input' => { 'name' => 'advice-feedback-optional', 'label' => 'Is there anything else you\'d like to tell us?', 'has_error' => false, 'optional' => true } }
     %button.cads-button__primary{type: "submit", value: "Submit", form: 'cads-advice-feedback', 'aria-label': 'Submit feedback'}
       Submit
       %span.cads-icon-arrow-right

--- a/haml/_breadcrumb.html.haml
+++ b/haml/_breadcrumb.html.haml
@@ -4,5 +4,5 @@
       %a.cads-breadcrumb{:href => "/"} Home
     - breadcrumb_links.each do |link|
       %li
-        %a.cads-breadcrumb{:href => link[:url], :title => link[:title]}
-          = link[:title]
+        %a.cads-breadcrumb{:href => link['url'], :title => link['title']}
+          = link['title']

--- a/haml/_callout.html.haml
+++ b/haml/_callout.html.haml
@@ -1,5 +1,5 @@
-%div{class: "cads-callout cads-callout-#{notice[:type]}"}
+%div{class: "cads-callout cads-callout-#{notice['type']}"}
   %h3
     %span.cads-callout-label
-    = notice[:title]
-  = notice[:body]
+    = notice['title']
+  = notice['body']

--- a/haml/_contact_details.html.haml
+++ b/haml/_contact_details.html.haml
@@ -1,3 +1,3 @@
 .cads-contact-details
-  %p.cads-heading-small= contact_details[:title]
-  = contact_details[:body]
+  %p.cads-heading-small= contact_details['title']
+  = contact_details['body']

--- a/haml/_input.html.haml
+++ b/haml/_input.html.haml
@@ -1,8 +1,8 @@
-.cads-form{ class: [input[:has_error] && 'cads-form-error', input[:optional] && 'cads-form-optional'] }
+.cads-form{ class: [input['has_error'] && 'cads-form-error', input['optional'] && 'cads-form-optional'] }
   .cads-form-error-marker
   .cads-form-content.cads-input-group
-    %label.cads-form-label.cads-heading-small{id: "#{input[:name]}-label", for: "#{input[:name]}-input" }
-      = input[:label]
-    %p.cads-form__hint= input[:hint]
-    %p.cads-form__error-message= input[:error_message]
-    %input.cads-input{type: "text", id: "#{input[:name]}-input"}
+    %label.cads-form-label.cads-heading-small{id: "#{input['name']}-label", for: "#{input['name']}-input" }
+      = input['label']
+    %p.cads-form__hint= input['hint']
+    %p.cads-form__error-message= input['error_message']
+    %input.cads-input{type: "text", id: "#{input['name']}-input"}

--- a/haml/_notice_banner.html.haml
+++ b/haml/_notice_banner.html.haml
@@ -1,3 +1,3 @@
 .cads-notice-banner
-  %span.cads-notice-banner__title= banner[:label]
-  %p.paragraph-s= banner[:body]
+  %span.cads-notice-banner__title= banner['label']
+  %p.paragraph-s= banner['body']

--- a/haml/_radio_group.html.haml
+++ b/haml/_radio_group.html.haml
@@ -1,11 +1,11 @@
-.cads-form{ class: [radio[:has_error] && 'cads-form-error', radio[:optional] && 'cads-form-optional'] }
+.cads-form{ class: [radio['has_error'] && 'cads-form-error', radio['optional'] && 'cads-form-optional'] }
   .cads-form-error-marker
   %fieldset.cads-form-content.cads-radio-group
-    %legend.cads-form-label.cads-heading-small= radio[:label]
-    %p.cads-form__hint= radio[:hint]
-    %p.cads-form__error-message= radio[:error_message]
-    - radio[:options].each do |radioItem|
-      %label.cads-radio-button{for: "#{radio[:name]}-#{radioItem[:value]}"}
-        = radioItem[:label]
-        %input{type: "radio", id: "#{radio[:name]}-#{radioItem[:value]}", name: radio[:name], value: radioItem[:value]}
+    %legend.cads-form-label.cads-heading-small= radio['label']
+    %p.cads-form__hint= radio['hint']
+    %p.cads-form__error-message= radio['error_message']
+    - radio['options'].each do |radioItem|
+      %label.cads-radio-button{for: "#{radio['name']}-#{radioItem['value']}"}
+        = radioItem['label']
+        %input{type: "radio", id: "#{radio['name']}-#{radioItem['value']}", name: radio['name'], value: radioItem['value']}
         %span.cads-radio-button-checkmark

--- a/haml/_radio_group_small.html.haml
+++ b/haml/_radio_group_small.html.haml
@@ -1,11 +1,11 @@
-.cads-form{ class: [radio[:has_error] && 'cads-form-error', radio[:optional] && 'cads-form-optional'] }
+.cads-form{ class: [radio['has_error'] && 'cads-form-error', radio['optional'] && 'cads-form-optional'] }
   .cads-form-error-marker
   %fieldset.cads-form-content.cads-radio-group.cads-radio-group__small
-    %legend.cads-form-label.cads-heading-small= radio[:label]
-    %p.cads-form__hint= radio[:hint]
-    %p.cads-form__error-message= radio[:error_message]
-    - radio[:options].each do |radioItem|
-      %label.cads-radio-button{for: "#{radio[:name]}-#{radioItem[:value]}"}
-        = radioItem[:label]
-        %input{type: "radio", id: "#{radio[:name]}-#{radioItem[:value]}", name: radio[:name], value: radioItem[:value]}
+    %legend.cads-form-label.cads-heading-small= radio['label']
+    %p.cads-form__hint= radio['hint']
+    %p.cads-form__error-message= radio['error_message']
+    - radio['options'].each do |radioItem|
+      %label.cads-radio-button{for: "#{radio['name']}-#{radioItem['value']}"}
+        = radioItem['label']
+        %input{type: "radio", id: "#{radio['name']}-#{radioItem['value']}", name: radio['name'], value: radioItem['value']}
         %span.cads-radio-button-checkmark

--- a/haml/_targeted-content.html.haml
+++ b/haml/_targeted-content.html.haml
@@ -1,10 +1,10 @@
-%details.cads-targeted-content{:id => targetContent[:id]}
-  %summary.cads-targeted-content__summary{:role => "button", :"aria-controls" => "#{targetContent[:id]}-content", :"aria-expanded" => "false"}
+%details.cads-targeted-content{:id => targetContent['id']}
+  %summary.cads-targeted-content__summary{:role => "button", :"aria-controls" => "#{targetContent['id']}-content", :"aria-expanded" => "false"}
     %span.cads-target-content__button.cads-icon-minus
     %span.cads-target-content__button.cads-icon-plus
     %span.cads-targeted-content__title
-      = targetContent[:title]
-  .cads-targeted-content__content{:id => "#{targetContent[:id]}-content"}
-    = targetContent[:body]
+      = targetContent['title']
+  .cads-targeted-content__content{:id => "#{targetContent['id']}-content"}
+    = targetContent['body']
     %hr.separator
-    %button.cads-linkbutton.cads-targeted-content__close-button{:"aria-label" => "Collapse #{targetContent[:title]}"}
+    %button.cads-linkbutton.cads-targeted-content__close-button{:"aria-label" => "Collapse #{targetContent['title']}"}

--- a/haml/_textarea.html.haml
+++ b/haml/_textarea.html.haml
@@ -1,8 +1,8 @@
-.cads-form{ class: [input[:has_error] && 'cads-form-error', input[:optional] && 'cads-form-optional'] }
+.cads-form{ class: [input['has_error'] && 'cads-form-error', input['optional'] && 'cads-form-optional'] }
   .cads-form-error-marker
   .cads-form-content.cads-input-group
-    %label.cads-form-label.cads-heading-small{id: "#{input[:name]}-label", for: "#{input[:name]}-input" }
-      = input[:label]
-    %p.cads-form__hint= input[:hint]
-    %p.cads-form__error-message= input[:error_message]
-    %textarea.cads-input.cads-textarea{type: "text", id: "#{input[:name]}-input", "aria-label": input[:label], rows: 4}
+    %label.cads-form-label.cads-heading-small{id: "#{input['name']}-label", for: "#{input['name']}-input" }
+      = input['label']
+    %p.cads-form__hint= input['hint']
+    %p.cads-form__error-message= input['error_message']
+    %textarea.cads-input.cads-textarea{type: "text", id: "#{input['name']}-input", "aria-label": input['label'], rows: 4}

--- a/styleguide/haml_locals.rb
+++ b/styleguide/haml_locals.rb
@@ -42,8 +42,8 @@
       { 'value' => 'opt2', 'label' => 'Option 2' }
     ],
     'error_message' => 'This is an error message',
-    'has_error' => 'true',
-    'optional' => 'true'
+    'has_error' => true,
+    'optional' => true
   },
 
   'input' => {
@@ -51,8 +51,8 @@
     'label' => 'This is the label for the input',
     'hint' => 'This is the hint for the input',
     'error_message' => 'This is an error messsage',
-    'has_error' => 'true',
-    'optional' => 'true'
+    'has_error' => true,
+    'optional' => true
   },
 
   'contact_details' => {

--- a/styleguide/haml_locals.rb
+++ b/styleguide/haml_locals.rb
@@ -14,7 +14,7 @@
     },
     {
       'url' => 'https =>//www.citizensadvice.org.uk/benefits/benefits-introduction/what-benefits-can-i-get/',
-      'title' => 'Benefit calculators => what benefits can you get'
+      'title' => 'Benefit calculators: what benefits can you get'
     }
   ],
 

--- a/styleguide/haml_locals.rb
+++ b/styleguide/haml_locals.rb
@@ -1,78 +1,79 @@
 # frozen_string_literal: true
 
+# frozen_string_literal => true
+
 @locals = {
-  breadcrumb_links: [
+  'breadcrumb_links' => [
     {
-      url: 'https://www.citizensadvice.org.uk/benefits/',
-      title: 'Benefits'
+      'url' => 'https =>//www.citizensadvice.org.uk/benefits/',
+      'title' => 'Benefits'
     },
     {
-      url: 'https://www.citizensadvice.org.uk/benefits/benefits-introduction/',
-      title: 'Benefits - introduction'
+      'url' => 'https =>//www.citizensadvice.org.uk/benefits/benefits-introduction/',
+      'title' => 'Benefits - introduction'
     },
     {
-      url: 'https://www.citizensadvice.org.uk/benefits/benefits-introduction/what-benefits-can-i-get/',
-      title: 'Benefit calculators: what benefits can you get'
+      'url' => 'https =>//www.citizensadvice.org.uk/benefits/benefits-introduction/what-benefits-can-i-get/',
+      'title' => 'Benefit calculators => what benefits can you get'
     }
   ],
 
-  notice: {
-    type: 'urgent',
-    title: 'Callout title: Urgent',
-    body: '<p>The important callout should be used for any important snippet of text that has serious and/or legal implications if the client does not follow the advice.</p>'
+  'notice' => {
+    'type' => 'urgent',
+    'title' => 'Callout title: Urgent',
+    'body' => '<p>The important callout should be used for any important snippet of text that has serious and/or legal implications if the client does not follow the advice.</p>'
   },
 
-  root_path: 'root_path',
+  'root_path' => 'root_path',
+  'sign_in_url' => '/sign-in/url',
+  'search_action_url' => '/the/search-action-url',
 
-  sign_in_url: '/sign-in/url',
-  search_action_url: '/the/search-action-url',
-
-  banner: {
-    label: 'Notice banner title',
-    body: 'If you’re a Thomas Cook customer and you’re stuck abroad or want to get your money back, get help from the Civil Aviation Authority.'
+  'banner' => {
+    'label' => 'Notice banner title',
+    'body' => 'If you’re a Thomas Cook customer and you’re stuck abroad or want to get your money back, get help from the Civil Aviation Authority.'
   },
 
-  radio: {
-    name: 'radiogroup-1',
-    label: 'Select an option',
-    hint: 'There are two options',
-    options: [{ value: 'opt1', label: 'Option 1' }, { value: 'opt2', label: 'Option 2' }],
-    error_message: 'This is an error message',
-    has_error: true,
-    optional: true
+  'radio' => {
+    'name' => 'radiogroup-1',
+    'label' => 'Select an option',
+    'hint' => 'There are two options',
+    'options' => [
+      { 'value' => 'opt1', 'label' => 'Option 1' },
+      { 'value' => 'opt2', 'label' => 'Option 2' }
+    ],
+    'error_message' => 'This is an error message',
+    'has_error' => 'true',
+    'optional' => 'true'
   },
 
-  input: {
-    name: 'inputABC',
-    label: 'This is the label for the input',
-    hint: 'This is the hint for the input',
-    error_message: 'This is an error messsage',
-    has_error: true,
-    optional: true
+  'input' => {
+    'name' => 'inputABC',
+    'label' => 'This is the label for the input',
+    'hint' => 'This is the hint for the input',
+    'error_message' => 'This is an error messsage',
+    'has_error' => 'true',
+    'optional' => 'true'
   },
 
-  contact_details: {
-    title: 'Bail for Immigration Detainees',
-    body: "<p>Telephone: 01234 567890</p><p>Monday to Thursday 8am to 1pm</p><p>Calls cost a lot of money</p><p><a href='http://link.to.the.website'>Link to the website</a></p>"
+  'contact_details' => {
+    'title' => 'Bail for Immigration Detainees',
+    'body' => "<p>Telephone: 01234 567890</p><p>Monday to Thursday 8am to 1pm</p><p>Calls cost a lot of money</p><p><a href='http =>//link.to.the.website'>Link to the website</a></p>"
   },
 
-  radio_has_error: true,
-  radio_error_message: 'Please select an option',
+  'page_review_date' => '21 September 2019',
 
-  page_review_date: '21 September 2019',
-
-  targetContent: {
-    id: 'target-content-123',
-    title: 'If you are a citizen of a country outside the EU, EEA or Switzerland',
-    body: '<p>You should apply to the EU Settlement Scheme if both:</p>
-<ul>
-<li>you’re in the UK by 31 December 2020</li>
-<li>you have family in the UK from the EU, EEA or Switzerland</li>
-</ul>
-<p>You need to apply to the scheme even if you have a permanent residence card as
-it will not be valid after 31 December 2020.</p>
-<p><a href="https://www.citizensadvice.org.uk/immigration/staying-in-the-uk-after-brexit/keeping-your-family-in-the-uk-after-brexit/">Check if you can apply to the EU Settlement Scheme</a></p>'
+  'targetContent' => {
+    'id' => 'target-content-123',
+    'title' => 'If you are a citizen of a country outside the EU, EEA or Switzerland',
+    'body' => '<p>You should apply to the EU Settlement Scheme if both =></p>
+  <ul>
+  <li>you’re in the UK by 31 December 2020</li>
+  <li>you have family in the UK from the EU, EEA or Switzerland</li>
+  </ul>
+  <p>You need to apply to the scheme even if you have a permanent residence card as
+  it will not be valid after 31 December 2020.</p>
+  <p><a href="https =>//www.citizensadvice.org.uk/immigration/staying-in-the-uk-after-brexit/keeping-your-family-in-the-uk-after-brexit/">Check if you can apply to the EU Settlement Scheme</a></p>'
   },
 
-  success_message: 'Thank you for your feedback'
+  'success_message' => 'Thank you for your feedback'
 }


### PR DESCRIPTION
Replace symbol hash access syntax for string, ie

`input[:error_message]` becomes `input['error_message']` in the haml templates and the data objects change from 
```
input: {
    name: 'inputABC',
    label: 'This is the label for the input',
    hint: 'This is the hint for the input',
    error_message: 'This is an error messsage',
    has_error: true,
    optional: true
  }
```
to
```
'input' => {
    'name' => 'inputABC',
    'label' => 'This is the label for the input',
    'hint' => 'This is the hint for the input',
    'error_message' => 'This is an error messsage',
    'has_error' => 'true',
    'optional' => 'true'
  },
```

To test the components in storybook should all look ok and work ok.