### PR TITLE
bugfix: Browserstack CI fixes [NP-765]

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -91,12 +91,12 @@ pipeline {
                 reportName: 'BackstopJS Report',
             ])
             archiveArtifacts([
-                artifacts: 'artifacts/screenshots/*.png, ' +
-                'artifacts/reports/report.html, ' +
-                'artifacts/reports/*.xml, ' +
-                'artifacts/reports/report.json, ' +
-                'artifacts/html_pages/*.html, ' +
-                'artifacts/logs/*.log',
+                artifacts: 'testing/artifacts/screenshots/*.png, ' +
+                'testing/artifacts/reports/report.html, ' +
+                'testing/artifacts/reports/*.xml, ' +
+                'testing/artifacts/reports/report.json, ' +
+                'testing/artifacts/html_pages/*.html, ' +
+                'testing/artifacts/logs/*.log',
                 allowEmptyArchive: true,
                 caseSensitive: false
             ])

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,6 +30,9 @@ services:
       dockerfile: ./testing/Dockerfile.cucumber
     image: 'design_system_cucumber${PROJECT_VERSION_TAG}'
     container_name: design-system-cucumber.test
+    environment:
+      - BRANCH_NAME
+      - BROWSER
     env_file:
       - testing/grid_ci.env
     volumes:
@@ -48,8 +51,10 @@ services:
     container_name: design-system-browserstack-cucumber.test
     environment:
       - BRANCH_NAME
+      - BROWSER
       - BROWSERSTACK_USERNAME
       - BROWSERSTACK_ACCESS_KEY
+      - BROWSERSTACK_CONFIGURATION_OPTIONS
     env_file:
       - testing/browserstack_ci.env
     depends_on: []

--- a/testing/features/support/core_ext/capybara/selenium/driver/firefox_driver.rb
+++ b/testing/features/support/core_ext/capybara/selenium/driver/firefox_driver.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+# This patch completely overwrites one extension method of Firefox driver specialisation
+# The issue is the chromedriver specialisation re-publicises the `commands` method on bridge.
+#
+# As this isn't public here. We need to `send` it. To bypass security. See:
+# https://github.com/teamcapybara/capybara/issues/2380
+# for more details/discussion including possible other fixes.
+#
+# LH - Sep 2020
+module Capybara::Selenium::Driver::FirefoxDriver
+  def self.extended(driver)
+    driver.extend Capybara::Selenium::Driver::W3CFirefoxDriver if w3c?(driver)
+    bridge = driver.send(:bridge)
+    bridge.extend Capybara::Selenium::IsDisplayed unless bridge.send(:commands, :is_element_displayed)
+  end
+end


### PR DESCRIPTION
Since merging the PR for 765 (Introduce and use Browserstack, a couple of small issues have become more apparent. This PR fixes them.

- `Jenkinsfile`
  - Our archiving wasn't working properly because our code sits inside `testing`
  - The newly mounted dir should now be archived correctly
- `docker-compose.yml`
  - This wasn't passing downstream variables
  - The build was always using default driver config (Kind of making browserstack redundant).
- `capybara`
  - Has a bug where the patching for their endpoints for Firefox uses a private method. In Chrome they make the private method public, but don't do this for Firefox. I've patched this and raised an issue (Linked in patch).
