### PR TITLE
v2.1.0 alpha.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## <sub>v2.1.0-alpha.0</sub>
+
+#### _Nov. 5, 2020_
+
 **Deprecations**:
 
 * Removed standalone `logo_clickable` component. Only used within header and footer

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@citizensadvice/design-system",
-  "version": "2.0.0",
+  "version": "2.1.0-alpha.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@citizensadvice/design-system",
-  "version": "2.0.0",
+  "version": "2.1.0-alpha.0",
   "description": "Citizens Advice Design System",
   "files": [
     "scss",

--- a/stats/size.json
+++ b/stats/size.json
@@ -590,6 +590,15 @@
           "size": 72093
         }
       ]
+    },
+    {
+      "version": "2.1.0-alpha.0",
+      "stats": [
+        {
+          "filename": "lib.css",
+          "size": 72813
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
Alpha release including:

**Deprecations**:

* Removed standalone `logo_clickable` component. Only used within header and footer
* Removed standalone `website_feedack` component. Only ever used within footer

**Bugfixes**:

* Header: Fix spacing and grid sizing around search form (NP-1024)
* Footer: Fix spacing and responsive styling (NP-1033)
* Callout: Don't render empty `.cads-callout-label` for standard callouts (no label)
