### PR TITLE
Fix npm build script

### DIFF
--- a/bin/test
+++ b/bin/test
@@ -2,6 +2,8 @@
 
 set -e
 
+npm run build
+
 bundle exec rubocop
 
 bundle exec haml-lint haml styleguide

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "pre-commit": "lint-staged",
     "check-size": "node ./scripts/check-size -r",
     "check-size:write": "node ./scripts/check-size -r -w",
-    "build:js": "babel src/js -d lib",
+    "build:js": "babel src/js -d lib --ignore src/js/**/*.test.js",
     "build:ts": "tsc -b",
     "build:scss": "node ./scripts/build -r && npm run check-size -r",
     "build": "npm run clean && npm-run-all build:scss build:js build:ts",

--- a/package.json
+++ b/package.json
@@ -121,7 +121,8 @@
     "coverageDirectory": "coverage",
     "testPathIgnorePatterns": [
       "/node_modules/",
-      "/vendor/"
+      "/vendor/",
+      "/lib/"
     ]
   },
   "lint-staged": {

--- a/src/ts/greedy-nav/GreedyNav.test.ts
+++ b/src/ts/greedy-nav/GreedyNav.test.ts
@@ -287,11 +287,11 @@ describe('Greedy Nav', () => {
 
     it('toggles the menu open', () => {
       const event = new dom.window.FocusEvent('focus');
-      nav.navDropdownToggle.dispatchEvent(event);
+      nav.navDropdownToggle!.dispatchEvent(event);
 
-      expect(nav.navDropdown.className).toContain('show');
-      expect(nav.mainNavWrapper.className).toContain('is-open');
-      expect(nav.navDropdownToggle.innerHTML).toContain('Close');
+      expect(nav.navDropdown!.className).toContain('show');
+      expect(nav.mainNavWrapper!.className).toContain('is-open');
+      expect(nav.navDropdownToggle!.innerHTML).toContain('Close');
     });
 
     it('when tabbing backwards through the dropdown menu', () => {
@@ -299,17 +299,17 @@ describe('Greedy Nav', () => {
 
       const openEvent = new dom.window.MouseEvent('focus');
 
-      nav.navDropdownToggle.dispatchEvent(openEvent);
+      nav.navDropdownToggle!.dispatchEvent(openEvent);
 
       const event = new dom.window.FocusEvent('blur', {
         relatedTarget: siteMenuItem,
       });
 
-      nav.navDropdownToggle.dispatchEvent(event);
+      nav.navDropdownToggle!.dispatchEvent(event);
 
-      expect(nav.navDropdown.className).not.toContain('show');
-      expect(nav.mainNavWrapper.className).not.toContain('is-open');
-      expect(nav.navDropdownToggle.innerHTML).toContain('More');
+      expect(nav.navDropdown!.className).not.toContain('show');
+      expect(nav.mainNavWrapper!.className).not.toContain('is-open');
+      expect(nav.navDropdownToggle!.innerHTML).toContain('More');
     });
   });
 });

--- a/src/ts/greedy-nav/tsconfig.common.json
+++ b/src/ts/greedy-nav/tsconfig.common.json
@@ -7,5 +7,5 @@
     "declaration": true
   },
   "include": ["./**/*.ts"],
-  "exclude": ["./**/*.spec.ts"]
+  "exclude": ["./**/*.test.ts"]
 }

--- a/src/ts/greedy-nav/tsconfig.json
+++ b/src/ts/greedy-nav/tsconfig.json
@@ -5,5 +5,5 @@
     "rootDir": "."
   },
   "include": ["./**/*.ts"],
-  "exclude": ["./**/*.spec.ts"]
+  "exclude": ["./**/*.test.ts"]
 }


### PR DESCRIPTION
Bit of a 🐰 🕳️  this one.

Introduced a build error in https://github.com/citizensadvice/design-system/pull/360 where a) I wasn't excluding `.test.ts(x)` files correctly and b) my changes (correctly) highlighted some typescript errors in the tests.

<img width="866" alt="Screenshot 2020-10-21 at 16 22 03" src="https://user-images.githubusercontent.com/123386/96743662-24f8da00-13bc-11eb-8c1b-4008c3e3c093.png">


**However**: neither of these were caught because we don't actually _build_ the lib directory at any point in CI. We technically only test that the Storybook webpack pipeline works, not that the actual distributed files are built correctly until we run a build ourselves. As a short-term fix I've included `npm run build` in the CI step, but we should probably revisit this.