### PR TITLE
Match release formatting with editorconfig

### DIFF
--- a/scripts/release.js
+++ b/scripts/release.js
@@ -29,7 +29,7 @@ function updateVersionNumber(newVersion) {
   packageJson.version = newVersion;
   // Write the updated file
   fs.writeJsonSync(PACKAGE_JSON, packageJson, {
-    spaces: 4,
+    spaces: 2,
     EOL: '\n',
   });
   log(


### PR DESCRIPTION
Noticed that the release script formats the `package.json` file with **4** spaces where `package.json` convention, and our `.editorconfig` settings for the project as a whole specify **2**. This causes some awkward diffs and conflicts when performing a release.

Wondering if longer term we could either defer to `npm version`, use something like https://github.com/sindresorhus/np to avoid the need to roll our own version bumping script? Or alternatively use `prettier` as a formatter when updating the file?

The simplest change I could make for now is to bring the number of spaces in sync with the config.