### PR TITLE
bugfix: Local Firefox Driver [NP-1065]

### DIFF
--- a/testing/features/support/core_ext/selenium/webdriver/firefox/options.rb
+++ b/testing/features/support/core_ext/selenium/webdriver/firefox/options.rb
@@ -1,5 +1,12 @@
 # frozen_string_literal: true
 
+# This patch fixes an issue with Selenium4 not camelising the browser_name property
+# The issue is the driver now fully W3C conformany expects `browserName`
+#
+# See: https://github.com/SeleniumHQ/selenium/pull/8834
+# for more details/discussion including this fix
+#
+# LH - Sep 2020
 module Selenium
   module WebDriver
     module Firefox

--- a/testing/features/support/core_ext/selenium/webdriver/firefox/options.rb
+++ b/testing/features/support/core_ext/selenium/webdriver/firefox/options.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Selenium
+  module WebDriver
+    module Firefox
+      class Options < WebDriver::Options
+        private
+
+        def generate_as_json(value, camelize_keys: true)
+          if value.is_a?(Hash)
+            value.each_with_object({}) do |(key, val), hash|
+              key = convert_json_key(key, camelize: camelize_keys)
+              hash[key] = generate_as_json(val, camelize_keys: key != 'prefs')
+            end
+          else
+            super
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Creates a patch that allows Firefox drivers to be created both locally and through grid (Browserstack appears to be unaffected).

The issue stems from the fact that the key for the browsername when created directly using `browser :firefox` appears to not be camelised, whereas the chrome one is being camelised. In Se4 this case mismatch is then bubbling up as an invalid key error.