### PR TITLE
Split cads-main-content into multiple classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Forms: Updated all forms classnames to use consistent BEM conventions
 * Forms: Removed `radio_group_small`, `radio_group`. Inline and small are now two separate modifiers
 * Forms: Refactor radio component. Fix line-height for wrapping text
+* Layout: Split `cads-main-content` out into `cads-page-title` and `cads-page-content`
 
 **New features**:
 

--- a/scss/4-elements/_misc.scss
+++ b/scss/4-elements/_misc.scss
@@ -8,22 +8,6 @@ hr,
   border-top: solid $cads-border-width-small $cads-language__border-colour;
 }
 
-.cads-main-content {
-  @extend .cads-max-content-width;
-
-  padding-top: $cads-spacing-5;
-  padding-bottom: 2 * $cads-spacing-7;
-
-  h1 {
-    margin-top: $cads-spacing-5;
-  }
-
-  img {
-    padding: 0;
-    margin: 0 0 $cads-spacing-4 0;
-  }
-}
-
 .cads-asset-type {
   &::before {
     content: '[';

--- a/scss/5-objects/_page-content.scss
+++ b/scss/5-objects/_page-content.scss
@@ -1,0 +1,15 @@
+// ============================================================================
+// Page content
+// ============================================================================
+
+/** @define page-title */
+.cads-page-title {
+  @extend %cads-h1;
+
+  margin-top: $cads-spacing-5;
+}
+
+/** @define page-content */
+.cads-page-content {
+  padding-bottom: cads-rem(80px);
+}

--- a/scss/5-objects/_prose.scss
+++ b/scss/5-objects/_prose.scss
@@ -38,6 +38,11 @@
       margin-bottom: 0;
     }
   }
+
+  img {
+    padding: 0;
+    margin: 0 0 $cads-spacing-4 0;
+  }
 }
 
 .cads-prose {

--- a/scss/5-objects/objects-imports.scss
+++ b/scss/5-objects/objects-imports.scss
@@ -1,2 +1,3 @@
 @import './grid';
 @import './prose';
+@import './page-content';

--- a/scss/6-components/_breadcrumbs.scss
+++ b/scss/6-components/_breadcrumbs.scss
@@ -12,6 +12,7 @@
 
   padding: $cads-spacing-3 0 $cads-spacing-3 $cads-spacing-4;
   border-bottom: $cads-border-width-small solid $cads-language__border_colour;
+  margin-bottom: $cads-spacing-5;
 
   &__list {
     margin: 0;

--- a/styleguide/sample-pages/advice-collection/_advice_collection.html.haml
+++ b/styleguide/sample-pages/advice-collection/_advice_collection.html.haml
@@ -4,15 +4,15 @@
   .cads-grid-row
     .cads-grid-col-12
       = render partial: "@citizensadvice/design-system/haml/breadcrumb", locals: {breadcrumbs: {"breadcrumb_links" => [{"url" => "/link", "title" => "Tables"}]}}
-%main.cads-main-content
+%main.cads-page-content
   .cads-grid-container
     .cads-grid-row
       .cads-grid-col-md-8
         = render partial: "@citizensadvice/design-system/haml/notice_banner"
     .cads-grid-row
       .cads-grid-col-md-8
+        %h1.cads-page-title Advice Collection
         .cads-prose
-          %h1 Advice Collection
           %p Here is a standard callout.
           = render partial: "@citizensadvice/design-system/haml/callout", locals: { 'notice' => { 'type' => 'standard', 'body' => '<h3>Standard callout</h3><p>This is a sample page. Note that the layout may not reflect the actual page layout of the website.</p>' } }
           %h2 Title after callout

--- a/styleguide/sample-pages/advice-collection/_advice_collection_adviser.html.haml
+++ b/styleguide/sample-pages/advice-collection/_advice_collection_adviser.html.haml
@@ -5,14 +5,14 @@
     .cads-grid-row
       .cads-grid-col-12
         = render partial: "@citizensadvice/design-system/haml/breadcrumb", locals: {breadcrumbs: {"breadcrumb_links" => [{"url" => "/link", "title" => "Tables"}]}}
-  %main.cads-main-content
+  %main.cads-page-content
     .cads-grid-container
       .cads-grid-row
         .cads-grid-col-md-8
           = render partial: "@citizensadvice/design-system/haml/notice_banner", locals: { 'banner' => { 'label' => 'Page Template Warning', 'body' => '<p>This is a sample page. Note that the layout may not reflect the actual page layout of the website.</p>' } }
       .cads-grid-row
         .cads-grid-col-md-8
-          %h1 Adviser Sample Page
+          %h1.cads-page-title Adviser Sample Page
           = render partial: "@citizensadvice/design-system/haml/oisc_warning", locals: { 'oisc_warning' => { 'title' => "This is an OISC level 2 topic", 'body' => "Generalist advisers can give clients the information on this page, but must refer them to an immigration specialist if they need advice. <a href='#'>Check what to do if your client needs level 2 advice.</a>", 'is_sticky' => true } }
           .cads-prose
             = render partial: "@citizensadvice/design-system/haml/callout", locals: { 'notice' => { 'type' => 'adviser', 'body' => '<h3>This is an adviser callout</h3><p>This is the body text of an adviser callout.</p>' } }

--- a/styleguide/sample-pages/generic/_forms.html.haml
+++ b/styleguide/sample-pages/generic/_forms.html.haml
@@ -4,40 +4,41 @@
   .cads-grid-row
     .cads-grid-col-12
       = render partial: "@citizensadvice/design-system/haml/breadcrumb", locals: {breadcrumbs: {"breadcrumb_links" => [{"url" => "/link", "title" => "Tables"}]}}
-%main.cads-main-content
+%main.cads-page-content
   .cads-grid-container
     .cads-grid-row
       .cads-grid-col-md-8
         = render partial: "@citizensadvice/design-system/haml/notice_banner"
     .cads-grid-row
-      .cads-grid-col-md-8.cads-prose
-        %h1 Consumer Query
-        %p From 1 April 2019 we are only able to provide general consumer advice to residents of England and Wales. If you are resident in Scotland and have a general consumer enquiry please contact Advice Direct Scotland / 0808 164 6000
+      .cads-grid-col-md-8
+        %h1.cads-page-title Consumer Query
+        .cads-prose
+          %p From 1 April 2019 we are only able to provide general consumer advice to residents of England and Wales. If you are resident in Scotland and have a general consumer enquiry please contact Advice Direct Scotland / 0808 164 6000
 
-        = render partial: "@citizensadvice/design-system/haml/input",
-          locals: { input: { "name" => "example-input", "label" => "First name or initials", "size" => "16ch" }}
+          = render partial: "@citizensadvice/design-system/haml/input",
+            locals: { input: { "name" => "example-input", "label" => "First name or initials", "size" => "16ch" }}
 
-        = render partial: "@citizensadvice/design-system/haml/input",
-          locals: { input: { "name" => "example-input", "label" => "Last name", "size" => "16ch" }}
+          = render partial: "@citizensadvice/design-system/haml/input",
+            locals: { input: { "name" => "example-input", "label" => "Last name", "size" => "16ch" }}
 
-        = render partial: "@citizensadvice/design-system/haml/textarea",
-          locals: { input: { "name" => "example-textarea", "label" => "Your complaint or enquiry", "hint" => "Please provide details of your complaint or enquiry." }}
+          = render partial: "@citizensadvice/design-system/haml/textarea",
+            locals: { input: { "name" => "example-textarea", "label" => "Your complaint or enquiry", "hint" => "Please provide details of your complaint or enquiry." }}
 
-        %h2 Purchase details
+          %h2 Purchase details
 
-        = render partial: "@citizensadvice/design-system/haml/radio_group",
-          locals: { radio: { "name" => "example-radio-group", "label" => "Have you paid for goods or services from this trader?", "options" => [{ "value" => "opt1", "label" => "Yes - If yes, answer the below questions" }, { "value" => "opt2", "label" => " No" }] } }
+          = render partial: "@citizensadvice/design-system/haml/radio_group",
+            locals: { radio: { "name" => "example-radio-group", "label" => "Have you paid for goods or services from this trader?", "options" => [{ "value" => "opt1", "label" => "Yes - If yes, answer the below questions" }, { "value" => "opt2", "label" => " No" }] } }
 
-        = render partial: "@citizensadvice/design-system/haml/input",
-          locals: { input: { "name" => "example-input", "label" => "What was the total amount paid for the goods or services?", "hint" => "Enter a value in pounds and pence only e.g. £112.00", "size" => "4ch" }}
+          = render partial: "@citizensadvice/design-system/haml/input",
+            locals: { input: { "name" => "example-input", "label" => "What was the total amount paid for the goods or services?", "hint" => "Enter a value in pounds and pence only e.g. £112.00", "size" => "4ch" }}
 
-        = render partial: "@citizensadvice/design-system/haml/radio_group",
-          locals: { radio: { "name" => "example-radio-group", "label" => "Have you contacted the trader about this complaint? ", "options" => [{ "value" => "opt1", "label" => "Yes - If yes, answer the below questions" }, { "value" => "opt2", "label" => " No" }] } }
+          = render partial: "@citizensadvice/design-system/haml/radio_group",
+            locals: { radio: { "name" => "example-radio-group", "label" => "Have you contacted the trader about this complaint? ", "options" => [{ "value" => "opt1", "label" => "Yes - If yes, answer the below questions" }, { "value" => "opt2", "label" => " No" }] } }
 
-        = render partial: "@citizensadvice/design-system/haml/textarea",
-          locals: { input: { "name" => "example-textarea", "label" => "Outline the trader's response to the complaint, if any"}}
+          = render partial: "@citizensadvice/design-system/haml/textarea",
+            locals: { input: { "name" => "example-textarea", "label" => "Outline the trader's response to the complaint, if any"}}
 
-        %button.cads-button.cads-button__primary{ "type" => "button" } Submit complaint
+          %button.cads-button.cads-button__primary{ "type" => "button" } Submit complaint
 
       .cads-grid-col-md-4
         %aside.cads-related-content

--- a/styleguide/sample-pages/generic/_tables.html.haml
+++ b/styleguide/sample-pages/generic/_tables.html.haml
@@ -4,24 +4,25 @@
   .cads-grid-row
     .cads-grid-col-12
       = render partial: "@citizensadvice/design-system/haml/breadcrumb", locals: {breadcrumbs: {"breadcrumb_links" => [{"url" => "/link", "title" => "Tables"}]}}
-%main.cads-main-content
+%main.cads-page-content
   .cads-grid-container
     .cads-grid-row
       .cads-grid-col-md-8
         = render partial: "@citizensadvice/design-system/haml/notice_banner"
     .cads-grid-row
-      .cads-grid-col-md-8.cads-prose
-        %h1 Tables examples
-        = render partial: "@citizensadvice/design-system/haml/callout", locals: { 'notice' => { 'type' => 'standard', 'body' => '<h3>Standard callout</h3><p>This is a sample page. Note that the layout may not reflect the actual page layout of the website.</p>' } }
-        %h3 This is a long table
-        = render partial: "@citizensadvice/design-system/haml/table", locals: { 'table_data' => table_data_long }
-        %p Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque a urna nisl. Aenean euismod purus a magna vulputate, eget volutpat neque volutpat. Donec dapibus scelerisque diam eu scelerisque. Vestibulum laoreet magna sagittis felis pellentesque semper. Nullam porta, arcu rhoncus euismod porttitor, risus augue bibendum ipsum, eget tincidunt mi lectus eget eros.
-        = render partial: "@citizensadvice/design-system/haml/table"
-        %p Etiam laoreet erat sit amet porttitor luctus. Sed vitae enim aliquet, aliquam velit sit amet, placerat diam. Aenean malesuada euismod arcu, vel imperdiet dolor facilisis vitae. Fusce ac lacinia metus, ut interdum nibh. Nunc a lorem dolor. In sodales urna eget libero commodo luctus. Suspendisse commodo est sit amet diam tempus, sit amet vehicula ex sodales.
-        %h3 Table without a caption
-        = render partial: "@citizensadvice/design-system/haml/table", locals: { 'table_data' => table_data_no_caption }
-        %p Etiam laoreet erat sit amet porttitor luctus. Sed vitae enim aliquet, aliquam velit sit amet, placerat diam. Aenean malesuada euismod arcu, vel imperdiet dolor facilisis vitae. Fusce ac lacinia metus, ut interdum nibh. Nunc a lorem dolor. In sodales urna eget libero commodo luctus. Suspendisse commodo est sit amet diam tempus, sit amet vehicula ex sodales.
-        = render partial: "@citizensadvice/design-system/haml/page_review"
+      .cads-grid-col-md-8
+        %h1.cads-page-title Tables examples
+        .cads-prose
+          = render partial: "@citizensadvice/design-system/haml/callout", locals: { 'notice' => { 'type' => 'standard', 'body' => '<h3>Standard callout</h3><p>This is a sample page. Note that the layout may not reflect the actual page layout of the website.</p>' } }
+          %h3 This is a long table
+          = render partial: "@citizensadvice/design-system/haml/table", locals: { 'table_data' => table_data_long }
+          %p Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque a urna nisl. Aenean euismod purus a magna vulputate, eget volutpat neque volutpat. Donec dapibus scelerisque diam eu scelerisque. Vestibulum laoreet magna sagittis felis pellentesque semper. Nullam porta, arcu rhoncus euismod porttitor, risus augue bibendum ipsum, eget tincidunt mi lectus eget eros.
+          = render partial: "@citizensadvice/design-system/haml/table"
+          %p Etiam laoreet erat sit amet porttitor luctus. Sed vitae enim aliquet, aliquam velit sit amet, placerat diam. Aenean malesuada euismod arcu, vel imperdiet dolor facilisis vitae. Fusce ac lacinia metus, ut interdum nibh. Nunc a lorem dolor. In sodales urna eget libero commodo luctus. Suspendisse commodo est sit amet diam tempus, sit amet vehicula ex sodales.
+          %h3 Table without a caption
+          = render partial: "@citizensadvice/design-system/haml/table", locals: { 'table_data' => table_data_no_caption }
+          %p Etiam laoreet erat sit amet porttitor luctus. Sed vitae enim aliquet, aliquam velit sit amet, placerat diam. Aenean malesuada euismod arcu, vel imperdiet dolor facilisis vitae. Fusce ac lacinia metus, ut interdum nibh. Nunc a lorem dolor. In sodales urna eget libero commodo luctus. Suspendisse commodo est sit amet diam tempus, sit amet vehicula ex sodales.
+          = render partial: "@citizensadvice/design-system/haml/page_review"
       .cads-grid-col-md-4
         %aside.cads-related-content
           %p.paragraph-s.section-title Related Content


### PR DESCRIPTION
Whilst working on box lists I ran into an issue where we need to break out of the grid (to allow a background colour to spread full-width).

Currently the `cads-main-content class` prevents this:

- It constrains the width at the page level. This doubles up what `cads-grid-container` does so is both unnecessary and limiting (literally)
- It applies arbitrary styles to images
- It sets styles on `h1`s

Based on this I've split `cads-main-content` out into two classes:

- `cads-page-title`: only concerned with setting h1 styles. It also fixes an issue with the current typography styles where h1s are typically _outside_ `cads-prose` classes (in order to keep the scope as narrow as possible) so don't have the correct sizes
- `cads-page-content`: Only concerned with setting page level margins. Can be applied contextually based on the context of the page rather than assuming it's a top-level class
- Moved the img styles into cads-prose
