### PR TITLE
feature: Automation Candidate Triage [NP-991]

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,14 +1,13 @@
 deployBranches = ['master']
 
 configurationTypes = [
-    //     ['Windows_10_83', 'chrome'], - These seem to be "too" popular!
     ['Windows_10_85', 'chrome'],
-    ['Windows_10_80', 'firefox'],
-    ['Windows_10_76', 'firefox'],
+    ['Windows_10_81', 'firefox'],
     ['Windows_7_80', 'chrome'],
     ['Windows_7_78', 'firefox'],
+    ['OSX_Mojave_84', 'chrome'],
     ['OSX_Mojave_78', 'firefox'],
-//     ['OSX_Mojave_12', 'safari'], - These seem to be "too" popular!
+    ['OSX_Mojave_12', 'safari'],
 ]
 
 cron_schedule = deployBranches.contains(BRANCH_NAME) ? '0 2 * * *' : ''

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,8 +6,9 @@ configurationTypes = [
     ['Windows_7_80', 'chrome'],
     ['Windows_7_78', 'firefox'],
     ['OSX_Mojave_84', 'chrome'],
-    ['OSX_Mojave_78', 'firefox'],
     ['OSX_Mojave_12', 'safari'],
+    ['iPhone11_13', 'safari'],
+    ['iPhone8_12', 'safari'],
 ]
 
 cron_schedule = deployBranches.contains(BRANCH_NAME) ? '0 2 * * *' : ''

--- a/testing/features/oisc_warnings.feature
+++ b/testing/features/oisc_warnings.feature
@@ -32,6 +32,7 @@ Feature: OISC Warning components
       Then the OISC title is visible
       And the OISC message is visible
 
+    @not_mobile @NP-1230
     Scenario: Sticky component follows you down the page
       When I scroll to the bottom of the page
       Then the OISC component is visible at the top of the viewport

--- a/testing/features/support/hooks.rb
+++ b/testing/features/support/hooks.rb
@@ -5,6 +5,7 @@ AfterConfiguration do
 end
 
 Before do |scenario|
+  skip_this_scenario("This needs fixing on mobile") if device? && scenario.source_tag_names.include?("@not_mobile")
   resize_window unless device?
   AutomationLogger.info("Running Scenario: #{scenario.name}")
   AutomationLogger.debug("BROWSERSTACK_CONFIGURATION_OPTIONS = #{ENV['BROWSERSTACK_CONFIGURATION_OPTIONS']}")


### PR DESCRIPTION
Now we have the Design-System running stably again (Admittedly with some belt-n-braces approaches). We should look to re-enable some more testing candidates and also streamline our existing ones.

This is still a work in progress and browsers/versions are very much up for discussion. But fundamentally this time we introduce iPhone's into our testing matrix.

The code for enabling these was done last Sprint, but I've only just wanted to introduce them now after running them privately for a little while. You'll note the format of BROWSERSTACK_CONFIG_OPTIONS is slightly different. Although this is not mandatory (Essentially the 3rd parameter on iPhone's is always the same as the 2nd, and as such it can be omitted - i.e. `iPhone8_12_12 == iPhone8_12`)