### PR TITLE
bugfix: Mark failing test [NP-1172]

### DIFF
--- a/testing/features/footer.feature
+++ b/testing/features/footer.feature
@@ -14,6 +14,7 @@ Feature: Footer component
     And a copyright notice is present
     And a company info is present
 
+  @failing @NP-1173
   Scenario: Report a problem with this page
     When I report a problem with this page
     Then a new tab is opened to report an issue with the page


### PR DESCRIPTION
The Footer test mentioned here fails on Firefox

I have created a breakout ticket in NP-1173 to tackle this issue with more details in it. TL;DR - On Firefox <80 this functionality isn't working as specified.
