### PR TITLE
hotfix: Remove some drivers whilst we investigate issues

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,10 +7,7 @@ configurationTypes = [
     ['Windows_10_76', 'firefox'],
     ['Windows_7_80', 'chrome'],
     ['Windows_7_75', 'firefox'],
-    ['Windows_7_11', 'internet_explorer'],
-    ['OSX_Catalina_83', 'chrome'],
     ['OSX_Catalina_77', 'firefox'],
-    ['OSX_Mojave_83', 'chrome'],
     ['OSX_Mojave_83', 'firefox'],
     ['OSX_Mojave_12', 'safari'],
 ]


### PR DESCRIPTION
IE11 has regressed on window resizing
MAC Chrome looks flaky and is not performing some commands as expected.

Will remove triage and re-add extra tickets down the line