### PR TITLE
Hotfix: Safari CI test

### DIFF
--- a/testing/features/step_definitions/oisc_warnings_steps.rb
+++ b/testing/features/step_definitions/oisc_warnings_steps.rb
@@ -42,9 +42,9 @@ Then("the OISC message is not visible") do
 end
 
 Then("the OISC component is visible at the top of the viewport") do
-  expect(@component.heading.vertical_position).to be > 900
+  expect(@component.heading.vertical_position).to be > 800
 
-  expect(@component.description.vertical_position).to be > 950
+  expect(@component.description.vertical_position).to be > 850
 end
 
 Then("the OISC component is no longer visible at the top of the viewport") do


### PR DESCRIPTION
Safari has less unusable space so it appears at a relative lower space

Safari windows have different "usable" spaces. So we need to account for that in our sticky test.