### PR TITLE
Docs tweaks

### DIFF
--- a/.storybook/manager-head.html
+++ b/.storybook/manager-head.html
@@ -1,8 +1,9 @@
 <script>
-  document.title = 'CA Design System';
+  var newTitle = 'Citizens Advice Design System';
+  document.title = newTitle;
   var observer = new MutationObserver(function (mutations) {
     if (document.title.match(/Storybook$/)) {
-      document.title = 'CA Design System';
+      document.title = document.title.replace('Storybook', newTitle);
     }
   }).observe(document.querySelector('title'), {
     childList: true,

--- a/styleguide/component.stories.js
+++ b/styleguide/component.stories.js
@@ -53,7 +53,8 @@ ${usage || ''}`,
 
 // Storybook section setup
 export default {
-  title: '3: Components',
+  title: 'Components',
+  id: '3: Components',
   parameters: {
     options: {
       showPanel: true,

--- a/styleguide/documentation/changelog.stories.mdx
+++ b/styleguide/documentation/changelog.stories.mdx
@@ -1,6 +1,0 @@
-import { Meta, Description } from '@storybook/addon-docs/blocks';
-import Changelog from '../../CHANGELOG.md';
-
-<Meta title="Welcome/Changelog" />
-
-<Description>{Changelog}</Description>

--- a/styleguide/documentation/contact.stories.mdx
+++ b/styleguide/documentation/contact.stories.mdx
@@ -1,7 +1,0 @@
-import { Meta } from '@storybook/addon-docs/blocks';
-
-<Meta title="Welcome/Contact" />
-
-# Contact
-
-All design system discussions take place in the #design-system Slack channel. For current issues, roadmap and other info see the [Github project board](https://github.com/citizensadvice/design-system-testing/projects/1) and [related issues](https://github.com/citizensadvice/design-system-testing/issues).

--- a/styleguide/documentation/getting-started.stories.mdx
+++ b/styleguide/documentation/getting-started.stories.mdx
@@ -128,3 +128,7 @@ Some components require polyfills for older browsers. Components which require p
 We don't include the polyfills by default in order to avoid double bundling if you have your own.
 
 If you are not using either of these components then you may not need any polyfills.
+
+## Contact
+
+All design system discussions take place in the #design-system Slack channel. For current issues, roadmap and other info see the [Github project board](https://github.com/citizensadvice/design-system-testing/projects/1) and [related issues](https://github.com/citizensadvice/design-system-testing/issues).

--- a/styleguide/documentation/getting-started.stories.mdx
+++ b/styleguide/documentation/getting-started.stories.mdx
@@ -129,6 +129,11 @@ We don't include the polyfills by default in order to avoid double bundling if y
 
 If you are not using either of these components then you may not need any polyfills.
 
+## Changelog
+
+- Release notes for each version (starting with v2.0.0) can be seen at [https://github.com/citizensadvice/design-system/releases]()
+- The full changelog can be found at [https://github.com/citizensadvice/design-system/blob/master/CHANGELOG.md]()
+
 ## Contact
 
 All design system discussions take place in the #design-system Slack channel. For current issues, roadmap and other info see the [Github project board](https://github.com/citizensadvice/design-system-testing/projects/1) and [related issues](https://github.com/citizensadvice/design-system-testing/issues).


### PR DESCRIPTION
A few small docs tweaks:

- Fixes an issue where the page title was always "CA Design System" rather than including the current story title
- Inline contact details into welcome guide. It was one sentence.
- Link to releases and changelog instead of inlining into Storybook. This is a partially generated doc so the formatting is a little troublesome in storybook and better to link off to github and the release page now we have it.