### PR TITLE
bugfix: add focus styles to error summary [NP-856]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* NP-856 Fix focus styles in error summary
+
 ## <sub>v1.9.1</sub>
 
 #### _Sep. 10, 2020_

--- a/haml/_error_summary.html.haml
+++ b/haml/_error_summary.html.haml
@@ -3,4 +3,9 @@
     There is a problem with
     %span.cads-error-summary__field_count 2 fields
   %ul.cads-list__no-bullet.cads-error-summary__list
-    %li Item 1
+    %li 
+      %a{:href => "#"}
+        Enter an email address in the correct format, like name@example.com
+    %li
+      %a{:href => "#"}  
+        Enter your full name

--- a/haml/_error_summary.html.haml
+++ b/haml/_error_summary.html.haml
@@ -1,5 +1,5 @@
-.cads-error-summary{"aria-live": "assertive"}
-  %p.cads-heading-small
+.cads-error-summary{"aria-live" => "assertive", "aria-labelledby" => "error-summary-title", :role => "alert", :tabindex => 0}
+  %p.cads-heading-small{:id => "error-summary-title"}
     There is a problem with
     %span.cads-error-summary__field_count 2 fields
   %ul.cads-list__no-bullet.cads-error-summary__list

--- a/scss/6-components/_error-summary.scss
+++ b/scss/6-components/_error-summary.scss
@@ -24,14 +24,19 @@
     margin-bottom: 0;
 
     li {
-      text-decoration: underline;
-
       &:last-of-type {
         margin-bottom: 0;
       }
 
       a {
         color: $cads-language__warning-colour;
+        text-decoration: underline;
+
+        &:focus {
+          color: $cads-language__text-colour;
+          text-decoration: none;
+          outline: none;
+        }
       }
     }
   }

--- a/scss/6-components/_error-summary.scss
+++ b/scss/6-components/_error-summary.scss
@@ -10,6 +10,11 @@
     width: 100%;
   }
 
+  &:focus {
+    outline: 2px solid $cads_language__focus-colour;
+    border-color: $cads_language__error-colour;
+  }
+
   .cads-heading-small {
     color: $cads-language__warning-colour;
     margin-bottom: $cads-spacing-4;

--- a/styleguide/component.stories.js
+++ b/styleguide/component.stories.js
@@ -121,8 +121,13 @@ You will need to provide the validation content and set the content.
 To set the number of fields use the <code>cads-error-summary__field_count</code>
 span and set the content to <code>1 field</code>, <code>5 fields</code>, etc.
 
+The error summary should gain focus when it first appears, tabbing should then flow through
+the links in the error summary in the normal way.
+
 Then use the <code>cads-error-summary__list</code> to add the relevant <code>li</code>
-items.`
+items.  Each item should contain a link with text that is the same as the error message next
+to the field.  Each link should give focus to the related field when clicked.
+`
   );
 export const logo = () =>
   renderHamlTemplate(


### PR DESCRIPTION
Reasons for change:
Error summary must be focusable and have correctly styled links with focus.  This PR address those two issues.

Changes:
 - correct focus styles on error summary and links within
 - add accessibility attrs and links into haml template
 - documentation updates to cover how the error summary should behave
