### PR TITLE
Component unit tests and lint fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5943,6 +5943,119 @@
         }
       }
     },
+    "@testing-library/jest-dom": {
+      "version": "5.11.4",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-5.11.4.tgz",
+      "integrity": "sha512-6RRn3epuweBODDIv3dAlWjOEHQLpGJHB2i912VS3JQtsD22+ENInhdDNl4ZZQiViLlIfFinkSET/J736ytV9sw==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.9.2",
+        "@types/testing-library__jest-dom": "^5.9.1",
+        "aria-query": "^4.2.2",
+        "chalk": "^3.0.0",
+        "css": "^3.0.0",
+        "css.escape": "^1.5.1",
+        "lodash": "^4.17.15",
+        "redent": "^3.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "css": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/css/-/css-3.0.0.tgz",
+          "integrity": "sha512-DG9pFfwOrzc+hawpmqX/dHYHJG+Bsdb0klhyi1sDneOgGOXy9wQIC8hzyVp1e4NRYDBdxcylvywPkkXCHAzTyQ==",
+          "dev": true,
+          "requires": {
+            "inherits": "^2.0.4",
+            "source-map": "^0.6.1",
+            "source-map-resolve": "^0.6.0"
+          }
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "redent": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+          "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+          "dev": true,
+          "requires": {
+            "indent-string": "^4.0.0",
+            "strip-indent": "^3.0.0"
+          }
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        },
+        "source-map-resolve": {
+          "version": "0.6.0",
+          "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.6.0.tgz",
+          "integrity": "sha512-KXBr9d/fO/bWo97NXsPIAW1bFSBOuCnjbNTBMO7N59hsv5i9yzRDfcYwwt0l04+VqnKC+EwzvJZIP/qkuMgR/w==",
+          "dev": true,
+          "requires": {
+            "atob": "^2.1.2",
+            "decode-uri-component": "^0.2.0"
+          }
+        },
+        "strip-indent": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+          "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+          "dev": true,
+          "requires": {
+            "min-indent": "^1.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
     "@types/anymatch": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/@types/anymatch/-/anymatch-1.3.1.tgz",
@@ -6305,6 +6418,15 @@
       "resolved": "https://registry.npmjs.org/@types/tapable/-/tapable-1.0.6.tgz",
       "integrity": "sha512-W+bw9ds02rAQaMvaLYxAbJ6cvguW/iJXNT6lTssS1ps6QdrMKttqEAMEG/b5CR8TZl3/L7/lH0ZV5nNR1LXikA==",
       "dev": true
+    },
+    "@types/testing-library__jest-dom": {
+      "version": "5.9.4",
+      "resolved": "https://registry.npmjs.org/@types/testing-library__jest-dom/-/testing-library__jest-dom-5.9.4.tgz",
+      "integrity": "sha512-6spmpkKOCVCO9XolAR23gfv09Nfd4QByRM3WbnYnPhVfjmOzEKlNrcj6GqFLZKduUvtJIH7Mf5t2TY6rs93zDA==",
+      "dev": true,
+      "requires": {
+        "@types/jest": "*"
+      }
     },
     "@types/tough-cookie": {
       "version": "4.0.0",
@@ -10014,6 +10136,12 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/css-what/-/css-what-2.1.3.tgz",
       "integrity": "sha512-a+EPoD+uZiNfh+5fxw2nO9QwFa6nJe2Or35fGY6Ipw1R3R4AGz1d1TEZrCegvw2YTmZ0jXirGYlzxxpYSHwpEg==",
+      "dev": true
+    },
+    "css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha1-QuJ9T6BK4y+TGktNQZH6nN3ul8s=",
       "dev": true
     },
     "cssesc": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1707,6 +1707,16 @@
         "regenerator-runtime": "^0.13.4"
       }
     },
+    "@babel/runtime-corejs3": {
+      "version": "7.12.1",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.12.1.tgz",
+      "integrity": "sha512-umhPIcMrlBZ2aTWlWjUseW9LjQKxi1dpFlQS8DzsxB//5K+u6GLTC/JliPKHsd5kJVPIU6X/Hy0YvWOYPcMxBw==",
+      "dev": true,
+      "requires": {
+        "core-js-pure": "^3.0.0",
+        "regenerator-runtime": "^0.13.4"
+      }
+    },
     "@babel/template": {
       "version": "7.10.4",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.10.4.tgz",
@@ -5851,10 +5861,98 @@
         "unist-util-find-all-after": "^3.0.1"
       }
     },
+    "@testing-library/dom": {
+      "version": "7.26.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-7.26.0.tgz",
+      "integrity": "sha512-fyKFrBbS1IigaE3FV21LyeC7kSGF84lqTlSYdKmGaHuK2eYQ/bXVPM5vAa2wx/AU1iPD6oQHsxy2QQ17q9AMCg==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.10.3",
+        "@types/aria-query": "^4.2.0",
+        "aria-query": "^4.2.2",
+        "chalk": "^4.1.0",
+        "dom-accessibility-api": "^0.5.1",
+        "lz-string": "^1.4.4",
+        "pretty-format": "^26.4.2"
+      },
+      "dependencies": {
+        "@jest/types": {
+          "version": "26.5.2",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.5.2.tgz",
+          "integrity": "sha512-QDs5d0gYiyetI8q+2xWdkixVQMklReZr4ltw7GFDtb4fuJIBCE6mzj2LnitGqCuAlLap6wPyb8fpoHgwZz5fdg==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^3.0.0",
+            "@types/node": "*",
+            "@types/yargs": "^15.0.0",
+            "chalk": "^4.0.0"
+          }
+        },
+        "@types/istanbul-reports": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
+          "integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-report": "*"
+          }
+        },
+        "ansi-regex": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "pretty-format": {
+          "version": "26.5.2",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.5.2.tgz",
+          "integrity": "sha512-VizyV669eqESlkOikKJI8Ryxl/kPpbdLwNdPs2GrbQs18MpySB5S0Yo0N7zkg2xTRiFq4CFw8ct5Vg4a0xP0og==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^26.5.2",
+            "ansi-regex": "^5.0.0",
+            "ansi-styles": "^4.0.0",
+            "react-is": "^16.12.0"
+          }
+        }
+      }
+    },
     "@types/anymatch": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/@types/anymatch/-/anymatch-1.3.1.tgz",
       "integrity": "sha512-/+CRPXpBDpo2RK9C68N3b2cOvO0Cf5B9aPijHsoDQTHivnGSObdOF2BRQOYjojWTDy6nQvMjmqRXIxH55VjxxA==",
+      "dev": true
+    },
+    "@types/aria-query": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-4.2.0.tgz",
+      "integrity": "sha512-iIgQNzCm0v7QMhhe4Jjn9uRh+I6GoPmt03CbEtwx3ao8/EfoQcmgtqH4vQ5Db/lxiIGaWDv6nwvunuh0RyX0+A==",
       "dev": true
     },
     "@types/babel__core": {
@@ -7344,6 +7442,16 @@
       "dev": true,
       "requires": {
         "sprintf-js": "~1.0.2"
+      }
+    },
+    "aria-query": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-4.2.2.tgz",
+      "integrity": "sha512-o/HelwhuKpTj/frsOsbNLNgnNGVIFsVP/SW2BSF14gVl7kAfMOJ6/8wUAUvG1R1NHKrfG+2sHZTu0yauT1qBrA==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.10.2",
+        "@babel/runtime-corejs3": "^7.10.2"
       }
     },
     "arity-n": {
@@ -10543,6 +10651,12 @@
       "requires": {
         "esutils": "^2.0.2"
       }
+    },
+    "dom-accessibility-api": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.4.tgz",
+      "integrity": "sha512-TvrjBckDy2c6v6RLxPv5QXOnU+SmF9nBII5621Ve5fu6Z/BDrENurBEvlC1f44lKEUVqOpK4w9E5Idc5/EgkLQ==",
+      "dev": true
     },
     "dom-converter": {
       "version": "0.2.0",
@@ -16568,6 +16682,12 @@
       "requires": {
         "yallist": "^4.0.0"
       }
+    },
+    "lz-string": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.4.4.tgz",
+      "integrity": "sha1-wNjq82BZ9wV5bh40SBHPTEmNOiY=",
+      "dev": true
     },
     "make-dir": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "@storybook/addon-a11y": "^6.0.25",
     "@storybook/addon-essentials": "^6.0.25",
     "@storybook/html": "^6.0.25",
+    "@testing-library/dom": "^7.26.0",
     "@types/jest": "^26.0.14",
     "@types/jsdom": "^16.2.4",
     "@typescript-eslint/eslint-plugin": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "lint:es": "eslint src scripts testing --ext .js,.ts",
     "lint": "prettier --check . && npm-run-all lint:css lint:es",
     "test": "npm run lint && jest",
+    "test:watch": "jest --watch --notify",
     "vr-test:install": "cd testing && npm install",
     "vr-test:test": "node scripts/vr-test.js",
     "vr-test:ci": "./bin/jenkins/visual_regression && docker-compose down",

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "@storybook/addon-essentials": "^6.0.25",
     "@storybook/html": "^6.0.25",
     "@testing-library/dom": "^7.26.0",
+    "@testing-library/jest-dom": "^5.11.4",
     "@types/jest": "^26.0.14",
     "@types/jsdom": "^16.2.4",
     "@typescript-eslint/eslint-plugin": "^4.3.0",

--- a/src/js/callout.js
+++ b/src/js/callout.js
@@ -9,10 +9,12 @@ const initCallouts = () => {
    */
   if (firstCallout && h2s.length === 0) {
     const h3ToReplace = firstCallout.querySelector('h3');
-    const heading = h3ToReplace.innerHTML;
-    const newHeading = document.createElement('h2');
-    newHeading.innerHTML = heading;
-    h3ToReplace.parentNode.replaceChild(newHeading, h3ToReplace);
+    if (h3ToReplace) {
+      const heading = h3ToReplace.innerHTML;
+      const newHeading = document.createElement('h2');
+      newHeading.innerHTML = heading;
+      h3ToReplace.parentNode.replaceChild(newHeading, h3ToReplace);
+    }
   }
 };
 

--- a/src/js/callout.js
+++ b/src/js/callout.js
@@ -1,20 +1,18 @@
 const initCallouts = () => {
-  try {
-    const h2s = document.getElementsByTagName('h2');
-    if (!h2s || !h2s.length) {
-      // Only do this if we don't have an H2 in the page
-      const callouts = document.getElementsByClassName('cads-callout');
-      if (callouts && callouts.length > 0) {
-        const callout = callouts[0];
-        const h3ToReplace = callout.getElementsByTagName('h3')[0];
-        const heading = h3ToReplace.innerHTML;
-        const newHeading = document.createElement('h2');
-        newHeading.innerHTML = heading;
-        h3ToReplace.parentNode.replaceChild(newHeading, h3ToReplace);
-      }
-    }
-  } catch (e) {
-    console.log(`Could not initialise callouts ${e}`);
+  const h2s = document.querySelectorAll('h2');
+  const firstCallout = document.querySelector('.cads-callout');
+
+  /**
+   * Only run if we:
+   * - Have a callout on the page
+   * - Don't already have a h2
+   */
+  if (firstCallout && h2s.length === 0) {
+    const h3ToReplace = firstCallout.querySelector('h3');
+    const heading = h3ToReplace.innerHTML;
+    const newHeading = document.createElement('h2');
+    newHeading.innerHTML = heading;
+    h3ToReplace.parentNode.replaceChild(newHeading, h3ToReplace);
   }
 };
 

--- a/src/js/callout.test.js
+++ b/src/js/callout.test.js
@@ -1,0 +1,21 @@
+/* eslint-env jest */
+import { screen } from '@testing-library/dom';
+
+import initCallouts from './callout';
+
+const mockCallout = `<div class="cads-callout cads-callout-standard">
+  <h3>Callout title</h3>
+  <p>Example callout text</p>
+</div>`;
+
+test('should convert h3 in callout to a h2 if there is no existing h2', () => {
+  document.body.innerHTML = mockCallout;
+  initCallouts();
+  expect(screen.queryByText('Callout title').nodeName).toBe('H2');
+});
+
+test('should retain h3 in callout if there is an existing h2', () => {
+  document.body.innerHTML = `<h2>Existing heading level 2</h2>${mockCallout}`;
+  initCallouts();
+  expect(screen.queryByText('Callout title').nodeName).toBe('H3');
+});

--- a/src/js/header.js
+++ b/src/js/header.js
@@ -24,6 +24,9 @@ const initHeader = () => {
         controlButton.title = 'Close search';
       }
     });
+  } else {
+    // eslint-disable-next-line no-console
+    console.warn('Header: no search toggle button found');
   }
 };
 

--- a/src/js/header.js
+++ b/src/js/header.js
@@ -1,27 +1,29 @@
 const initHeader = () => {
-  try {
-    const header = document.getElementsByClassName('cads-header')[0];
-    const controlButton = document.getElementsByClassName(
-      'cads-search-reveal'
-    )[0];
+  const CLASS_NAMES = {
+    showSearch: 'cads-header-show-search',
+    iconSearch: 'cads-icon_search',
+    iconClose: 'cads-icon_close',
+  };
 
+  const header = document.querySelector('.cads-header');
+  const controlButton = header.querySelector('.cads-search-reveal');
+
+  if (header && controlButton) {
     controlButton.addEventListener('click', () => {
-      if (header.classList.contains('cads-header-show-search')) {
-        header.classList.remove('cads-header-show-search');
-        controlButton.classList.remove('cads-icon_close');
-        controlButton.classList.add('cads-icon_search');
+      if (header.classList.contains(CLASS_NAMES.showSearch)) {
+        header.classList.remove(CLASS_NAMES.showSearch);
+        controlButton.classList.remove(CLASS_NAMES.iconClose);
+        controlButton.classList.add(CLASS_NAMES.iconSearch);
         controlButton.setAttribute('aria-expanded', 'false');
         controlButton.title = 'Open search';
       } else {
-        header.classList.add('cads-header-show-search');
-        controlButton.classList.remove('cads-icon_search');
-        controlButton.classList.add('cads-icon_close');
+        header.classList.add(CLASS_NAMES.showSearch);
+        controlButton.classList.remove(CLASS_NAMES.iconSearch);
+        controlButton.classList.add(CLASS_NAMES.iconClose);
         controlButton.setAttribute('aria-expanded', 'true');
         controlButton.title = 'Close search';
       }
     });
-  } catch (e) {
-    console.warn(`Could not initialise header ${e}`);
   }
 };
 

--- a/src/js/header.js
+++ b/src/js/header.js
@@ -10,13 +10,13 @@ const initHeader = () => {
         header.classList.remove('cads-header-show-search');
         controlButton.classList.remove('cads-icon_close');
         controlButton.classList.add('cads-icon_search');
-        controlButton.ariaExpanded = false;
+        controlButton.setAttribute('aria-expanded', 'false');
         controlButton.title = 'Open search';
       } else {
         header.classList.add('cads-header-show-search');
         controlButton.classList.remove('cads-icon_search');
         controlButton.classList.add('cads-icon_close');
-        controlButton.ariaExpanded = true;
+        controlButton.setAttribute('aria-expanded', 'true');
         controlButton.title = 'Close search';
       }
     });

--- a/src/js/header.test.js
+++ b/src/js/header.test.js
@@ -1,0 +1,46 @@
+/* eslint-env jest */
+import { screen } from '@testing-library/dom';
+import '@testing-library/jest-dom/extend-expect';
+
+import initHeader from './header';
+
+const searchFormHtml = `<form action='/the/search-action-url' class='cads-search' role='search'>
+  <input aria-label='Search through site content' name='q' type='search'>
+  <button class='cads-button cads-search__button' title='Submit search query'></button>
+</form>`;
+
+const minimalHeaderHtml = `<header class='cads-header' data-testid="header">
+  <div class='cads-grid-container'>
+    <div class='cads-grid-row'>
+      <div class='cads-grid-col-md-5 cads-header-logo-row'>
+        <a class='cads-logo' href='root_path'
+          title='Citizens Advice homepage'></a>
+        <button aria-expanded='false'
+          class='cads-search-reveal cads-icon_search'
+          title='Open search'></button>
+      </div>
+      <div class='cads-grid-col-md-7 cads-align-right cads-header-search-row'>
+        ${searchFormHtml}
+      </div>
+    </div>
+  </div>
+</header>`;
+
+test('allow toggling search', () => {
+  document.body.innerHTML = minimalHeaderHtml;
+  initHeader();
+
+  const headerEl = screen.getByTestId('header');
+  const controlButtonEl = screen.getByTitle('Open search');
+
+  expect(headerEl).not.toHaveClass('cads-header-show-search');
+  expect(controlButtonEl).toHaveAttribute('aria-expanded', 'false');
+  expect(controlButtonEl).toHaveClass('cads-icon_search');
+
+  controlButtonEl.click();
+
+  expect(headerEl).toHaveClass('cads-header-show-search');
+  expect(controlButtonEl.title).toBe('Close search');
+  expect(controlButtonEl).toHaveAttribute('aria-expanded', 'true');
+  expect(controlButtonEl).toHaveClass('cads-icon_close');
+});

--- a/src/js/targeted-content.js
+++ b/src/js/targeted-content.js
@@ -1,49 +1,53 @@
 const initTargetedContent = () => {
-  try {
-    const pageContents = document.getElementsByClassName('cads-main-content');
-    const pageContent = pageContents?.[0] ?? document;
-    const content = pageContent.getElementsByClassName('cads-targeted-content');
+  const CLASS_NAMES = {
+    isOpen: 'is-open',
+  };
 
-    // Expand/collapse handlers for individual items
-    for (let i = 0; i < content.length; i++) {
-      const item = content[i];
-      const summary = item.getElementsByClassName(
-        'cads-targeted-content__summary'
-      )[0];
+  const pageContents = document.querySelector('.cads-main-content') || document;
+  const targetedContentEls = pageContents.querySelectorAll(
+    '.cads-targeted-content'
+  );
+
+  if (targetedContentEls.length > 0) {
+    for (let i = 0; i < targetedContentEls.length; i++) {
+      const item = targetedContentEls[i];
+      const summary = item.querySelector('summary');
 
       summary.addEventListener('click', () => {
-        if (item.classList.contains('is-open')) {
-          item.classList.remove('is-open');
-          summary.setAttribute('aria-expanded', false);
+        if (item.classList.contains(CLASS_NAMES.isOpen)) {
+          item.classList.remove(CLASS_NAMES.isOpen);
+          summary.setAttribute('aria-expanded', 'false');
         } else {
-          item.classList.add('is-open');
-          summary.setAttribute('aria-expanded', true);
+          item.classList.add(CLASS_NAMES.isOpen);
+          summary.setAttribute('aria-expanded', 'true');
         }
       });
-      item
-        .getElementsByClassName('cads-targeted-content__close-button')[0]
-        .addEventListener('click', () => {
-          item.classList.remove('is-open');
-          summary.setAttribute('aria-expanded', false);
+
+      const closeButtonEl = item.querySelector(
+        '.cads-targeted-content__close-button'
+      );
+
+      if (closeButtonEl) {
+        closeButtonEl.addEventListener('click', () => {
+          item.classList.remove(CLASS_NAMES.isOpen);
+          summary.setAttribute('aria-expanded', 'false');
           item.open = false;
         });
+      }
     }
 
-    // Print setup
-    // eslint-disable-next-line
+    /**
+     * Toggle open all targeted content elements if printing
+     */
     window.addEventListener('beforeprint', () => {
-      for (let i = 0; i < content.length; i++) {
-        const item = content[i];
-        const summary = item.getElementsByClassName(
-          'cads-targeted-content__summary'
-        )[0];
+      for (let i = 0; i < targetedContentEls.length; i++) {
+        const item = targetedContentEls[i];
+        const summary = item.querySelector('summary');
         if (!item.classList.contains('is-open')) {
           summary.click();
         }
       }
     });
-  } catch (e) {
-    console.warn(`Could not initialise targeted content ${e}`);
   }
 };
 

--- a/src/js/targeted-content.test.js
+++ b/src/js/targeted-content.test.js
@@ -1,0 +1,53 @@
+/* eslint-env jest */
+import { screen } from '@testing-library/dom';
+import '@testing-library/jest-dom/extend-expect';
+
+import initTargetedContent from './targeted-content';
+
+const componentHtml = `<details class='cads-targeted-content' id='target-content-123' data-testid="targeted-content">
+  <summary aria-controls='target-content-123-content' aria-expanded='false'
+    class='cads-targeted-content__summary' role='button'>
+    <span class='cads-target-content__button cads-icon_minus'></span>
+    <span class='cads-target-content__button cads-icon_plus'></span>
+    <span class='cads-targeted-content__title'>
+      Summary title
+    </span>
+  </summary>
+  <div class='cads-targeted-content__content' id='target-content-123-content'>
+    Details content
+    <button aria-label='Collapse'
+      class='cads-linkbutton cads-targeted-content__close-button'></button>
+  </div>
+</details>`;
+
+test('allow toggling targeted content', () => {
+  document.body.innerHTML = componentHtml;
+  initTargetedContent();
+
+  const detailsEl = screen.getByTestId('targeted-content');
+  const summaryEl = screen.getByText('Summary title').parentElement;
+
+  function expectOpen() {
+    expect(detailsEl).toHaveClass('is-open');
+    expect(summaryEl).toHaveAttribute('aria-expanded', 'true');
+  }
+
+  function expectClosed() {
+    expect(detailsEl).not.toHaveClass('is-open');
+    expect(summaryEl).toHaveAttribute('aria-expanded', 'false');
+  }
+
+  expectClosed();
+
+  summaryEl.click();
+  expectOpen();
+
+  summaryEl.click();
+  expectClosed();
+
+  summaryEl.click();
+  expectOpen();
+
+  screen.getByLabelText('Collapse').click();
+  expectClosed();
+});


### PR DESCRIPTION
Adds testing-library unit tests for:

- callout heading swap
- header search toggle
- targeted content

Also fixes lint warnings and general pattern of using `try/catch` and `console.logs` in favour of using guard statements. Removed lots of `[0]` code by using `querySelector` which returns the first match by design.
