### PR TITLE
bugfix: Footer: Report this Page tests working! [NP-1173]

### DIFF
--- a/testing/features/footer.feature
+++ b/testing/features/footer.feature
@@ -7,14 +7,13 @@ Feature: Footer component
   Background:
     Given a Footer component is on the page
 
-  Scenario: Footer is present
+  Scenario: Footer contains a variety of links / content
     Then a report problem with this page link is present
     And each header item has at least 1 link below it
     And a footer logo is present
     And a copyright notice is present
     And a company info is present
 
-  @failing @NP-1173
-  Scenario: Report a problem with this page
+  Scenario: Users can report a problem about the specific page they are on
     When I report a problem with this page
-    Then a new window/tab is opened to report an issue with the page
+    Then I am presented with a form to report the issue about the page I am on

--- a/testing/features/footer.feature
+++ b/testing/features/footer.feature
@@ -17,4 +17,4 @@ Feature: Footer component
   @failing @NP-1173
   Scenario: Report a problem with this page
     When I report a problem with this page
-    Then a new tab is opened to report an issue with the page
+    Then a new window/tab is opened to report an issue with the page

--- a/testing/features/step_definitions/footer_steps.rb
+++ b/testing/features/step_definitions/footer_steps.rb
@@ -29,7 +29,7 @@ Then("a company info is present") do
   expect(@component.initial_form).to have_company_info
 end
 
-Then("a new window\\/tab is opened to report an issue with the page") do
+Then("I am presented with a form to report the issue about the page I am on") do
   switch_to_newly_opened_window!(new_page: true)
 
   expect(page.current_url).to eq("https://www.research.net/r/J8PLH2H")

--- a/testing/features/step_definitions/footer_steps.rb
+++ b/testing/features/step_definitions/footer_steps.rb
@@ -29,7 +29,8 @@ Then("a company info is present") do
   expect(@component.initial_form).to have_company_info
 end
 
-Then("a new tab is opened to report an issue with the page") do
+Then("a new window\\/tab is opened to report an issue with the page") do
   switch_to_newly_opened_window!(new_page: true)
+
   expect(page.current_url).to eq("https://www.research.net/r/J8PLH2H")
 end

--- a/testing/features/support/helpers/page.rb
+++ b/testing/features/support/helpers/page.rb
@@ -75,7 +75,7 @@ module Helpers
     end
 
     def second_window
-      (page.windows.to_a - [page.current_window]).first
+      page.windows.detect { |window| !window.current? }
     end
 
     def wait_for_new_url

--- a/testing/features/support/helpers/page.rb
+++ b/testing/features/support/helpers/page.rb
@@ -25,7 +25,8 @@ module Helpers
     end
 
     def switch_to_newly_opened_window!(new_page: false)
-      page.switch_to_window(page.windows.last)
+      wait_for_second_window
+      page.switch_to_window(second_window)
       wait_for_new_url if firefox? && new_page
     end
 
@@ -67,6 +68,14 @@ module Helpers
 
     def height(fallback: 800)
       ENV.fetch("BROWSER_HEIGHT", fallback)
+    end
+
+    def wait_for_second_window
+      Selenium::WebDriver::Wait.new.until { page.windows.length == 2 }
+    end
+
+    def second_window
+      (page.windows.to_a - [page.current_window]).first
     end
 
     def wait_for_new_url


### PR DESCRIPTION
So we now do a 3 step check during out wait for switch context

1) Wait until 2 windows have been detected
2) Once we have 2 windows (Note that a Tab and window are treated the same in this subsection of the Capybara API), detect which window is **not** the one we have current browsing context in (Always the other one) - Then switch to it
3) Wait until the current windows url is not `about:blank`

This should ensure we are always on the correct window, and that we have the correct loaded context.