### PR TITLE
feature:Breadcrumbs Spec [NP-623]

### DIFF
--- a/testing/features/breadcrumbs.feature
+++ b/testing/features/breadcrumbs.feature
@@ -1,0 +1,14 @@
+Feature: Breadcrumbs component
+
+  The Breadcrumbs component allows users to see a navigable path to their
+  previous content pages they have traversed through
+
+  Background:
+    Given a Breadcrumbs component is on the page
+
+  Scenario: Validate initial state
+    Then a series of breadcrumbs are present
+
+  Scenario: Breadcrumbs only link up till the last one
+    Then the initial breadcrumbs are all links
+    But the final breadcrumb isn't a link

--- a/testing/features/step_definitions/breadcrumbs_steps.rb
+++ b/testing/features/step_definitions/breadcrumbs_steps.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+Given("a Breadcrumbs component is on the page") do
+  @component = DesignSystem::Breadcrumbs.new
+  @component.load
+end
+
+Then("a series of breadcrumbs are present") do
+  expect(@component.initial_form).to have_breadcrumbs
+end
+
+Then("the initial breadcrumbs are all links") do
+  expect(@component.initial_form.all_but_last_breadcrumb).to have_link
+end
+
+Then("the final breadcrumb isn't a link") do
+  expect(@component.initial_form.breadcrumbs.last).not_to have_link
+end

--- a/testing/features/step_definitions/breadcrumbs_steps.rb
+++ b/testing/features/step_definitions/breadcrumbs_steps.rb
@@ -10,7 +10,7 @@ Then("a series of breadcrumbs are present") do
 end
 
 Then("the initial breadcrumbs are all links") do
-  expect(@component.initial_form.all_but_last_breadcrumb).to have_link
+  expect(@component.initial_form.all_but_last_breadcrumb).to all have_link
 end
 
 Then("the final breadcrumb isn't a link") do

--- a/testing/features/support/pages/breadcrumbs.rb
+++ b/testing/features/support/pages/breadcrumbs.rb
@@ -2,10 +2,10 @@
 
 module DesignSystem
   class Breadcrumbs < SitePrism::Page
-    set_url "/iframe.html?id=3-components--breadcrumbs&viewMode=story"
+    set_url "/iframe.html?id=3-components--breadcrumb&viewMode=story"
 
     section :initial_form, "#a11yComponentToTest" do
-      element :breadcrumbs, ".cads-breadcrumbs li"
+      elements :breadcrumbs, ".cads-breadcrumbs li"
 
       def all_but_last_breadcrumb
         breadcrumbs[0..-2]

--- a/testing/features/support/pages/breadcrumbs.rb
+++ b/testing/features/support/pages/breadcrumbs.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module DesignSystem
+  class Breadcrumbs < SitePrism::Page
+    set_url "/iframe.html?id=3-components--breadcrumbs&viewMode=story"
+
+    section :initial_form, "#a11yComponentToTest" do
+      element :breadcrumbs, ".cads-breadcrumbs li"
+
+      def all_but_last_breadcrumb
+        breadcrumbs[0..-2]
+      end
+    end
+
+    load_validation do
+      AutomationLogger.debug("Waiting for Breadcrumbs component.")
+      [has_initial_form?(wait: 5), "Initial Breadcrumbs component didn't load correctly!"]
+    end
+  end
+end


### PR DESCRIPTION
Added Feature specification for Breadcrumbs

NB: I used the capybara helper `has_link?` for links, as the specific URL's contained aren't validatable (As they link off to invalid URLs) - These are then used as `have_link` for the assertion. But I don't provide more details, as they're irrelevant.