### PR TITLE
feature: Specification: Asset Hyperlink [NP-716]

### DIFF
--- a/testing/features/asset_hyperlink.feature
+++ b/testing/features/asset_hyperlink.feature
@@ -15,4 +15,3 @@ Feature: Asset Hyperlink component
     And the label includes an icon
     And the label includes the file size
     And the label is a downloadable link
-    

--- a/testing/features/asset_hyperlink.feature
+++ b/testing/features/asset_hyperlink.feature
@@ -1,0 +1,18 @@
+Feature: Asset Hyperlink component
+
+  The Asset Hyperlink component allows content managers to provide an
+  easy way for users to download files
+
+  Background:
+    Given an Asset Hyperlink component is on the page
+
+  Scenario: Validate initial state
+    Then the header says "Asset hyperlink"
+    And a link to download a PDF is present
+
+  Scenario: Label is easy to read and informative for users with Accessibility needs
+    Then the label includes a name at the beginning
+    And the label includes an icon
+    And the label includes the file size
+    And the label is a downloadable link
+    

--- a/testing/features/asset_hyperlink.feature
+++ b/testing/features/asset_hyperlink.feature
@@ -8,9 +8,9 @@ Feature: Asset Hyperlink component
 
   Scenario: Validate initial state
     Then the header says "Asset hyperlink"
-    And a link to download a PDF is present
+    And a link to the PDF is present
 
-  Scenario: Label is easy to read and informative for users with Accessibility needs
+  Scenario: Label is informative and easy to understand for all types of user
     Then the label includes a name at the beginning
     And the label includes an icon
     And the label includes the file size

--- a/testing/features/step_definitions/asset_hyperlink_steps.rb
+++ b/testing/features/step_definitions/asset_hyperlink_steps.rb
@@ -10,7 +10,7 @@ Then("a link to download a PDF is present") do
 end
 
 Then("the label includes a name at the beginning") do
-  expect(@component.download_link.text).to start_with("Test pdf")
+  expect(@component.initial_form.download_link.text).to start_with("Test pdf")
 end
 
 Then("the label includes an icon") do
@@ -18,9 +18,11 @@ Then("the label includes an icon") do
 end
 
 Then("the label includes the file size") do
-  expect(@component.download_size).to match(file_size)
+  expect(@component.initial_form.download_size.text).to match(file_size)
 end
 
 Then("the label is a downloadable link") do
-  expect(@component.download_link["href"]).not_to be_empty
+  expect(@component.initial_form.download_link["href"]).not_to be_nil
+
+  expect(@component.initial_form.download_link["href"]).not_to be_empty
 end

--- a/testing/features/step_definitions/asset_hyperlink_steps.rb
+++ b/testing/features/step_definitions/asset_hyperlink_steps.rb
@@ -5,8 +5,8 @@ Given("an Asset Hyperlink component is on the page") do
   @component.load
 end
 
-Then("a link to download a PDF is present") do
-  expect(@component).to have_download_link
+Then("a link to the PDF is present") do
+  expect(@component.initial_form).to have_download_link
 end
 
 Then("the label includes a name at the beginning") do

--- a/testing/features/step_definitions/asset_hyperlink_steps.rb
+++ b/testing/features/step_definitions/asset_hyperlink_steps.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+Given("an Asset Hyperlink component is on the page") do
+  @component = DesignSystem::AssetHyperlink.new
+  @component.load
+end
+
+Then("a link to download a PDF is present") do
+  expect(@component).to have_download_link
+end
+
+Then("the label includes a name at the beginning") do
+  expect(@component.download_link.text).to start_with("Test pdf")
+end
+
+Then("the label includes an icon") do
+  "Complex TBD"
+end
+
+Then("the label includes the file size") do
+  expect(@component.download_size).to match(file_size)
+end
+
+Then("the label is a downloadable link") do
+  expect(@component.download_link["href"]).not_to be_empty
+end

--- a/testing/features/step_definitions/asset_hyperlink_steps.rb
+++ b/testing/features/step_definitions/asset_hyperlink_steps.rb
@@ -14,7 +14,7 @@ Then("the label includes a name at the beginning") do
 end
 
 Then("the label includes an icon") do
-  "Complex TBD"
+  expect(@component.initial_form.download_icon_content).not_to be_blank
 end
 
 Then("the label includes the file size") do
@@ -22,7 +22,5 @@ Then("the label includes the file size") do
 end
 
 Then("the label is a downloadable link") do
-  expect(@component.initial_form.download_link["href"]).not_to be_nil
-
-  expect(@component.initial_form.download_link["href"]).not_to be_empty
+  expect(@component.initial_form.download_link["href"]).not_to be_blank
 end

--- a/testing/features/support/core_ext/object.rb
+++ b/testing/features/support/core_ext/object.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class Object
+  def blank?
+    nil? || empty?
+  end
+end

--- a/testing/features/support/env.rb
+++ b/testing/features/support/env.rb
@@ -22,6 +22,7 @@ require_relative "helpers/drivers"
 require_relative "helpers/faraday"
 require_relative "helpers/methods"
 require_relative "helpers/page"
+require_relative "helpers/regex"
 
 require_relative "automation_logger"
 
@@ -40,6 +41,7 @@ require_relative "drivers/browserstack/ios"
 World(
   Helpers::Page,
   Helpers::Methods,
+  Helpers::Regex,
   Capybara::RSpecMatcherProxies
 )
 

--- a/testing/features/support/helpers/regex.rb
+++ b/testing/features/support/helpers/regex.rb
@@ -5,9 +5,9 @@ module Helpers
     # This matches either a regular integer - i.e. `3` or a float i.e. `6.5`
     # Followed by either kb or mb
     #
-    # (3).match?(file_size)     #=> true
-    # (6.5).match?(file_size)   #=> true
-    # (41.99).match?(file_size) #=> true
+    # "3mb".match?(file_size)      #=> true
+    # "6.5kb".match?(file_size)    #=> true
+    # "41.919mb".match?(file_size) #=> true
     #
     def file_size
       /^\d+.?\d*[k|m]b$/

--- a/testing/features/support/helpers/regex.rb
+++ b/testing/features/support/helpers/regex.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Helpers
+  module Regex
+    # This matches either a regular integer - i.e. `3` or a float i.e. `6.5`
+    # Followed by either kb or mb
+    #
+    # (3).match?(file_size)     #=> true
+    # (6.5).match?(file_size)   #=> true
+    # (41.99).match?(file_size) #=> true
+    #
+    def file_size
+      /\d+.?\d*[k|m]b/
+    end
+  end
+end

--- a/testing/features/support/helpers/regex.rb
+++ b/testing/features/support/helpers/regex.rb
@@ -10,7 +10,7 @@ module Helpers
     # (41.99).match?(file_size) #=> true
     #
     def file_size
-      /\d+.?\d*[k|m]b/
+      /^\d+.?\d*[k|m]b$/
     end
   end
 end

--- a/testing/features/support/pages/asset_hyperlink.rb
+++ b/testing/features/support/pages/asset_hyperlink.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module DesignSystem
+  class AssetHyperlink < SitePrism::Page
+    set_url "/iframe.html?id=3-components--asset-hyperlink&viewMode=story"
+
+    element :page_title, "h1"
+    section :initial_form, "#a11yComponentToTest" do
+      element :download_link, "a"
+      element :download_size, ".cads-asset-type"
+    end
+
+    load_validation do
+      AutomationLogger.debug("Waiting for Asset Hyperlink component.")
+      [has_initial_form?(wait: 5), "Initial Asset Hyperlink component didn't load correctly!"]
+    end
+  end
+end

--- a/testing/features/support/pages/asset_hyperlink.rb
+++ b/testing/features/support/pages/asset_hyperlink.rb
@@ -8,6 +8,14 @@ module DesignSystem
     section :initial_form, "#a11yComponentToTest" do
       element :download_link, "a"
       element :download_size, ".cads-asset-type"
+
+      def download_icon_content
+        Capybara.current_session.evaluate_script(
+          "window.getComputedStyle(
+            document.querySelector('.cads-icon_file'), '::before'
+          ).getPropertyValue('content')"
+        ).delete('\\"')
+      end
     end
 
     load_validation do


### PR DESCRIPTION
Here is the specification for Asset Hyperlink

As this is a static test. Primarily we just validate what it looks like. Given that different browsers and users will control what happens on link click, it doesn't make sense to test this.

FYI: I wasn't sure if the `F` which comes out of the content for the icon meant anything, so I just validate that there is "some" icon value, not specifically an F.
