### PR TITLE
Stylelint blacklist → disallowed-list

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -3,7 +3,7 @@
     "plugins": ["stylelint-scss", "stylelint-selector-bem-pattern"],
     "ignoreFiles": ["**/_normalize.scss", "**/_cads-iconfont.scss"],
     "rules": {
-        "at-rule-blacklist": ["debug"],
+        "at-rule-disallowed-list": ["debug"],
         "at-rule-empty-line-before": [
             "always",
             {
@@ -18,7 +18,7 @@
         "color-named": "never",
         "declaration-colon-newline-after": null,
         "indentation": 2,
-        "property-blacklist": ["transition"],
+        "property-disallowed-list": ["transition"],
         "rule-empty-line-before": [
             "always-multi-line",
             {

--- a/scss/2-tools/_animation.scss
+++ b/scss/2-tools/_animation.scss
@@ -1,5 +1,5 @@
 @mixin cads-transition-animation($property: '') {
-  /* stylelint-disable property-blacklist */
+  /* stylelint-disable property-disallowed-list */
   @if $property != '' {
     transition: $property $cads-animation-speed;
   } @else {


### PR DESCRIPTION
Stylelint have sensibly deprecated `blacklist` properties in favour of `disallowed-list` versions. Updating the config and comments to cover this.