### PR TITLE
bugfix: Cucumber Hooks [NP-1099]

### DIFF
--- a/testing/features/support/core_ext/cucumber/core/test/case.rb
+++ b/testing/features/support/core_ext/cucumber/core/test/case.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Cucumber
+  module Core
+    module Test
+      class Case
+        def feature_file_name
+          feature_file_path.split("/").last.split(".").first
+        end
+
+        private
+
+        def feature_file_path
+          location.to_s
+        end
+      end
+    end
+  end
+end

--- a/testing/features/support/helpers/page.rb
+++ b/testing/features/support/helpers/page.rb
@@ -44,12 +44,16 @@ module Helpers
       current_session.execute_script("return document.documentElement.outerHTML")
     end
 
-    def image_file_path(scenario)
-      "artifacts/screenshots/#{timestamp}_#{scenario.feature.name}_#{scenario.name}.png"
+    def image_file_path(test_case)
+      "artifacts/screenshots/#{name_of_file(test_case)}.png"
     end
 
-    def html_file_path(scenario)
-      "artifacts/html_pages/#{timestamp}_#{scenario.feature.name}_#{scenario.name}.html"
+    def html_file_path(test_case)
+      "artifacts/html_pages/#{name_of_file(test_case)}.html"
+    end
+
+    def name_of_file(test_case)
+      "#{timestamp}_#{test_case.feature_file_name}_#{test_case.name}"
     end
 
     def width(fallback: 1600)


### PR DESCRIPTION
- Fix cucumber hooks by using the feature file name as opposed to feature name (No longer in pickle).
  - This has been broken since the cucumber4 upgrade

NB: This is copied from the `public-website-cucumber` fix done a week or so ago.