### PR TITLE
feature: Run nightly design system regression tests [NP-292]

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,7 +12,10 @@ configurationTypes = [
 //     ['OSX_Mojave_12', 'safari'], - These seem to be "too" popular!
 ]
 
+cron_schedule = BRANCH_NAME == "master" ? "0 2 * * *" : ""
+
 pipeline {
+    triggers { cron(cron_schedule) }
     agent {
         label 'docker && awsaccess'
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,7 +12,7 @@ configurationTypes = [
 //     ['OSX_Mojave_12', 'safari'], - These seem to be "too" popular!
 ]
 
-cron_schedule = BRANCH_NAME == "master" ? "0 2 * * *" : ""
+cron_schedule = deployBranches.contains(BRANCH_NAME) ? "0 2 * * *" : ""
 
 pipeline {
     triggers { cron(cron_schedule) }


### PR DESCRIPTION
Adds a full build to run at 2AM every night to catch any regressions that have merged in during the day.