### PR TITLE
NP-415 Remove footer_feedback component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* NP-415 Remove footer feedback component
+
 ## <sub>v0.14.0</sub>
 
 #### _May. 14, 2020_

--- a/haml/_footer_feedback.html.haml
+++ b/haml/_footer_feedback.html.haml
@@ -1,3 +1,0 @@
-.cads-feedback
-  Is there anything wrong with this page?
-  = react_component('SurveyLink', { text: "Let us know.", destination: "https://www.research.net/r/J8PLH2H" }, { prerender: true })


### PR DESCRIPTION
The footer_feedback component is redundant, the feedback link is now part of the footer.