### PR TITLE
Untag button feature specs

### DIFF
--- a/testing/features/buttons.feature
+++ b/testing/features/buttons.feature
@@ -6,37 +6,30 @@ Feature: Buttons components
   Background:
     Given the Buttons component is on the page
 
-  @future_release @v1.9.4+
   Scenario: Validate initial state
     Then all the buttons are present
 
-  @future_release @v1.9.4+
   Scenario: Primary Button changes color when hovered over
     When I hover over the Primary Button
     Then the background color of the Primary Button changes
 
-  @future_release @v1.9.4+
   Scenario: Primary Button changes color when clicked on
     When I click on the Primary Button
     Then the background color of the Primary Button changes
 
-  @future_release @v1.9.4+
   Scenario: Secondary Button changes color when hovered over
     When I hover over the Secondary Button
     Then the background color of the Secondary Button changes
 
-  @future_release @v1.9.4+
   Scenario: Secondary Button changes color when clicked on
     When I click on the Secondary Button
     Then the background color of the Secondary Button changes
     And the text color of the Secondary Button changes
 
-  @future_release @v1.9.4+
   Scenario: Tertiary Button changes color when hovered over
     When I hover over the Tertiary Button
     Then the background color of the Tertiary Button changes
 
-  @future_release @v1.9.4+
   Scenario: Tertiary Button changes color when clicked on
     When I click on the Tertiary Button
     Then the background color of the Tertiary Button changes


### PR DESCRIPTION
Now that v1.10.0 has been released I should be able to untag the button feature specs as `@future_release`