### PR TITLE
Callout markup bug

### DIFF
--- a/.haml-lint.yml
+++ b/.haml-lint.yml
@@ -18,7 +18,6 @@ linters:
     exclude:
       - 'haml/_asset_hyperlink.html.haml'
       - 'haml/_breadcrumb.html.haml'
-      - 'haml/_callout.html.haml'
       - 'haml/_contact_details.html.haml'
       - 'haml/_navigation.html.haml'
       - 'haml/_notice_banner.html.haml'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 * Header: Fix spacing and grid sizing around search form (NP-1024)
 * Footer: Fix spacing and responsive styling (NP-1033)
+* Callout: Don't render empty `.cads-callout-label` for standard callouts (no label)
 
 ## <sub>v2.0.0</sub>
 

--- a/haml/_callout.html.haml
+++ b/haml/_callout.html.haml
@@ -2,7 +2,7 @@
 - type = notice.fetch('type', 'standard')
 
 %div{class: "cads-callout cads-callout-#{type}"}
-  .cads-callout-label
-    - if type != 'standard'
+  - if type != 'standard'
+    .cads-callout-label
       = t("cads.callout.#{type}")
   = notice['body']

--- a/haml/_callout.html.haml
+++ b/haml/_callout.html.haml
@@ -1,8 +1,7 @@
 -# Default type to standard if none is provided
-- type = notice.fetch('type', 'standard')
+- type = notice.fetch("type", "standard")
 
-%div{class: "cads-callout cads-callout-#{type}"}
-  - if type != 'standard'
-    .cads-callout-label
-      = t("cads.callout.#{type}")
-  = notice['body']
+.cads-callout{ class: "cads-callout-#{type}" }
+  - if type != "standard"
+    .cads-callout-label= t("cads.callout.#{type}")
+  = notice["body"]

--- a/scss/6-components/_callout.scss
+++ b/scss/6-components/_callout.scss
@@ -6,10 +6,6 @@
   padding: $cads-spacing-4;
   margin: 0 0 $cads-spacing-5 0;
 
-  .cads-callout__adviser-label {
-    display: none;
-  }
-
   h2:first-of-type,
   h3:first-of-type {
     @extend %cads-h3;

--- a/styleguide/sample-pages/advice-collection/_advice_collection_adviser.html.haml
+++ b/styleguide/sample-pages/advice-collection/_advice_collection_adviser.html.haml
@@ -16,15 +16,6 @@
           = render partial: "@citizensadvice/design-system/haml/oisc_warning", locals: { 'oisc_warning' => { 'title' => "This is an OISC level 2 topic", 'body' => "Generalist advisers can give clients the information on this page, but must refer them to an immigration specialist if they need advice. <a href='#'>Check what to do if your client needs level 2 advice.</a>", 'is_sticky' => true } }
           .cads-prose
             = render partial: "@citizensadvice/design-system/haml/callout", locals: { 'notice' => { 'type' => 'adviser', 'body' => '<h3>This is an adviser callout</h3><p>This is the body text of an adviser callout.</p>' } }
-            %p Here is an important callout with adviser content
-            .cads-callout.cads-callout-important
-              .cads-callout__adviser-label
-              %h3 This is the callout title
-              %p The important callout should be used for any important snippet of text that has serious and/or legal implications if the client does not follow the advice.
-              .cads-callout.cads-callout-adviser
-                .cads-callout__adviser-label
-                %h3 This is the callout title
-                %p The important callout should be used for any important snippet of text that has serious and/or legal implications if the client does not follow the advice.
             %p
               Every page should have some lorem ipsum. So here it is.
             %ul


### PR DESCRIPTION
**Bugfix**: Don't render empty .cads-callout-label for standard callouts (no label)

Also enables haml-lint rubocop checks for this component and fixes any warnings. Plus removes some misleading examples of nested callouts (we have a backlog task to document nested callouts more generally)