### PR TITLE
feat: fix keyboard navigation in IE 11 [NP-465]

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,12 @@
 {
-    "presets": ["@babel/preset-env", "@babel/preset-typescript"]
+    "presets": ["@babel/preset-env", "@babel/preset-typescript"],
+    "plugins": [
+        [
+            "@babel/plugin-transform-runtime",
+            {
+                "regenerator": true
+            }
+        ],
+        "@babel/plugin-proposal-class-properties"
+    ]
 }

--- a/.eslintrc
+++ b/.eslintrc
@@ -32,6 +32,11 @@
             }
         }
     ],
-    "ignorePatterns": ["lib", "tsconfig*", "**/src/**/*.scss"],
+    "ignorePatterns": [
+        "lib",
+        "tsconfig*",
+        "**/src/**/*.scss",
+        "**/src/**/__fixtures__/*.html"
+    ],
     "parser": "@typescript-eslint/parser"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+* NP-465 GreedyNav works with IE11
 ## <sub>v1.7.1</sub>
 
 #### _Aug. 13, 2020_

--- a/package-lock.json
+++ b/package-lock.json
@@ -916,6 +916,26 @@
                 "@babel/helper-plugin-utils": "^7.10.4"
             }
         },
+        "@babel/plugin-transform-runtime": {
+            "version": "7.11.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.11.0.tgz",
+            "integrity": "sha512-LFEsP+t3wkYBlis8w6/kmnd6Kb1dxTd+wGJ8MlxTGzQo//ehtqlVL4S9DNUa53+dtPSQobN2CXx4d81FqC58cw==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-module-imports": "^7.10.4",
+                "@babel/helper-plugin-utils": "^7.10.4",
+                "resolve": "^1.8.1",
+                "semver": "^5.5.1"
+            },
+            "dependencies": {
+                "semver": {
+                    "version": "5.7.1",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+                    "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+                    "dev": true
+                }
+            }
+        },
         "@babel/plugin-transform-shorthand-properties": {
             "version": "7.10.4",
             "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.10.4.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@citizensadvice/design-system",
-    "version": "1.6.0",
+    "version": "1.7.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -4712,6 +4712,7 @@
             "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
             "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
             "dev": true,
+            "optional": true,
             "requires": {
                 "file-uri-to-path": "1.0.0"
             }
@@ -5109,15 +5110,6 @@
             "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
             "integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk=",
             "dev": true
-        },
-        "bufferstreams": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/bufferstreams/-/bufferstreams-1.1.3.tgz",
-            "integrity": "sha512-HaJnVuslRF4g2kSDeyl++AaVizoitCpL9PglzCYwy0uHHyvWerfvEb8jWmYbF1z4kiVFolGomnxSGl+GUQp2jg==",
-            "dev": true,
-            "requires": {
-                "readable-stream": "^2.0.2"
-            }
         },
         "builtin-status-codes": {
             "version": "3.0.0",
@@ -6615,12 +6607,6 @@
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.2.tgz",
             "integrity": "sha512-ofovWglpqoqbfLNOTBNZLSbMuGrblAf1efvvArGKOZMBrIoJeu5UsAipQolkijtyQx5MtAzT/J9IHj/CEY1mJw==",
-            "dev": true
-        },
-        "cubic2quad": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/cubic2quad/-/cubic2quad-1.1.1.tgz",
-            "integrity": "sha1-abGcYaP1tB7PLx1fro+wNBWqixU=",
             "dev": true
         },
         "cuint": {
@@ -8468,7 +8454,8 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
             "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
-            "dev": true
+            "dev": true,
+            "optional": true
         },
         "filesize": {
             "version": "3.6.1",
@@ -9212,27 +9199,6 @@
                 "pify": "^4.0.1"
             }
         },
-        "handlebars": {
-            "version": "4.7.6",
-            "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.6.tgz",
-            "integrity": "sha512-1f2BACcBfiwAfStCKZNrUCgqNZkGsAT7UM3kkYtXuLo0KnaVfjKOyf7PRzB6++aK9STyT1Pd2ZCPe3EGOXleXA==",
-            "dev": true,
-            "requires": {
-                "minimist": "^1.2.5",
-                "neo-async": "^2.6.0",
-                "source-map": "^0.6.1",
-                "uglify-js": "^3.1.4",
-                "wordwrap": "^1.0.0"
-            },
-            "dependencies": {
-                "source-map": {
-                    "version": "0.6.1",
-                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-                    "dev": true
-                }
-            }
-        },
         "har-schema": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
@@ -9762,18 +9728,6 @@
                     "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
                     "dev": true
                 }
-            }
-        },
-        "icon-font-generator": {
-            "version": "2.1.10",
-            "resolved": "https://registry.npmjs.org/icon-font-generator/-/icon-font-generator-2.1.10.tgz",
-            "integrity": "sha512-p8iMm+eG9toP/nRt3K7u19NPgPkjOzJS+zdf/FG7TXH0SE7teiBQIzge2aDvQOZf4HYtCVswz0Do3/nEQHLAhA==",
-            "dev": true,
-            "requires": {
-                "colors": "^1.2.1",
-                "glob": "^7.1.2",
-                "minimist": "^1.2.0",
-                "webfonts-generator": "^0.4.0"
             }
         },
         "iconv-lite": {
@@ -13217,12 +13171,6 @@
             "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=",
             "dev": true
         },
-        "microbuffer": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/microbuffer/-/microbuffer-1.0.0.tgz",
-            "integrity": "sha1-izgy7UDIfVH0e7I0kTppinVtGdI=",
-            "dev": true
-        },
         "microevent.ts": {
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/microevent.ts/-/microevent.ts-0.1.1.tgz",
@@ -13522,15 +13470,6 @@
             "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
             "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
             "dev": true
-        },
-        "neatequal": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/neatequal/-/neatequal-1.0.0.tgz",
-            "integrity": "sha1-LuEhG8n6bkxVcV/SELsFYC6xrjs=",
-            "dev": true,
-            "requires": {
-                "varstream": "^0.3.2"
-            }
         },
         "negotiator": {
             "version": "0.6.2",
@@ -18171,18 +18110,6 @@
                 "strip-ansi": "^3.0.0"
             }
         },
-        "string.fromcodepoint": {
-            "version": "0.2.1",
-            "resolved": "https://registry.npmjs.org/string.fromcodepoint/-/string.fromcodepoint-0.2.1.tgz",
-            "integrity": "sha1-jZeDM8C8klOPUPOD5IiPPlYZ1lM=",
-            "dev": true
-        },
-        "string.prototype.codepointat": {
-            "version": "0.2.1",
-            "resolved": "https://registry.npmjs.org/string.prototype.codepointat/-/string.prototype.codepointat-0.2.1.tgz",
-            "integrity": "sha512-2cBVCj6I4IOvEnjgO/hWqXjqBGsY+zwPmHl12Srk9IXSZ56Jwwmy+66XO5Iut/oQVR7t5ihYdLB0GMa4alEUcg==",
-            "dev": true
-        },
         "string.prototype.matchall": {
             "version": "4.0.2",
             "resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.2.tgz",
@@ -18827,85 +18754,11 @@
                 }
             }
         },
-        "svg-pathdata": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/svg-pathdata/-/svg-pathdata-1.0.4.tgz",
-            "integrity": "sha1-emgTQqrH7/2NUq+6eZmRDJ2juVk=",
-            "dev": true,
-            "requires": {
-                "readable-stream": "~2.0.4"
-            },
-            "dependencies": {
-                "process-nextick-args": {
-                    "version": "1.0.7",
-                    "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-                    "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
-                    "dev": true
-                },
-                "readable-stream": {
-                    "version": "2.0.6",
-                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
-                    "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
-                    "dev": true,
-                    "requires": {
-                        "core-util-is": "~1.0.0",
-                        "inherits": "~2.0.1",
-                        "isarray": "~1.0.0",
-                        "process-nextick-args": "~1.0.6",
-                        "string_decoder": "~0.10.x",
-                        "util-deprecate": "~1.0.1"
-                    }
-                },
-                "string_decoder": {
-                    "version": "0.10.31",
-                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                    "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-                    "dev": true
-                }
-            }
-        },
         "svg-tags": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/svg-tags/-/svg-tags-1.0.0.tgz",
             "integrity": "sha1-WPcc7jvVGbWdSyqEO2x95krAR2Q=",
             "dev": true
-        },
-        "svg2ttf": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/svg2ttf/-/svg2ttf-4.3.0.tgz",
-            "integrity": "sha512-LZ0B7zzHWLWbzLzwaKGHQvPOuxCXLReIb3LSxFSGUy1gMw2Utk6KGNbTmbmRL6Rk1qDSmTixnDrQgnXaL9n0CA==",
-            "dev": true,
-            "requires": {
-                "argparse": "^1.0.6",
-                "cubic2quad": "^1.0.0",
-                "lodash": "^4.17.10",
-                "microbuffer": "^1.0.0",
-                "svgpath": "^2.1.5",
-                "xmldom": "~0.1.22"
-            }
-        },
-        "svgicons2svgfont": {
-            "version": "5.0.2",
-            "resolved": "https://registry.npmjs.org/svgicons2svgfont/-/svgicons2svgfont-5.0.2.tgz",
-            "integrity": "sha1-BRGCPGSRvhp9VDKS4pqK5ietBAY=",
-            "dev": true,
-            "requires": {
-                "commander": "^2.9.0",
-                "neatequal": "^1.0.0",
-                "readable-stream": "^2.0.4",
-                "sax": "^1.1.5",
-                "string.fromcodepoint": "^0.2.1",
-                "string.prototype.codepointat": "^0.2.0",
-                "svg-pathdata": "^1.0.4"
-            },
-            "dependencies": {
-                "commander": {
-                    "version": "2.20.3",
-                    "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-                    "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-                    "dev": true
-                }
-            }
         },
         "svgo": {
             "version": "1.3.2",
@@ -18968,12 +18821,6 @@
                     }
                 }
             }
-        },
-        "svgpath": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/svgpath/-/svgpath-2.3.0.tgz",
-            "integrity": "sha512-N/4UDu3Y2ICik0daMmFW1tplw0XPs1nVIEVYkTiQfj9/JQZeEtAKaSYwheCwje1I4pQ5r22fGpoaNIvGgsyJyg==",
-            "dev": true
         },
         "symbol-observable": {
             "version": "1.2.0",
@@ -19492,39 +19339,6 @@
                 "tslib": "^1.8.1"
             }
         },
-        "ttf2eot": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/ttf2eot/-/ttf2eot-2.0.0.tgz",
-            "integrity": "sha1-jmM3pYWr0WCKDISVirSDzmn2ZUs=",
-            "dev": true,
-            "requires": {
-                "argparse": "^1.0.6",
-                "microbuffer": "^1.0.0"
-            }
-        },
-        "ttf2woff": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/ttf2woff/-/ttf2woff-2.0.2.tgz",
-            "integrity": "sha512-X68badwBjAy/+itU49scLjXUL094up+rHuYk+YAOTTBYSUMOmLZ7VyhZJuqQESj1gnyLAC2/5V8Euv+mExmyPA==",
-            "dev": true,
-            "requires": {
-                "argparse": "^1.0.6",
-                "microbuffer": "^1.0.0",
-                "pako": "^1.0.0"
-            }
-        },
-        "ttf2woff2": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/ttf2woff2/-/ttf2woff2-2.0.3.tgz",
-            "integrity": "sha1-XgIK/m5kMofzrXaHq+0g/mVOsyk=",
-            "dev": true,
-            "requires": {
-                "bindings": "^1.2.1",
-                "bufferstreams": "^1.1.0",
-                "nan": "^2.1.0",
-                "node-gyp": "^3.0.3"
-            }
-        },
         "tty-browserify": {
             "version": "0.0.0",
             "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
@@ -19661,12 +19475,6 @@
                     }
                 }
             }
-        },
-        "underscore": {
-            "version": "1.10.2",
-            "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.10.2.tgz",
-            "integrity": "sha512-N4P+Q/BuyuEKFJ43B9gYuOj4TQUHXX+j2FqguVOpjkssLUUrnJofCcBccJSCoeturDoZU6GorDTHSvUDlSQbTg==",
-            "dev": true
         },
         "unfetch": {
             "version": "4.1.0",
@@ -20096,41 +19904,6 @@
                 "spdx-expression-parse": "^3.0.0"
             }
         },
-        "varstream": {
-            "version": "0.3.2",
-            "resolved": "https://registry.npmjs.org/varstream/-/varstream-0.3.2.tgz",
-            "integrity": "sha1-GKxklHZfP/GjWtmkvgU77BiKXeE=",
-            "dev": true,
-            "requires": {
-                "readable-stream": "^1.0.33"
-            },
-            "dependencies": {
-                "isarray": {
-                    "version": "0.0.1",
-                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                    "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-                    "dev": true
-                },
-                "readable-stream": {
-                    "version": "1.1.14",
-                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-                    "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
-                    "dev": true,
-                    "requires": {
-                        "core-util-is": "~1.0.0",
-                        "inherits": "~2.0.1",
-                        "isarray": "0.0.1",
-                        "string_decoder": "~0.10.x"
-                    }
-                },
-                "string_decoder": {
-                    "version": "0.10.31",
-                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                    "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-                    "dev": true
-                }
-            }
-        },
         "vary": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
@@ -20417,32 +20190,6 @@
                 "rgb2hex": "^0.2.0",
                 "serialize-error": "^7.0.0",
                 "webdriver": "6.4.0"
-            }
-        },
-        "webfonts-generator": {
-            "version": "0.4.0",
-            "resolved": "https://registry.npmjs.org/webfonts-generator/-/webfonts-generator-0.4.0.tgz",
-            "integrity": "sha1-X4n8gccWDm4Mu8m3OH5CpYUf2kY=",
-            "dev": true,
-            "requires": {
-                "handlebars": "^4.0.5",
-                "mkdirp": "^0.5.0",
-                "q": "^1.1.2",
-                "svg2ttf": "^4.0.0",
-                "svgicons2svgfont": "^5.0.0",
-                "ttf2eot": "^2.0.0",
-                "ttf2woff": "^2.0.1",
-                "ttf2woff2": "^2.0.3",
-                "underscore": "^1.7.0",
-                "url-join": "^1.1.0"
-            },
-            "dependencies": {
-                "url-join": {
-                    "version": "1.1.0",
-                    "resolved": "https://registry.npmjs.org/url-join/-/url-join-1.1.0.tgz",
-                    "integrity": "sha1-dBxsL0WWxIMNZxhGCSDQySIC3Hg=",
-                    "dev": true
-                }
             }
         },
         "webidl-conversions": {
@@ -20741,12 +20488,6 @@
             "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
             "dev": true
         },
-        "wordwrap": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-            "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
-            "dev": true
-        },
         "worker-farm": {
             "version": "1.7.0",
             "resolved": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.7.0.tgz",
@@ -20884,12 +20625,6 @@
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
             "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
-            "dev": true
-        },
-        "xmldom": {
-            "version": "0.1.31",
-            "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.31.tgz",
-            "integrity": "sha512-yS2uJflVQs6n+CyjHoaBmVSqIDevTAWrzMmjG1Gc7h1qQ7uVozNhEPJAwZXWyGQ/Gafo3fCwrcaokezLPupVyQ==",
             "dev": true
         },
         "xtend": {

--- a/package.json
+++ b/package.json
@@ -51,6 +51,8 @@
     "devDependencies": {
         "@babel/cli": "^7.10.5",
         "@babel/core": "^7.11.0",
+        "@babel/plugin-proposal-class-properties": "^7.10.4",
+        "@babel/plugin-transform-runtime": "^7.11.0",
         "@babel/preset-env": "^7.11.0",
         "@babel/preset-typescript": "^7.10.4",
         "@storybook/addon-a11y": "^5.3.19",

--- a/scss/1-settings/_grid.scss
+++ b/scss/1-settings/_grid.scss
@@ -15,7 +15,7 @@ $cads-nav-breakpoint-gutters: (
     // 16px
         md: $cads-spacing-5,
     // 16px
-        lg: $cads-spacing-5
+        lg: $cads-spacing-6
 ) !default;
 
 $cads-container-max-widths: (

--- a/scss/6-components/_navigation.scss
+++ b/scss/6-components/_navigation.scss
@@ -81,13 +81,14 @@ nav,
 
     .cads-nav-link {
         color: $cads-palette__white;
-        padding: calc(1rem - 1px) calc(1rem - 8px);
+        padding: calc(1rem - 2px) calc(1rem - 7px);
         display: inline-block;
         text-decoration: none;
+        outline: none;
 
         @include cads-transition-animation();
 
-        border: 1px solid;
+        border: 2px solid;
         border-color: $cads-palette__heritage-blue;
         line-height: 1em;
 

--- a/scss/6-components/_navigation.scss
+++ b/scss/6-components/_navigation.scss
@@ -84,7 +84,6 @@ nav,
         padding: calc(1rem - 2px) calc(1rem - 7px);
         display: inline-block;
         text-decoration: none;
-        outline: none;
 
         @include cads-transition-animation();
 

--- a/scss/6-components/_navigation.scss
+++ b/scss/6-components/_navigation.scss
@@ -81,7 +81,7 @@ nav,
 
     .cads-nav-link {
         color: $cads-palette__white;
-        padding: calc(1rem - 2px) calc(1rem - 7px);
+        padding: calc(1rem - 2px) calc(1rem - 12px);
         display: inline-block;
         text-decoration: none;
 

--- a/src/ts/greedy-nav/GreedyNav.spec.ts
+++ b/src/ts/greedy-nav/GreedyNav.spec.ts
@@ -1,10 +1,9 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 /* eslint-disable import/no-extraneous-dependencies */
-import { JSDOM, DOMWindow } from 'jsdom';
+import { JSDOM } from 'jsdom';
 import path from 'path';
 
-import { doc } from 'prettier';
-import GreedyNav, {
+import {
     getClosest,
     showToggle,
     updateLabel,

--- a/src/ts/greedy-nav/GreedyNav.ts
+++ b/src/ts/greedy-nav/GreedyNav.ts
@@ -13,14 +13,12 @@ const supports = !!document.querySelector && !!root.addEventListener; // Feature
  * This constant should be used in place of focusout/blur when assigning
  * event handlers.
  */
-const blurEventName =
-    'blur'; /* Object.prototype.hasOwnProperty.call(
+const blurEventName = Object.prototype.hasOwnProperty.call(
     MouseEvent,
     'relatedTarget'
 )
     ? 'focusout'
     : 'blur';
-*/
 /**
  * Get the closest matching element up the DOM tree
  * @param {Element} element Starting element

--- a/src/ts/greedy-nav/GreedyNav.ts
+++ b/src/ts/greedy-nav/GreedyNav.ts
@@ -652,7 +652,7 @@ export class GreedyNavMenu {
             );
 
             if (
-                !parent(<HTMLElement>event.relatedTarget, this.toggleWrapper) &&
+                !parent(relatedTarget(event, document), this.toggleWrapper) &&
                 navDropdown &&
                 navDropdownToggle
             ) {

--- a/src/ts/greedy-nav/GreedyNav.ts
+++ b/src/ts/greedy-nav/GreedyNav.ts
@@ -571,62 +571,18 @@ export class GreedyNavMenu {
         _this.classList.add('cads-greedy-nav');
     }
 
-    createNavToggleBlurHandler = (
-        _this: HTMLElement,
-        lastItemCloseHandler: (e: FocusEvent) => void,
-        toggleWrapper: HTMLElement
-    ) => (e: FocusEvent): void => {
-        if (!parent(relatedTarget(e, this.document), toggleWrapper)) {
-            // tabbing backwards
-            this.document
-                .querySelector<HTMLElement>(
-                    `${this.navDropdownSelector} li:last-child a`
-                )
-                ?.removeEventListener(blurEventName, lastItemCloseHandler);
-            _this
-                .querySelector<HTMLElement>(this.navDropdownSelector)
-                ?.classList.remove('show');
-
-            (<HTMLElement>e.currentTarget)?.classList.remove('is-open');
-
-            (<HTMLElement>e.currentTarget)?.classList.remove('is-open');
-            _this.classList.remove('is-open');
-
-            updateLabel(
-                _this,
-                this.settings.navDropdownLabel,
-                this.navDropdownToggleSelector,
-                this.settings.navDropdownLabelActive
-            );
-
-            /**
-             * Toggle aria hidden for accessibility
-             */
-            _this
-                .querySelector<HTMLElement>(this.navDropdownSelector)
-                ?.setAttribute('aria-hidden', 'false');
-        } else {
-            // tabbing forwards
-            this.document
-                .querySelector<HTMLElement>(
-                    `${this.navDropdownSelector} li:last-child a`
-                )
-                ?.addEventListener(blurEventName, lastItemCloseHandler);
-        }
-    };
-
     /**
      * Bind eventlisteners
      */
-    listeners(navWrapperElement: HTMLElement): void {
+    listeners(navWrapper: HTMLElement): void {
         window.addEventListener('resize', () => {
-            this.doesItFit(navWrapperElement, this.settings.throttleDelay);
+            this.doesItFit(navWrapper, this.settings.throttleDelay);
         });
 
         window.addEventListener(
             'orientationchange',
             () => {
-                this.doesItFit(navWrapperElement, this.settings.throttleDelay);
+                this.doesItFit(navWrapper, this.settings.throttleDelay);
             },
             true
         );
@@ -637,16 +593,16 @@ export class GreedyNavMenu {
             navDropdownLabel
         } = this.settings;
 
-        const navDropdownToggle = navWrapperElement.querySelector<HTMLElement>(
+        const navDropdownToggle = navWrapper.querySelector<HTMLElement>(
             this.navDropdownToggleSelector
         );
 
         if (navDropdownToggle) {
             // Toggle dropdown
             navDropdownToggle.addEventListener('mousedown', event => {
-                const navDropdown = navWrapperElement.querySelector<
-                    HTMLElement
-                >(this.navDropdownSelector);
+                const navDropdown = navWrapper.querySelector<HTMLElement>(
+                    this.navDropdownSelector
+                );
 
                 if (navDropdown) {
                     event.stopPropagation();
@@ -658,16 +614,16 @@ export class GreedyNavMenu {
                             'is-open'
                         );
                     }
-                    toggleClass(navWrapperElement, 'is-open');
+                    toggleClass(navWrapper, 'is-open');
 
                     /**
                      * Toggle aria hidden for accessibility
                      */
-                    if (navWrapperElement.classList.contains('is-open')) {
+                    if (navWrapper.classList.contains('is-open')) {
                         navDropdown.setAttribute('aria-hidden', 'true');
 
                         updateLabel(
-                            navWrapperElement,
+                            navWrapper,
                             navDropdownLabelActive,
                             this.navDropdownToggleSelector,
                             this.settings.navDropdownLabelActive
@@ -678,7 +634,7 @@ export class GreedyNavMenu {
                         navDropdown.setAttribute('aria-hidden', 'false');
 
                         updateLabel(
-                            navWrapperElement,
+                            navWrapper,
                             navDropdownLabel,
                             this.navDropdownToggleSelector,
                             this.settings.navDropdownLabelActive
@@ -693,7 +649,7 @@ export class GreedyNavMenu {
                 return;
             }
 
-            const navDropdown = navWrapperElement.querySelector<HTMLElement>(
+            const navDropdown = navWrapper.querySelector<HTMLElement>(
                 this.navDropdownSelector
             );
 
@@ -704,17 +660,17 @@ export class GreedyNavMenu {
             ) {
                 removeClass(navDropdown, 'show');
                 removeClass(navDropdownToggle, 'is-open');
-                removeClass(navWrapperElement, 'is-open');
+                removeClass(navWrapper, 'is-open');
                 updateLabel(
-                    navWrapperElement,
+                    navWrapper,
                     navDropdownLabel,
                     this.navDropdownToggleSelector,
                     this.settings.navDropdownLabelActive
                 );
 
-                const navDropdownLink = navWrapperElement.querySelector<
-                    HTMLElement
-                >(`${this.navDropdownSelector} li:last-child a`);
+                const navDropdownLink = navWrapper.querySelector<HTMLElement>(
+                    `${this.navDropdownSelector} li:last-child a`
+                );
 
                 if (navDropdownLink) {
                     navDropdownLink.removeEventListener(
@@ -727,12 +683,12 @@ export class GreedyNavMenu {
 
         if (navDropdownToggle) {
             navDropdownToggle.addEventListener('focus', (event: FocusEvent) => {
-                const navDropdown = navWrapperElement.querySelector<
-                    HTMLElement
-                >(this.navDropdownSelector);
+                const navDropdown = navWrapper.querySelector<HTMLElement>(
+                    this.navDropdownSelector
+                );
 
                 if (navDropdown) {
-                    if (navWrapperElement.className.indexOf('is-open') === -1) {
+                    if (navWrapper.className.indexOf('is-open') === -1) {
                         addClass(navDropdown, 'show');
                         if (
                             event.currentTarget &&
@@ -740,9 +696,9 @@ export class GreedyNavMenu {
                         ) {
                             addClass(event.currentTarget, 'is-open');
                         }
-                        addClass(navWrapperElement, 'is-open');
+                        addClass(navWrapper, 'is-open');
                         updateLabel(
-                            navWrapperElement,
+                            navWrapper,
                             navDropdownLabelActive,
                             this.navDropdownToggleSelector,
                             this.settings.navDropdownLabelActive
@@ -761,11 +717,65 @@ export class GreedyNavMenu {
         if (navDropdownToggle && this.toggleWrapper) {
             navDropdownToggle.addEventListener(
                 blurEventName,
-                this.createNavToggleBlurHandler(
-                    navWrapperElement,
-                    lastItemCloseHandler,
-                    this.toggleWrapper
-                )
+                (e: FocusEvent): void => {
+                    if (
+                        !parent(
+                            relatedTarget(e, this.document),
+                            this.toggleWrapper
+                        )
+                    ) {
+                        // tabbing backwards
+                        this.document
+                            .querySelector<HTMLElement>(
+                                `${this.navDropdownSelector} li:last-child a`
+                            )
+                            ?.removeEventListener(
+                                blurEventName,
+                                lastItemCloseHandler
+                            );
+
+                        navWrapper
+                            .querySelector<HTMLElement>(
+                                this.navDropdownSelector
+                            )
+                            ?.classList.remove('show');
+
+                        (<HTMLElement>e.currentTarget)?.classList.remove(
+                            'is-open'
+                        );
+
+                        (<HTMLElement>e.currentTarget)?.classList.remove(
+                            'is-open'
+                        );
+                        navWrapper.classList.remove('is-open');
+
+                        updateLabel(
+                            navWrapper,
+                            this.settings.navDropdownLabel,
+                            this.navDropdownToggleSelector,
+                            this.settings.navDropdownLabelActive
+                        );
+
+                        /**
+                         * Toggle aria hidden for accessibility
+                         */
+                        navWrapper
+                            .querySelector<HTMLElement>(
+                                this.navDropdownSelector
+                            )
+                            ?.setAttribute('aria-hidden', 'false');
+                    } else {
+                        // tabbing forwards
+                        this.document
+                            .querySelector<HTMLElement>(
+                                `${this.navDropdownSelector} li:last-child a`
+                            )
+                            ?.addEventListener(
+                                blurEventName,
+                                lastItemCloseHandler
+                            );
+                    }
+                }
             );
         }
 
@@ -773,7 +783,7 @@ export class GreedyNavMenu {
          * Remove when clicked outside dropdown
          */
         this.document.addEventListener('click', (event: MouseEvent) => {
-            const navDropdown = navWrapperElement.querySelector<HTMLElement>(
+            const navDropdown = navWrapper.querySelector<HTMLElement>(
                 this.navDropdownSelector
             );
             if (
@@ -788,9 +798,9 @@ export class GreedyNavMenu {
             ) {
                 navDropdown.classList.remove('show');
                 navDropdown.classList.remove('is-open');
-                navWrapperElement.classList.remove('is-open');
+                navWrapper.classList.remove('is-open');
                 updateLabel(
-                    navWrapperElement,
+                    navWrapper,
                     navDropdownLabel,
                     this.navDropdownToggleSelector,
                     this.settings.navDropdownLabelActive

--- a/src/ts/greedy-nav/__fixtures__/menu.html
+++ b/src/ts/greedy-nav/__fixtures__/menu.html
@@ -1,0 +1,66 @@
+<html>
+
+<head>
+    <meta charset="utf-8" />
+</head>
+
+<body>
+    <div class='cads-navigation-full-width-wrapper'>
+        <nav class='cads-navigation'>
+            <ul class='cads-list-unordered'>
+                <li>
+                    <a class='cads-nav-link' href='/benefits/' title='Benefits'>
+                        Benefits
+                    </a>
+                </li>
+                <li>
+                    <a class='cads-nav-link' href='/work/' title='Work'>
+                        Work
+                    </a>
+                </li>
+                <li>
+                    <a class='cads-nav-link' href='/debt-and-money/' title='Debt and money'>
+                        Debt and money
+                    </a>
+                </li>
+                <li>
+                    <a class='cads-nav-link' href='/consumer/' title='Consumer'>
+                        Consumer
+                    </a>
+                </li>
+                <li>
+                    <a class='cads-nav-link' href='/housing/' title='Housing'>
+                        Housing
+                    </a>
+                </li>
+                <li>
+                    <a class='cads-nav-link' href='/family/' title='Family'>
+                        Family
+                    </a>
+                </li>
+                <li>
+                    <a class='cads-nav-link' href='/law-and-courts/' title='Law and courts'>
+                        Law and courts
+                    </a>
+                </li>
+                <li>
+                    <a class='cads-nav-link' href='/immigration/' title='Immigration'>
+                        Immigration
+                    </a>
+                </li>
+                <li>
+                    <a class='cads-nav-link' href='/health/' title='Health'>
+                        Health
+                    </a>
+                </li>
+                <li>
+                    <a class='cads-nav-link' href='/more' title='More from us'>
+                        More from us
+                    </a>
+                </li>
+            </ul>
+        </nav>
+    </div>
+</body>
+
+</html>


### PR DESCRIPTION
Fixes keyboard navigation in ie11 by correctly checking document.activeElement.

I've also made some small refactors to name variables more clearly and use TS null checking features.

Finally a thicker default border is added to site nav items to prevent it 'jumping' when navigating.

JSDOM tests added, mostly as an example of how to write them - I had to make one fairly major change to allow this to work correctly which involves passing in a reference to document to GreedyNavMenu.