### PR TITLE
feature: Enable Browserstack [NP-765]

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -14,6 +14,9 @@ quote_type = "single"
 [*.{rb, feature, haml, yml}]
 indent_size = 2
 
+[Jenkinsfile]
+indent_size = 4
+
 [*.md]
 max_line_length = 0
 trim_trailing_whitespace = false

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -42,6 +42,18 @@ pipeline {
                     sh './bin/jenkins/test'
                     sh './bin/docker/grid_tests'
                 }
+
+                // Debug code to be removed after testing
+                configurationTypes = [
+                    ['Windows_10_83', 'chrome'],
+                    ['Windows_7_83', 'chrome'],
+                    ['OSX_Mojave_83', 'chrome'],
+                ]
+
+                configurationTypes.each { config, browser ->
+                    sh 'echo $config'
+                    sh 'echo $browser'
+                }
             }
         }
 
@@ -55,6 +67,16 @@ pipeline {
                     ])
                     {
                         withDockerSandbox {
+                            configurationTypes = [
+                                ['Windows_10_83', 'chrome'],
+                                ['Windows_7_83', 'chrome'],
+                                ['OSX_Mojave_83', 'chrome'],
+                            ]
+
+                            configurationTypes.each { config, browser ->
+                                sh 'echo $config'
+                                sh 'echo $browser'
+                            }
                             sh './bin/docker/browserstack_tests'
                         }
                     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -62,8 +62,7 @@ pipeline {
                         {
                             withDockerSandbox {
                                 configurationTypes.each { opts ->
-                                    config = opts[0]
-                                    browser = opts[1]
+                                    def (config, browser) = opts
                                     sh "echo Browserstack configuration to be used is: $config"
                                     sh "echo Browser Under Test is: $browser"
                                     sh "BROWSERSTACK_CONFIGURATION_OPTIONS=$config BROWSER=$browser ./bin/docker/browserstack_tests"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,11 @@
 deployBranches = ['master']
 
+configurationTypes = [
+    ['Windows_10_83', 'chrome'],
+    ['Windows_7_83', 'chrome'],
+    ['OSX_Mojave_83', 'chrome'],
+]
+
 pipeline {
     agent {
         label 'docker && awsaccess'
@@ -25,7 +31,7 @@ pipeline {
                 }
             }
         }
-        stage ('Lint') {
+        stage('Lint') {
             steps {
                 script { env.BUILD_STAGE = 'Lint' }
                 withDockerSandbox(["ca-styleguide${CA_STYLEGUIDE_VERSION_TAG}"]) {
@@ -44,22 +50,15 @@ pipeline {
                 }
 
                 // Debug code to be removed after testing
-                configurationTypes = [
-                    ['Windows_10_83', 'chrome'],
-                    ['Windows_7_83', 'chrome'],
-                    ['OSX_Mojave_83', 'chrome'],
-                ]
-
                 configurationTypes.each { config, browser ->
                     sh 'echo $config'
                     sh 'echo $browser'
                 }
             }
         }
-
         stage('Full Regression Test') {
-            if (deployBranches.contains(BRANCH_NAME)) {
-                steps {
+            steps {
+                if (deployBranches.contains(BRANCH_NAME)) {
                     script { env.BUILD_STAGE = 'Full Regression Test' }
                     withVaultSecrets([
                         BROWSERSTACK_USERNAME: '/secret/devops/public-website/develop/env, BROWSERSTACK_USERNAME',
@@ -67,12 +66,6 @@ pipeline {
                     ])
                     {
                         withDockerSandbox {
-                            configurationTypes = [
-                                ['Windows_10_83', 'chrome'],
-                                ['Windows_7_83', 'chrome'],
-                                ['OSX_Mojave_83', 'chrome'],
-                            ]
-
                             configurationTypes.each { config, browser ->
                                 sh 'echo $config'
                                 sh 'echo $browser'

--- a/testing/cucumber.yml
+++ b/testing/cucumber.yml
@@ -1,4 +1,4 @@
-passing: --tags 'not @failing'
+passing: --tags 'not @failing and not @future_release'
 
 html: --format html --out artifacts/reports/report.html
 junit: --format junit --out artifacts/reports


### PR DESCRIPTION
Browserstack is now enabled for the design-system

It will only run on master, and will run to begin with 3 combinations of Chrome (Win10,Win7,OSX Mojave).

Once we've had this running for a **couple of weeks** we can do the following...

- Refactor runners to include more browser combinations
- Alter / add extra info dumps to slack
- Monitor timings to ensure we're not going too crazy (As we're still adding more tests)

Once we've had this running for a **few months** we can do the following...

- Start having artifacts publish automatically to slack
- Look into whether we should move the tests elsewhere
- Look into running browserstack directly on branches (Obviously a smaller subset of browsers)
- Research into getting it running on a timer