### PR TITLE
Allow docs to use brand font

### DIFF
--- a/.storybook/manager.js
+++ b/.storybook/manager.js
@@ -1,13 +1,7 @@
 require('url-polyfill');
 
 import { addons } from '@storybook/addons';
-import { create } from '@storybook/theming/create';
-import { version } from '../package.json';
-
-const theme = create({
-  base: 'light',
-  brandTitle: `Citizens Advice Design System v${version}`,
-});
+import theme from './theme';
 
 addons.setConfig({
   panelPosition: 'bottom',

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,4 +1,9 @@
+import theme from './theme';
+
 export const parameters = {
+  docs: {
+    theme: theme,
+  },
   options: {
     layout: 'padded',
     isToolshown: true,

--- a/.storybook/theme.js
+++ b/.storybook/theme.js
@@ -1,0 +1,8 @@
+import { create } from '@storybook/theming/create';
+import { version } from '../package.json';
+
+export default create({
+  base: 'light',
+  brandTitle: `Citizens Advice Design System v${version}`,
+  fontBase: "'Open Sans', helvetica, 'helvetica neue', arial, sans-serif",
+});


### PR DESCRIPTION
Extracted from https://github.com/citizensadvice/design-system/pull/409

Allows the docs to use Open Sans, rather than the default storybook docs font. 