### PR TITLE
refactor: Flaky button tests [NP-XXX]

### DIFF
--- a/testing/features/buttons.feature
+++ b/testing/features/buttons.feature
@@ -3,23 +3,12 @@ Feature: Buttons components
   The Button components gives the current site a variety of means of
   providing means to submit data
 
+  NB: Due to these buttons being very visual and the behaviour changing
+  dependent on each browser, we will validate them with some rigorous VRT
+  tests later on, and not test any behaviour here
+
   Background:
     Given the Buttons component is on the page
 
   Scenario: Validate initial state
     Then all the buttons are present
-
-  Scenario: Primary Button changes color when clicked on
-    When I click on the Primary Button
-    Then the background color of the Primary Button changes
-
-  Scenario: Secondary Button changes color when clicked on
-    When I click on the Secondary Button
-    Then the background color of the Secondary Button changes
-    And the text color of the Secondary Button changes
-
-  Scenario: Tertiary Button changes color when clicked on
-    When I click on the Tertiary Button
-    Then the background color of the Tertiary Button changes
-    And the text color of the Tertiary Button changes
-    

--- a/testing/features/step_definitions/buttons_steps.rb
+++ b/testing/features/step_definitions/buttons_steps.rb
@@ -5,20 +5,6 @@ Given("the Buttons component is on the page") do
   @component.load
 end
 
-When("I click on the {button-type} Button") do |button|
-  @component.send(button).click
-end
-
 Then("all the buttons are present") do
   expect(@component).to be_all_there
-end
-
-Then("the background color of the {button-type} Button changes") do |button|
-  expect(@component.background_color_of(button))
-    .not_to eq(@component.initial_background_color_of(button))
-end
-
-Then("the text color of the {button-type} Button changes") do |button|
-  expect(@component.text_color_of(button))
-    .not_to eq(@component.initial_text_color_of(button))
 end

--- a/testing/features/support/drivers/browserstack/payload_values_generator.rb
+++ b/testing/features/support/drivers/browserstack/payload_values_generator.rb
@@ -28,11 +28,11 @@ module Drivers
         private
 
         def master?
-          docker_tag.include?("master")
+          docker_tag&.include?("master")
         end
 
         def branch?
-          docker_tag.include?("PR-")
+          docker_tag&.include?("PR-")
         end
 
         # Example: PR-81

--- a/testing/features/support/pages/buttons.rb
+++ b/testing/features/support/pages/buttons.rb
@@ -38,18 +38,6 @@ module DesignSystem
         }
     end
 
-    def background_color_of(button_name)
-      send(button_name).background_color
-    end
-
-    def text_color_of(button_name)
-      send(button_name).color
-    end
-
-    def font_weight_of(button_name)
-      send(button_name).font_weight
-    end
-
     def initial_background_color_of(button_name)
       initial_properties.dig(button_name.to_sym, :background)
     end


### PR DESCRIPTION
In collaboration with David R we are going to do a couple of things.

- Try spec out a new fully formed ticket for testing Button states (The combination of BDD / VRT tests both don't cover the purpose and cause issues
- To remove the BDD tests from this portion of the repo **but** retain the assertion logic. So that if we cannot fix them, we can revert back to these with some more helpers (Hover over/Hover off e.t.c.)

NB: I also added `nil-safe` checks for `docker_tag`. This works on anything after ruby 2.3 (We're using 2.6), so no issues here. Was a minor bugfix/refactor.