### PR TITLE
bugfix: Firefox new tab issue [NP-1172]

### DIFF
--- a/testing/features/footer.feature
+++ b/testing/features/footer.feature
@@ -10,7 +10,7 @@ Feature: Footer component
   Scenario: Footer is present
     Then a report problem with this page link is present
     And each header item has at least 1 link below it
-    And a logo is present
+    And a footer logo is present
     And a copyright notice is present
     And a company info is present
 

--- a/testing/features/header.feature
+++ b/testing/features/header.feature
@@ -12,7 +12,7 @@ Feature: Header component
     Scenario: Header has some quick links
       Then a language change link is present
       And a login link is present
-      And a logo is present
+      And a header logo is present
 
     Scenario: Header has a search option
       When I type "Immigration" into the search box
@@ -26,7 +26,7 @@ Feature: Header component
     Scenario: Header has some quick links
       Then a language change link is present
       And a logout link is present
-      And a logo is present
+      And a header logo is present
 
     @future_release @NP-1137
     Scenario: Header has a search option

--- a/testing/features/step_definitions/footer_steps.rb
+++ b/testing/features/step_definitions/footer_steps.rb
@@ -30,6 +30,6 @@ Then("a company info is present") do
 end
 
 Then("a new tab is opened to report an issue with the page") do
-  switch_to_newly_opened_window!
+  switch_to_newly_opened_window!(new_page: true)
   expect(page.current_url).to eq("https://www.research.net/r/J8PLH2H")
 end

--- a/testing/features/step_definitions/footer_steps.rb
+++ b/testing/features/step_definitions/footer_steps.rb
@@ -17,7 +17,7 @@ Then("each header item has at least 1 link below it") do
   expect(@component.category_titles).to all have_links
 end
 
-Then("a logo is present") do
+Then("a footer logo is present") do
   expect(@component.initial_form).to have_logo
 end
 

--- a/testing/features/step_definitions/header_steps.rb
+++ b/testing/features/step_definitions/header_steps.rb
@@ -18,7 +18,7 @@ Then("a login/logout link is present") do
   expect(@component).to have_login
 end
 
-Then("a logo is present") do
+Then("a header logo is present") do
   expect(@component.logo["title"]).to eq("Citizens Advice homepage")
 
   expect(@component.logo["href"]).not_to be_blank

--- a/testing/features/support/helpers/env_variables.rb
+++ b/testing/features/support/helpers/env_variables.rb
@@ -38,6 +38,10 @@ module Helpers
       ENV["BROWSER"] == "chrome"
     end
 
+    def firefox?
+      ENV["BROWSER"] == "firefox"
+    end
+
     def safari?
       ENV["BROWSER"] == "safari"
     end

--- a/testing/features/support/helpers/page.rb
+++ b/testing/features/support/helpers/page.rb
@@ -24,8 +24,9 @@ module Helpers
       attach(file_path, "text/html")
     end
 
-    def switch_to_newly_opened_window!
+    def switch_to_newly_opened_window!(new_page: false)
       page.switch_to_window(page.windows.last)
+      wait_for_new_url if firefox? && new_page
     end
 
     private
@@ -66,6 +67,10 @@ module Helpers
 
     def height(fallback: 800)
       ENV.fetch("BROWSER_HEIGHT", fallback)
+    end
+
+    def wait_for_new_url
+      Selenium::WebDriver::Wait.new.until { page.current_url != "about:blank" }
     end
   end
 end


### PR DESCRIPTION
**Previously:**

When firefox loads up a new tab. It first loads `about:blank`. Because this is a static white page. Selenium detects the page has loaded correctly and continues on.

Shortly after a "redirect" then changes the URL. And selenium then goes into "load" mode again and waits for the page to load. However by this time, it's too late, as we've checked the url and triggered a failure.

NB: This doesn't appear to affect chrome.

**Now:**

Explicitly wait until the url "isn't" `about:blank` if on firefox, and we've asked it to wait for a new url.