### PR TITLE
Hotfix/failing ci

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,8 +7,8 @@ configurationTypes = [
     ['Windows_7_78', 'firefox'],
     ['OSX_Mojave_84', 'chrome'],
     ['OSX_Mojave_12', 'safari'],
-    ['iPhone11_13', 'safari'],
-    ['iPhone8_12', 'safari'],
+    ['iPhone11_13', 'ios'],
+    ['iPhone8_12', 'ios'],
 ]
 
 cron_schedule = deployBranches.contains(BRANCH_NAME) ? '0 2 * * *' : ''

--- a/testing/features/breadcrumbs.feature
+++ b/testing/features/breadcrumbs.feature
@@ -1,3 +1,4 @@
+@not_on_mobile @NP-1253
 Feature: Breadcrumbs component
 
   The Breadcrumbs component allows users to see a navigable path to their


### PR DESCRIPTION
This fixes 2 additional issues that have now surfaced (SHAs)

- The Jenkinsfile was misconfigured. We're using ios drivers which are "similar" but different to safaridrivers
- The breadcrumb tests needs a re-think for iPhones. So we're going to fix it for them!