### PR TITLE
Browserstack Partioning Fix

### DIFF
--- a/testing/features/support/drivers/browserstack/payload_values_generator.rb
+++ b/testing/features/support/drivers/browserstack/payload_values_generator.rb
@@ -48,7 +48,7 @@ module Drivers
         # Example: master_ad4b223
         # Example: PR-284_dbbb8b6
         def pr_with_sha
-          @pr_with_sha ||= docker_tag.split("design-system/").last
+          @pr_with_sha ||= docker_tag.delete_prefix("design-system/")
         end
       end
     end

--- a/testing/features/support/drivers/browserstack/payload_values_generator.rb
+++ b/testing/features/support/drivers/browserstack/payload_values_generator.rb
@@ -35,17 +35,17 @@ module Drivers
           docker_tag&.include?("PR-")
         end
 
-        # Example: PR-81
+        # Example: PR-284
         def pr_without_build_iteration
-          pr_sha_reference.split(/-\d+_/).first
+          pr_sha_reference.split("_").first
         end
 
         def build_iteration
-          pr_sha_reference.split("_").first.split("-").last
+          pr_sha_reference.split("_").last
         end
 
         # Example: master_ad4b223
-        # Example: PR-83_abcde123
+        # Example: PR-284_dbbb8b6
         def pr_sha_reference
           @pr_sha_reference ||= docker_tag.split("design-system/").last
         end

--- a/testing/features/support/drivers/browserstack/payload_values_generator.rb
+++ b/testing/features/support/drivers/browserstack/payload_values_generator.rb
@@ -9,9 +9,9 @@ module Drivers
 
         def build_name
           if master?
-            "Design System - #{pr_sha_reference} - URL: #{base_url}"
+            "Design System - #{pr_with_sha} - URL: #{base_url}"
           elsif branch?
-            "Design System - #{pr_without_build_iteration} - URL: #{base_url}"
+            "Design System - #{pr_without_sha} - URL: #{base_url}"
           else
             "Local Machine run - Month #{Time.now.month} - Ignore results!"
           end
@@ -19,7 +19,7 @@ module Drivers
 
         def session_name
           if branch? || master?
-            "Build: #{build_iteration} - CALLING_PROJECT: design-system"
+            "SHA: #{sha} - CALLING_PROJECT: design-system"
           else
             "Local run: Ran at #{timestamp}"
           end
@@ -36,17 +36,18 @@ module Drivers
         end
 
         # Example: PR-284
-        def pr_without_build_iteration
-          pr_sha_reference.split("_").first
+        def pr_without_sha
+          pr_with_sha.split("_").first
         end
 
-        def build_iteration
-          pr_sha_reference.split("_").last
+        # Example: ad4b223
+        def sha
+          pr_with_sha.split("_").last
         end
 
         # Example: master_ad4b223
         # Example: PR-284_dbbb8b6
-        def pr_sha_reference
+        def pr_with_sha
           @pr_sha_reference ||= docker_tag.split("design-system/").last
         end
       end

--- a/testing/features/support/drivers/browserstack/payload_values_generator.rb
+++ b/testing/features/support/drivers/browserstack/payload_values_generator.rb
@@ -9,7 +9,7 @@ module Drivers
 
         def build_name
           if master?
-            "Design System - #{pr_with_build_iteration} - URL: #{base_url}"
+            "Design System - #{pr_sha_reference} - URL: #{base_url}"
           elsif branch?
             "Design System - #{pr_without_build_iteration} - URL: #{base_url}"
           else
@@ -41,17 +41,13 @@ module Drivers
         end
 
         def build_iteration
-          pr_with_build_iteration.split("-").last
+          pr_sha_reference.split("_").first.split("-").last
         end
 
-        # Example: PR-81-1
-        def pr_with_build_iteration
-          pr_sha_reference.split("_").first
-        end
-
-        # Example: PR-81-1_98eb207
+        # Example: master_ad4b223
+        # Example: PR-83_abcde123
         def pr_sha_reference
-          @pr_sha_reference ||= docker_tag.split("design-system-").last
+          @pr_sha_reference ||= docker_tag.split("design-system/").last
         end
       end
     end

--- a/testing/features/support/drivers/browserstack/payload_values_generator.rb
+++ b/testing/features/support/drivers/browserstack/payload_values_generator.rb
@@ -48,7 +48,7 @@ module Drivers
         # Example: master_ad4b223
         # Example: PR-284_dbbb8b6
         def pr_with_sha
-          @pr_sha_reference ||= docker_tag.split("design-system/").last
+          @pr_with_sha ||= docker_tag.split("design-system/").last
         end
       end
     end

--- a/testing/features/support/helpers/env_variables.rb
+++ b/testing/features/support/helpers/env_variables.rb
@@ -55,6 +55,7 @@ module Helpers
     end
 
     # Example: design-system/master_ad4b223
+    # Example: design-system/PR-284_dbbb8b6
     def docker_tag
       ENV["DOCKER_TAG"]
     end

--- a/testing/features/support/helpers/env_variables.rb
+++ b/testing/features/support/helpers/env_variables.rb
@@ -54,7 +54,7 @@ module Helpers
       ENV.fetch("APP_URL", "https://citizensadvice.github.io/design-system")
     end
 
-    # Example: dev_jenkins-public-website-cucumber-PR-81-1_98eb207
+    # Example: design-system/master_ad4b223
     def docker_tag
       ENV["DOCKER_TAG"]
     end


### PR DESCRIPTION
Fix browserstack partitioning for Design System

As this used a different syntax / naming convention for their DOCKER_TAG env vars, we need a slightly different string sanitization. We also use SHA instead of build ref as that isn't passed through to Docker for some reason. Not really important as we still have the granularity required.