### PR TITLE
Set docs as primary view

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,11 +1,11 @@
-import { addDecorator, addParameters } from '@storybook/html';
+import { addDecorator } from '@storybook/html';
 
 addDecorator(
   (storyFn) => `<div class="cads-styleguide__wrapper">${storyFn()}</div>`
 );
 
-// Option defaults:
-addParameters({
+export const parameters = {
+  viewMode: 'docs',
   options: {
     isToolshown: true,
     showPanel: true,
@@ -15,4 +15,4 @@ addParameters({
       order: ['Welcome', ['Getting started'], 'Components'],
     },
   },
-});
+};

--- a/styleguide/component.stories.js
+++ b/styleguide/component.stories.js
@@ -65,6 +65,7 @@ ${usage || ''}`,
 export default {
   title: '3: Components',
   parameters: {
+    viewMode: 'story',
     options: {
       showPanel: true,
     },

--- a/styleguide/foundations.stories.js
+++ b/styleguide/foundations.stories.js
@@ -18,6 +18,10 @@ export default {
     (storyFn) =>
       `<div class="cads-styleguide-max-content-width">${storyFn()}</div>`,
   ],
+  parameters: {
+    viewMode: 'story',
+    options: { showPanel: false },
+  },
 };
 
 function getColours(type, sass) {

--- a/styleguide/page.stories.js
+++ b/styleguide/page.stories.js
@@ -44,6 +44,7 @@ function renderHamlTemplate(
 export default {
   title: '4: Sample pages',
   parameters: {
+    viewMode: 'story',
     options: {
       showPanel: true,
     },


### PR DESCRIPTION
Requested by @soniaturcotte in https://github.com/citizensadvice/design-system/pull/242

Set docs as the primary view for new components documentation. @soniaturcotte This is worth a play. It's possible but IMO makes switching to the canvas view significantly more confusing.