### PR TITLE
Use npm version for release script

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -124,6 +124,14 @@ After the new version branch is merged, switch to `master`, pull the latest chan
 npm publish
 ```
 
+Followed by
+
+```
+git push origin v{your_version_here}
+```
+
+To publish the release tag to GitHub.
+
 A `prePublish` script will ensure you can only run npm publish from a `master` that is in a clean state. It will build the package and publish to npm.
 
 **_Note:_** To run this step you need to be part of the npm org and have 2FA enabled.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -116,8 +116,6 @@ npm run release
 
 This prepares the release and puts it in a branch with the appropriate version name, which needs a pull request to be merged into master. Once that is merged you can then do the actual release.
 
-**Note:** The current release script does not update the version inside `package-lock.json`. To correct this you should run `npm install` after creating a release and commit the resulting change.
-
 ### 2. Publish to npm
 
 After the new version branch is merged, switch to `master`, pull the latest changes and run:

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -171,7 +171,7 @@ prompt([
               git
                 .add('.')
                 .commit(releaseMessage)
-                .push('origin', newVersionBranch, (gitErr2) => {
+                .push(['origin', '--tags'], newVersionBranch, (gitErr2) => {
                   if (gitErr2) {
                     showError(gitErr2, true);
                   }

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -3,7 +3,7 @@ const fs = require('fs-extra');
 const chalk = require('chalk');
 const path = require('path');
 const { prompt } = require('inquirer');
-const { spawnSync } = require('child_process');
+const { execSync, spawnSync } = require('child_process');
 const semver = require('semver');
 const moment = require('moment');
 const { checkBuildOutput } = require('./check-size');
@@ -17,25 +17,9 @@ const PACKAGE_NAME = 'design-system';
 const FULL_PACKAGE_NAME = `${ORG_NAME}/${PACKAGE_NAME}`;
 
 function updateVersionNumber(newVersion) {
-  log(
-    chalk.blue.dim(
-      `${ok} Updating version number in ${FULL_PACKAGE_NAME}/package.json to ${newVersion}`
-    )
-  );
-  // Update the version number in package.json
-  const PACKAGE_JSON = path.join(PATH, 'package.json');
-  const packageJson = fs.readJsonSync(PACKAGE_JSON);
-  packageJson.version = newVersion;
-  // Write the updated file
-  fs.writeJsonSync(PACKAGE_JSON, packageJson, {
-    spaces: 2,
-    EOL: '\n',
-  });
-  log(
-    chalk.green(
-      `${ok} Updated version number in ${FULL_PACKAGE_NAME}/package.json to ${newVersion}`
-    )
-  );
+  log(chalk.blue.dim(`${ok} Updating version number to ${newVersion}`));
+  execSync(`npm version ${newVersion}`);
+  log(chalk.green(`${ok} Updated version number to ${newVersion}`));
 }
 
 /* ///////////////////////////////////////////////////////////////////////// */

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -171,7 +171,7 @@ prompt([
               git
                 .add('.')
                 .commit(releaseMessage)
-                .push(['origin', '--tags'], newVersionBranch, (gitErr2) => {
+                .push('origin', newVersionBranch, (gitErr2) => {
                   if (gitErr2) {
                     showError(gitErr2, true);
                   }

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -114,7 +114,7 @@ prompt([
         process.exit(1);
       }
 
-      const newVersionBranch = `v${newVersion}`;
+      const newVersionBranch = `release/v${newVersion}`;
       const git = simpleGit(PATH);
 
       git.checkoutBranch(newVersionBranch, 'HEAD', (gitErr) => {

--- a/testing/features/support/core_ext/selenium/webdriver/firefox/options.rb
+++ b/testing/features/support/core_ext/selenium/webdriver/firefox/options.rb
@@ -17,7 +17,7 @@ module Selenium
           if value.is_a?(Hash)
             value.each_with_object({}) do |(key, val), hash|
               key = convert_json_key(key, camelize: camelize_keys)
-              hash[key] = generate_as_json(val, camelize_keys: key != 'prefs')
+              hash[key] = generate_as_json(val, camelize_keys: key != "prefs")
             end
           else
             super


### PR DESCRIPTION
Fixes a bugbear with the current release script:

We currently manually update the package.json version but this a) causes issues with formatting and b) always misses out the version in package-lock.json. `npm version` does this for us.

The default include making a git tag of the version too which is think is a good thing to do, but if we want to disable that for now we can add `--no-git-tag-version`.
