### PR TITLE
build: don't build docs if newVersion contains alpha

### DIFF
--- a/scripts/release.js
+++ b/scripts/release.js
@@ -152,18 +152,20 @@ prompt([
         fs.writeFileSync(changelogPath, newChangelog, 'utf8');
 
         // Rebuild the docs
-        const docsBuildStatus = spawnSync('npm run docs:build', {
-          cwd: __dirname,
-          shell: true,
-        }).status;
+        if (!newVersion.indexOf('alpha')) {
+          const docsBuildStatus = spawnSync('npm run docs:build', {
+            cwd: __dirname,
+            shell: true,
+          }).status;
 
-        if (docsBuildStatus === 0) {
-          log(chalk.green.dim(`${ok} Documentation build complete.`));
-        } else {
-          showError(
-            `${error} Documentation build failed, check the repo status.`,
-            true
-          );
+          if (docsBuildStatus === 0) {
+            log(chalk.green.dim(`${ok} Documentation build complete.`));
+          } else {
+            showError(
+              `${error} Documentation build failed, check the repo status.`,
+              true
+            );
+          }
         }
 
         try {


### PR DESCRIPTION
We don't want to push docs to live if we are releasing an alpha build.