### PR TITLE
refactor: Moved wcag file and removed wait-for-it [NP-1164]

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,13 +35,13 @@ services:
   wcag-tests:
     build:
       context: ./
-      dockerfile: ./testing/Dockerfile.wcag
+      dockerfile: ./docker/Dockerfile.wcag
       cache_from:
         - '979633842206.dkr.ecr.eu-west-1.amazonaws.com/design-system:dev_wcag_${CA_STYLEGUIDE_VERSION_TAG}'
         - '979633842206.dkr.ecr.eu-west-1.amazonaws.com/design-system:wcag'
     image: '979633842206.dkr.ecr.eu-west-1.amazonaws.com/design-system:dev_wcag_${CA_STYLEGUIDE_VERSION_TAG}'
     container_name: wcag-tests.test
-    command: wait-for-it --timeout=120 --strict ca-styleguide:6006 -- pa11y-ci --config=/src/wcag/pa11yci.ci.js
+    command: pa11y-ci --config=/src/wcag/pa11yci.ci.js
     volumes:
       - ./testing:/src
     depends_on:

--- a/docker/Dockerfile.wcag
+++ b/docker/Dockerfile.wcag
@@ -2,8 +2,6 @@ FROM alekzonder/puppeteer:1
 
 USER root
 
-RUN apt-get update && apt-get install wait-for-it
-
 RUN yarn global add pa11y-ci
 
 ENV PATH "/usr/local/share/.config/yarn/global/node_modules/.bin/:${PATH}"


### PR DESCRIPTION
This was the very simple one.

- Moved wcag Dockerfile to docker folder with the others
- Removed the wait-for-it package from the Dockerfile
- Fixed up the docker-compose file to deal with other changes
