### PR TITLE
feature: locale switch url [NP-1165]

### DIFF
--- a/.storybook/manager.js
+++ b/.storybook/manager.js
@@ -1,3 +1,5 @@
+require('url-polyfill');
+
 import { addons } from '@storybook/addons';
 import { create } from '@storybook/theming/create';
 import { version } from '../package.json';

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -32,8 +32,15 @@ export const globalTypes = {
   },
 };
 
-const withLocaleClassname = (Story, { globals }) => {
-  return `<div class="cads-lang-${globals.locale || 'en'}">${Story()}</div>`;
+const setLocaleFromUrl = (Story, context) => {
+  const params = new URL(document.location).searchParams;
+
+  const locale = params.get('locale');
+  if (locale) {
+    context.globals.locale = locale;
+  }
+
+  return Story();
 };
 
-export const decorators = [withLocaleClassname];
+export const decorators = [setLocaleFromUrl];

--- a/package-lock.json
+++ b/package-lock.json
@@ -25565,6 +25565,12 @@
         }
       }
     },
+    "url-polyfill": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/url-polyfill/-/url-polyfill-1.1.11.tgz",
+      "integrity": "sha512-p3Vw21dz901xeu++K6db2CZgfwMZjzVAH2buek66I0HKY+DHSh/AXz+p9B/+RhhZ9l3xDMBviwe99Eeu+UJB3g==",
+      "dev": true
+    },
     "use": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",

--- a/package.json
+++ b/package.json
@@ -105,7 +105,8 @@
     "stylelint-scss": "^3.18.0",
     "stylelint-selector-bem-pattern": "^2.1.0",
     "systemjs": "^6.5.1",
-    "typescript": "^4.0.3"
+    "typescript": "^4.0.3",
+    "url-polyfill": "^1.1.11"
   },
   "dependencies": {},
   "browserslist": [

--- a/styleguide/translations/translated.stories.mdx
+++ b/styleguide/translations/translated.stories.mdx
@@ -47,3 +47,7 @@ import haml from './_example.html.haml';
     {(_, options) => translate(haml, options)}
   </Story>
 </Preview>
+
+## Testing translations
+
+To support automated testing of translations you may simply add `&locale=<locale>` to the end of a url. This will work with both the main site and individual component iframes.


### PR DESCRIPTION
This features allows the design-system locale to be set via the `locale` query string parameter.

This works with both the main site and the component iframe pages.

Add `&locale=cy` to the end of a url to test. Currently the translation documentation is the only translated feature (pending updated strings).

I need to test whether the polyfill is needed, I'm fairly sure it will..