### PR TITLE
feature: header accepts alternative language link and title [NP-642]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* NP-642 Header takes language switcher paramaters
+
 ## <sub>v1.8.1</sub>
 
 #### _Aug. 26, 2020_

--- a/haml/_header.html.haml
+++ b/haml/_header.html.haml
@@ -7,7 +7,7 @@
       .cads-grid-col-md-7.cads-align-right.cads-header-search-row
         %ul.cads-list-unordered.cads-list-unordered__inline.cads-header-account-panel
           %li
-            %a{href: "/?lang"} Language
+            %a{href: alt_language['url']}= alt_language['title']
           %li
             %a{href: sign_in['url']}
               = sign_in['text']

--- a/styleguide/haml_locals.rb
+++ b/styleguide/haml_locals.rb
@@ -124,6 +124,11 @@
     ]
   },
 
+  'alt_language'  => {
+    'url' => '#?lang=cy',
+    'title' => 'Cymraeg'
+  },
+
   'navigation_links' => [
     {
       'url' => '/benefits/',

--- a/styleguide/samples/_advice_collection.html.haml
+++ b/styleguide/samples/_advice_collection.html.haml
@@ -1,4 +1,4 @@
-= render partial: "@citizensadvice/design-system/haml/header"
+= render partial: "@citizensadvice/design-system/haml/header", local: { alt_language: alt_language }
 = render partial: "@citizensadvice/design-system/haml/navigation"
 .cads-grid-container
   .cads-grid-row

--- a/styleguide/samples/_advice_collection_adviser.html.haml
+++ b/styleguide/samples/_advice_collection_adviser.html.haml
@@ -1,5 +1,5 @@
 .cads-adviser
-  = render partial: "@citizensadvice/design-system/haml/header", local: { 'sign_in': { 'url' => '/sign-out/url', 'text' => 'Sign out' } }
+  = render partial: "@citizensadvice/design-system/haml/header", local: { alt_language: alt_language, 'sign_in': { 'url' => '/sign-out/url', 'text' => 'Sign out' } }
   = render partial: "@citizensadvice/design-system/haml/navigation"
   .cads-grid-container
     .cads-grid-row

--- a/styleguide/samples/_tables.html.haml
+++ b/styleguide/samples/_tables.html.haml
@@ -1,4 +1,4 @@
-= render partial: "@citizensadvice/design-system/haml/header"
+= render partial: "@citizensadvice/design-system/haml/header", local: { alt_language: alt_language }
 = render partial: "@citizensadvice/design-system/haml/navigation"
 .cads-grid-container
   .cads-grid-row


### PR DESCRIPTION
Introduce `alt_language` local to the `header` haml component. This will allow the public website to inject a url and title to the header which is displayed in the top right corner near the sign-in button.

Related to ticket NP-715: Fetch welsh language content.