### PR TITLE
Skip scenario on iOS12 device

### DIFF
--- a/testing/features/oisc_warnings.feature
+++ b/testing/features/oisc_warnings.feature
@@ -37,11 +37,13 @@ Feature: OISC Warning components
       When I scroll to the bottom of the page
       Then the OISC component is visible at the top of the viewport
 
+    @not_ios12 @NP-1264
     Scenario: Sticky component can be closed off
       When I scroll to the bottom of the page
       And I close the sticky component
       Then the OISC component is no longer visible at the top of the viewport
 
+    @not_ios12 @NP-1264
     Scenario: Sticky component is no longer sticky after being closed
       When I scroll to the bottom of the page
       And I close the sticky component

--- a/testing/features/support/drivers/browserstack/ios.rb
+++ b/testing/features/support/drivers/browserstack/ios.rb
@@ -29,14 +29,6 @@ module Drivers
           "1.16.0"
         end
       end
-
-      def ios13?
-        browserstack_os_version == "13"
-      end
-
-      def ios12?
-        browserstack_os_version == "12"
-      end
     end
   end
 end

--- a/testing/features/support/helpers/env_variables.rb
+++ b/testing/features/support/helpers/env_variables.rb
@@ -77,11 +77,11 @@ module Helpers
     end
 
     def ios13?
-      browserstack_os_version == "13"
+      browserstack? && browserstack_os_version == "13"
     end
 
     def ios12?
-      browserstack_os_version == "12"
+      browserstack? && browserstack_os_version == "12"
     end
   end
 end

--- a/testing/features/support/helpers/env_variables.rb
+++ b/testing/features/support/helpers/env_variables.rb
@@ -75,5 +75,13 @@ module Helpers
     def browserstack_browser_version
       ENV.fetch("BROWSERSTACK_CONFIGURATION_OPTIONS").split("_")[2]
     end
+
+    def ios13?
+      browserstack_os_version == "13"
+    end
+
+    def ios12?
+      browserstack_os_version == "12"
+    end
   end
 end

--- a/testing/features/support/hooks.rb
+++ b/testing/features/support/hooks.rb
@@ -7,6 +7,7 @@ end
 Before do |test_case|
   I18n.locale = :en
   skip_this_scenario("This needs fixing on mobile") if device? && test_case.source_tag_names.include?("@not_mobile")
+  skip_this_scenario("This needs fixing on iOS12") if ios12? && test_case.source_tag_names.include?("@not_ios12")
   resize_window unless device?
   AutomationLogger.info("Running Scenario: #{test_case.name}")
   AutomationLogger.debug("BROWSERSTACK_CONFIGURATION_OPTIONS = #{ENV['BROWSERSTACK_CONFIGURATION_OPTIONS']}")


### PR DESCRIPTION
These two tests appear to fail on iOS12. So we've broken them out and conditionally skipped them only on iOS12