### PR TITLE
fix: add specific js-* class to greedy nav, config and tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* add `.js-cads-greedy-nav` class to header navigation and fix greedy nav config 
+
 ## <sub>v1.13.0</sub>
 
 #### _Oct. 13, 2020_

--- a/haml/_navigation.html.haml
+++ b/haml/_navigation.html.haml
@@ -1,5 +1,5 @@
 .cads-navigation-full-width-wrapper
-  %nav.cads-navigation
+  %nav.cads-navigation.js-cads-greedy-nav
     %ul.cads-list-unordered
       - navigation_links.each_with_index do |link, index|
         %li

--- a/src/ts/greedy-nav/Config.ts
+++ b/src/ts/greedy-nav/Config.ts
@@ -59,7 +59,7 @@ interface Config {
 
 const defaultConfig: Config = {
   initClass: 'js-CadsGreedyNav',
-  mainNavWrapper: 'nav',
+  mainNavWrapper: '.js-cads-greedy-nav',
   mainNav: 'ul',
   navDropdownClassName: 'cads-greedy-nav__dropdown',
   navDropdownToggleClassName: 'cads-greedy-nav__dropdown-toggle',

--- a/src/ts/greedy-nav/__fixtures__/menu.html
+++ b/src/ts/greedy-nav/__fixtures__/menu.html
@@ -5,7 +5,7 @@
 
   <body>
     <div class="cads-navigation-full-width-wrapper">
-      <nav class="cads-navigation">
+      <nav class="cads-navigation js-cads-greedy-nav">
         <ul class="cads-list-unordered">
           <li>
             <a class="cads-nav-link" href="/benefits/" title="Benefits">


### PR DESCRIPTION
The greedy nav default config used a naked `nav` element to initiate the greedy nav behaviour.  This PR changes this to a specific `.js-cads-greedy-nav` class.