### PR TITLE
feature: Specification - Contact Details [NP-717]

### DIFF
--- a/testing/features/advice_feedback.feature
+++ b/testing/features/advice_feedback.feature
@@ -7,8 +7,7 @@ Feature: Advice Feedback component
     Given an Advice Feedback component is on the page
 
   Scenario: Validate initial state
-    Then the header says "Advice feedback"
-    And I am able to provide feedback
+    Then I am able to provide feedback
 
   Scenario: User giving positive feedback
     When I inform Citizens Advice that the advice was useful

--- a/testing/features/asset_hyperlink.feature
+++ b/testing/features/asset_hyperlink.feature
@@ -7,8 +7,7 @@ Feature: Asset Hyperlink component
     Given an Asset Hyperlink component is on the page
 
   Scenario: Validate initial state
-    Then the header says "Asset hyperlink"
-    And a link to the PDF is present
+    Then a link to the PDF is present
 
   Scenario: Label is informative and easy to understand for all types of user
     Then the label includes a name at the beginning

--- a/testing/features/buttons.feature
+++ b/testing/features/buttons.feature
@@ -7,8 +7,7 @@ Feature: Buttons components
     Given the Buttons component is on the page
 
   Scenario: Validate initial state
-    Then the header says "Buttons"
-    And all the buttons are present
+    Then all the buttons are present
 
   Scenario: Primary Button changes color when hovered over
     When I hover over the Primary Button

--- a/testing/features/callout.feature
+++ b/testing/features/callout.feature
@@ -5,9 +5,6 @@ Feature: Callout component
   Background:
     Given a Callout component is on the page
 
-  Scenario: Validate initial state
-    Then the header says "Callout"
-    And a callout title and message are present
-
-  Scenario: Ensure component has an "Important" label
-    Then an "Important" label is present above the callout title
+  Scenario: Validate state of component
+    Then a callout title and message are present
+    And an "Important" label is present above the callout title

--- a/testing/features/contact_details.feature
+++ b/testing/features/contact_details.feature
@@ -1,0 +1,15 @@
+Feature: Contact Details component
+
+  The Contact Details component provides users with full contact information
+  so that they can contact the relevant authority via different methods
+
+  Background:
+    Given a Contact Details component is on the page
+
+  Scenario: Validate initial state
+    Then the header says "Contact Details"
+    And a contact details block of text is present
+
+  Scenario: Ensure component is of correct size/format
+    Then there is at least 1 paragraph
+    And the top paragraph is bold

--- a/testing/features/contact_details.feature
+++ b/testing/features/contact_details.feature
@@ -6,9 +6,6 @@ Feature: Contact Details component
   Background:
     Given a Contact Details component is on the page
 
-  Scenario: Validate initial state
-    Then the header says "Contact details"
-
-  Scenario: Ensure component is of correct size/format
+  Scenario: Validate state of component
     Then there is at least 1 paragraph
     And the top paragraph is bold

--- a/testing/features/contact_details.feature
+++ b/testing/features/contact_details.feature
@@ -7,8 +7,7 @@ Feature: Contact Details component
     Given a Contact Details component is on the page
 
   Scenario: Validate initial state
-    Then the header says "Contact Details"
-    And a contact details block of text is present
+    Then the header says "Contact details"
 
   Scenario: Ensure component is of correct size/format
     Then there is at least 1 paragraph

--- a/testing/features/step_definitions/advice_feedback_steps.rb
+++ b/testing/features/step_definitions/advice_feedback_steps.rb
@@ -37,10 +37,6 @@ Then("I am thanked for providing feedback") do
   expect(@component.positive_response_form.flash_message.text).to eq("Thank you for your feedback.")
 end
 
-Then("the header says {string}") do |string|
-  expect(@component.page_title.text).to eq(string)
-end
-
 Then("I must provide more information") do
   expect(@component).to have_negative_response_form
 

--- a/testing/features/step_definitions/contact_details_steps.rb
+++ b/testing/features/step_definitions/contact_details_steps.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+Given("a Contact Details component is on the page") do
+  @component = DesignSystem::ContactDetails.new
+  @component.load
+end
+
+Then("a contact details block of text is present") do
+  expect(@component.initial_form).to have_heading
+end
+
+Then("there is at least 1 paragraph") do
+  expect(@component.initial_form).to have_paragraphs
+end
+
+Then("the top paragraph is bold") do
+  expect(@component.initial_form.paragraphs.first).to be_bold
+end

--- a/testing/features/step_definitions/contact_details_steps.rb
+++ b/testing/features/step_definitions/contact_details_steps.rb
@@ -5,14 +5,10 @@ Given("a Contact Details component is on the page") do
   @component.load
 end
 
-Then("a contact details block of text is present") do
-  expect(@component.initial_form).to have_heading
-end
-
 Then("there is at least 1 paragraph") do
   expect(@component.initial_form).to have_paragraphs
 end
 
 Then("the top paragraph is bold") do
-  expect(@component.initial_form.paragraphs.first).to be_bold
+  expect(@component.initial_form).to have_first_bold_paragraph
 end

--- a/testing/features/support/pages/advice_feedback.rb
+++ b/testing/features/support/pages/advice_feedback.rb
@@ -4,8 +4,6 @@ module DesignSystem
   class AdviceFeedback < SitePrism::Page
     set_url "/iframe.html?id=3-components--advice-feedback&viewMode=story"
 
-    element :page_title, "h1"
-
     section :initial_form, ".cads-advice-feedback__step1" do
       element :heading, ".cads-heading-small"
       element :yes, "#cads-advice-feedback__yes"

--- a/testing/features/support/pages/asset_hyperlink.rb
+++ b/testing/features/support/pages/asset_hyperlink.rb
@@ -4,7 +4,6 @@ module DesignSystem
   class AssetHyperlink < SitePrism::Page
     set_url "/iframe.html?id=3-components--asset-hyperlink&viewMode=story"
 
-    element :page_title, "h1"
     section :initial_form, "#a11yComponentToTest" do
       element :download_link, "a"
       element :download_size, ".cads-asset-type"

--- a/testing/features/support/pages/buttons.rb
+++ b/testing/features/support/pages/buttons.rb
@@ -4,7 +4,6 @@ module DesignSystem
   class Buttons < SitePrism::Page
     set_url "/iframe.html?id=3-components--buttons&viewMode=story"
 
-    element :page_title, "h1"
     element :primary, "[type='button']:not(.cads-button)"
     element :secondary, "[type='button'].cads-button.cads-button__secondary"
     element :tertiary, "[type='button'].cads-button.cads-button__tertiary"

--- a/testing/features/support/pages/callout.rb
+++ b/testing/features/support/pages/callout.rb
@@ -4,8 +4,6 @@ module DesignSystem
   class Callout < SitePrism::Page
     set_url "/iframe.html?id=3-components--callout&viewMode=story"
 
-    element :page_title, "h1"
-
     section :initial_form, ".cads-callout-important" do
       element :heading, "h3"
       element :message, "p"

--- a/testing/features/support/pages/contact_details.rb
+++ b/testing/features/support/pages/contact_details.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module DesignSystem
+  class ContactDetails < SitePrism::Page
+    set_url "/iframe.html?id=3-components--contact-details&viewMode=story"
+
+    element :page_title, "h1"
+
+    section :initial_form, ".cads-contact-details" do
+      elements :paragraphs, "p"
+      element :first_bold_paragraph, "p:nth-of-type(1) strong"
+    end
+
+    load_validation do
+      AutomationLogger.debug("Waiting for Contact Details component.")
+      [has_initial_form?(wait: 5), "Initial Contact Details component didn't load correctly!"]
+    end
+  end
+end

--- a/testing/features/support/pages/contact_details.rb
+++ b/testing/features/support/pages/contact_details.rb
@@ -4,8 +4,6 @@ module DesignSystem
   class ContactDetails < SitePrism::Page
     set_url "/iframe.html?id=3-components--contact-details&viewMode=story"
 
-    element :page_title, "h1"
-
     section :initial_form, ".cads-contact-details" do
       elements :paragraphs, "p"
       element :first_bold_paragraph, "p:nth-of-type(1) strong"


### PR DESCRIPTION
This is a really small spec as it's static and almost completely configurable.

Only assertions from story / Panos' input was that the top item should be bold and there should be at least 1 paragraph at all times.