### PR TITLE
feature: Browserstack Chunking [NP-854]

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,13 +2,13 @@ deployBranches = ['master']
 
 configurationTypes = [
     ['Windows_10_83', 'chrome'],
-    ['Windows_10_81', 'chrome'],
-    ['Windows_10_77', 'firefox'],
+    ['Windows_10_85', 'chrome'],
+    ['Windows_10_80', 'firefox'],
     ['Windows_10_76', 'firefox'],
     ['Windows_7_80', 'chrome'],
-    ['Windows_7_75', 'firefox'],
-    ['OSX_Catalina_77', 'firefox'],
-    ['OSX_Mojave_76', 'firefox'],
+    ['Windows_7_78', 'firefox'],
+    ['OSX_Catalina_80', 'firefox'],
+    ['OSX_Mojave_78', 'firefox'],
     ['OSX_Mojave_12', 'safari'],
 ]
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,6 +45,7 @@ services:
     environment:
       - BRANCH_NAME
       - BROWSER
+      - DOCKER_TAG
     env_file:
       - testing/grid_ci.env
     volumes:
@@ -62,8 +63,6 @@ services:
     <<: *cucumber_default
     container_name: design-system-browserstack-cucumber.test
     environment:
-      - BRANCH_NAME
-      - BROWSER
       - BROWSERSTACK_USERNAME
       - BROWSERSTACK_ACCESS_KEY
       - BROWSERSTACK_CONFIGURATION_OPTIONS

--- a/testing/features/buttons.feature
+++ b/testing/features/buttons.feature
@@ -6,42 +6,20 @@ Feature: Buttons components
   Background:
     Given the Buttons component is on the page
 
-  @future_release @v1.9.4+
   Scenario: Validate initial state
     Then all the buttons are present
 
-  @future_release @v1.9.4+
-  Scenario: Primary Button changes color when hovered over
-    When I hover over the Primary Button
-    Then the background color of the Primary Button changes
-
-  @future_release @v1.9.4+
   Scenario: Primary Button changes color when clicked on
     When I click on the Primary Button
     Then the background color of the Primary Button changes
 
-  @future_release @v1.9.4+
-  Scenario: Secondary Button changes color when hovered over
-    When I hover over the Secondary Button
-    Then the background color of the Secondary Button changes
-
-  @future_release @v1.9.4+
   Scenario: Secondary Button changes color when clicked on
     When I click on the Secondary Button
     Then the background color of the Secondary Button changes
     And the text color of the Secondary Button changes
 
-  @future_release @v1.9.4+
-  Scenario: Tertiary Button changes color when hovered over
-    When I hover over the Tertiary Button
-    Then the background color of the Tertiary Button changes
-
-  @future_release @v1.9.4+
   Scenario: Tertiary Button changes color when clicked on
     When I click on the Tertiary Button
     Then the background color of the Tertiary Button changes
     And the text color of the Tertiary Button changes
-
-  #Scenario: Tertiary button has less prominent text
-  #  Then the Tertiary button text is less prominent than the Primary Button
-  #  And the Tertiary button text is less prominent than the Secondary Button
+    

--- a/testing/features/step_definitions/buttons_steps.rb
+++ b/testing/features/step_definitions/buttons_steps.rb
@@ -5,10 +5,6 @@ Given("the Buttons component is on the page") do
   @component.load
 end
 
-When("I hover over the {button-type} Button") do |button|
-  @component.send(button).hover
-end
-
 When("I click on the {button-type} Button") do |button|
   @component.send(button).click
 end
@@ -25,13 +21,4 @@ end
 Then("the text color of the {button-type} Button changes") do |button|
   expect(@component.text_color_of(button))
     .not_to eq(@component.initial_text_color_of(button))
-end
-
-Then("the Tertiary button text is less prominent than the {button-type} Button") do |button|
-  if safari?
-    expect(@component.font_weight_of("tertiary")).to eq("normal")
-    expect(@component.font_weight_of(button)).to eq("bold")
-  else
-    expect(@component.font_weight_of("tertiary")).to be < @component.font_weight_of(button)
-  end
 end

--- a/testing/features/support/drivers/browserstack/base.rb
+++ b/testing/features/support/drivers/browserstack/base.rb
@@ -47,7 +47,7 @@ module Drivers
           "bstack:options" => {
             "buildName" => build_name,
             "projectName" => "Design System tests",
-            "sessionName" => "CI tests called from within Design System",
+            "sessionName" => session_name,
             "os" => os,
             "osVersion" => os_version,
             "local" => "false",
@@ -65,11 +65,11 @@ module Drivers
       end
 
       def build_name
-        if ENV["BRANCH_NAME"]
-          "#{ENV['BRANCH_NAME']} running on #{base_url}"
-        else
-          "Local Machine run - Ignore results!"
-        end
+        PayloadValuesGenerator.new.build_name
+      end
+
+      def session_name
+        PayloadValuesGenerator.new.session_name
       end
 
       def os

--- a/testing/features/support/drivers/browserstack/base.rb
+++ b/testing/features/support/drivers/browserstack/base.rb
@@ -65,11 +65,11 @@ module Drivers
       end
 
       def build_name
-        PayloadValuesGenerator.new.build_name
+        PayloadValuesGenerator.build_name
       end
 
       def session_name
-        PayloadValuesGenerator.new.session_name
+        PayloadValuesGenerator.session_name
       end
 
       def os

--- a/testing/features/support/drivers/browserstack/payload_values_generator.rb
+++ b/testing/features/support/drivers/browserstack/payload_values_generator.rb
@@ -3,54 +3,56 @@
 module Drivers
   class Browserstack
     class PayloadValuesGenerator
-      include Helpers::EnvVariables
-      include Helpers::Methods
+      class << self
+        include Helpers::EnvVariables
+        include Helpers::Methods
 
-      def build_name
-        if master?
-          "Design System - #{pr_with_build_iteration} - URL: #{base_url}"
-        elsif branch?
-          "Design System - #{pr_without_build_iteration} - URL: #{base_url}"
-        else
-          "Local Machine run - Month #{Time.now.month} - Ignore results!"
+        def build_name
+          if master?
+            "Design System - #{pr_with_build_iteration} - URL: #{base_url}"
+          elsif branch?
+            "Design System - #{pr_without_build_iteration} - URL: #{base_url}"
+          else
+            "Local Machine run - Month #{Time.now.month} - Ignore results!"
+          end
         end
-      end
 
-      def session_name
-        if branch? || master?
-          "Build: #{build_iteration} - CALLING_PROJECT: design-system"
-        else
-          "Local run: Ran at #{timestamp}"
+        def session_name
+          if branch? || master?
+            "Build: #{build_iteration} - CALLING_PROJECT: design-system"
+          else
+            "Local run: Ran at #{timestamp}"
+          end
         end
-      end
 
-      private
+        private
 
-      def master?
-        docker_tag.include?("master")
-      end
+        def master?
+          docker_tag.include?("master")
+        end
 
-      def branch?
-        docker_tag.include?("PR-")
-      end
+        def branch?
+          docker_tag.include?("PR-")
+        end
 
-      # Example: PR-81
-      def pr_without_build_iteration
-        pr_sha_reference.split(/-\d+_/).first
-      end
+        # Example: PR-81
+        def pr_without_build_iteration
+          pr_sha_reference.split(/-\d+_/).first
+        end
 
-      def build_iteration
-        pr_with_build_iteration.split("-").last
-      end
+        def build_iteration
+          pr_with_build_iteration.split("-").last
+        end
 
-      # Example: PR-81-1
-      def pr_with_build_iteration
-        pr_sha_reference.split("_").first
-      end
+        # Example: PR-81-1
+        def pr_with_build_iteration
+          pr_sha_reference.split("_").first
+        end
 
-      # Example: PR-81-1_98eb207
-      def pr_sha_reference
-        @pr_sha_reference ||= docker_tag.split("design-system-").last
+        # Example: PR-81-1_98eb207
+        def pr_sha_reference
+          @pr_sha_reference ||= docker_tag.split("design-system-").last
+        end
       end
     end
   end

--- a/testing/features/support/drivers/browserstack/payload_values_generator.rb
+++ b/testing/features/support/drivers/browserstack/payload_values_generator.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+module Drivers
+  class Browserstack
+    class PayloadValuesGenerator
+      include Helpers::EnvVariables
+      include Helpers::Methods
+
+      def build_name
+        if master?
+          "PWC - #{pr_with_build_iteration} - URL: #{base_url}"
+        elsif branch?
+          "PWC - #{pr_without_build_iteration} - URL: #{base_url}"
+        else
+          "Local Machine run - Month #{Time.now.month} - Ignore results!"
+        end
+      end
+
+      def session_name
+        if branch? || master?
+          "Build: #{build_iteration} - CALLING_PROJECT: design-system"
+        else
+          "Local run: Ran at #{timestamp}"
+        end
+      end
+
+      private
+
+      def master?
+        docker_tag.include?("master")
+      end
+
+      def branch?
+        docker_tag.include?("PR-")
+      end
+
+      # Example: PR-81
+      def pr_without_build_iteration
+        pr_sha_reference.split(/-\d+_/).first
+      end
+
+      def build_iteration
+        pr_with_build_iteration.split("-").last
+      end
+
+      # Example: PR-81-1
+      def pr_with_build_iteration
+        pr_sha_reference.split("_").first
+      end
+
+      # Example: PR-81-1_98eb207
+      def pr_sha_reference
+        @pr_sha_reference ||= docker_tag.split("public-website-cucumber-").last
+      end
+    end
+  end
+end

--- a/testing/features/support/drivers/browserstack/payload_values_generator.rb
+++ b/testing/features/support/drivers/browserstack/payload_values_generator.rb
@@ -8,9 +8,9 @@ module Drivers
 
       def build_name
         if master?
-          "PWC - #{pr_with_build_iteration} - URL: #{base_url}"
+          "Design System - #{pr_with_build_iteration} - URL: #{base_url}"
         elsif branch?
-          "PWC - #{pr_without_build_iteration} - URL: #{base_url}"
+          "Design System - #{pr_without_build_iteration} - URL: #{base_url}"
         else
           "Local Machine run - Month #{Time.now.month} - Ignore results!"
         end
@@ -50,7 +50,7 @@ module Drivers
 
       # Example: PR-81-1_98eb207
       def pr_sha_reference
-        @pr_sha_reference ||= docker_tag.split("public-website-cucumber-").last
+        @pr_sha_reference ||= docker_tag.split("design-system-").last
       end
     end
   end

--- a/testing/features/support/env.rb
+++ b/testing/features/support/env.rb
@@ -37,6 +37,7 @@ require_relative "drivers/browserstack/android"
 require_relative "drivers/browserstack/chrome"
 require_relative "drivers/browserstack/internet_explorer"
 require_relative "drivers/browserstack/ios"
+require_relative "drivers/browserstack/payload_values_generator"
 
 World(
   Helpers::Page,

--- a/testing/features/support/helpers/env_variables.rb
+++ b/testing/features/support/helpers/env_variables.rb
@@ -53,5 +53,10 @@ module Helpers
     def base_url
       ENV.fetch("APP_URL", "https://citizensadvice.github.io/design-system")
     end
+
+    # Example: dev_jenkins-public-website-cucumber-PR-81-1_98eb207
+    def docker_tag
+      ENV["DOCKER_TAG"]
+    end
   end
 end


### PR DESCRIPTION
- Fix browserstack chunks into more granular ones.
  - This is the same work that went into `public-website-cucumber` available here: https://github.com/citizensadvice/public-website-cucumber/pull/81
  - PR's will be grouped into one cumulative pot (Irrespective of commits)
  - `master` builds will all be grouped according to the instance of `master`
  - Local builds will be grouped by month

**NB:** I also quickly re-enabled some button tests and remove some button tests FYI @davidsauntson 