### PR TITLE
feature: Add firefox to Local grid test runs [NP-1174]

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,11 +19,11 @@ def ecr_credential = 'ecr:eu-west-1:cita-devops'
 
 def images = [:]
 
-def withCucumberNode(String description, Array imageArray, Closure body) {
+def withCucumberNode(String description, Map imageMap, Closure body) {
     node("docker && awsaccess") {
         stage (description) {
             checkout scm
-            withDockerSandbox(imageArray) {
+            withDockerSandbox(imageMap) {
                 // Call closure
                 body()
             } // withDockerSandbox

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -132,7 +132,7 @@ pipeline {
             parallel {
                 stage('Interim Stage: Test Chrome') {
                     steps {
-                        script {
+                        script { env.BUILD_STAGE = 'Interim Stage: Test Chrome' }
                         withDockerSandbox([
                             images['ruby'],
                             'selenium/hub:4.0.0-alpha-6-20200609',
@@ -152,7 +152,7 @@ pipeline {
                 }
                 stage('Interim Stage: Test Firefox') {
                     steps {
-                        script {
+                        script { env.BUILD_STAGE = 'Interim Stage: Test Firefox' }
                         withDockerSandbox([
                             images['ruby'],
                             'selenium/hub:4.0.0-alpha-6-20200609',

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,14 +19,11 @@ def ecr_credential = 'ecr:eu-west-1:cita-devops'
 
 def images = [:]
 
-def withCucumberNode(String description, Boolean useBrowserStack = false, Closure body) {
+def withCucumberNode(String description, Array images, Closure body) {
     node("docker && awsaccess") {
         stage (description) {
             checkout scm
-            docker.withRegistry(DOCKER_REGISTRY_URL, params.ecrCredentialId) {
-                docker.image("$DOCKER_IMAGE_ID").pull()
-            }
-            withDockerSandbox(["$DOCKER_IMAGE_ID"]) {
+            withDockerSandbox(images) {
                 // Call closure
                 body()
             } // withDockerSandbox
@@ -148,11 +145,14 @@ pipeline {
                 stage('Interim Stage: Test Chrome') {
                     steps {
                         script { env.BUILD_STAGE = 'Interim Stage: Test Chrome' }
-                        withDockerSandbox([
-                            images['ruby'],
-                            'selenium/hub:4.0.0-alpha-6-20200609',
-                            'selenium/node-chrome:4.0.0-alpha-6-20200609',
-                            'selenium/node-firefox:4.0.0-alpha-6-20200609' ]) {
+                        withCucumberNode('Interim Stage: Test Chrome (inner)',
+                            [
+                                images['ruby'],
+                                'selenium/hub:4.0.0-alpha-6-20200609',
+                                'selenium/node-chrome:4.0.0-alpha-6-20200609',
+                                'selenium/node-firefox:4.0.0-alpha-6-20200609'
+                            ]
+                        ) {
                             script {
                                 try {
                                     sh 'BROWSER=chrome bin/docker/grid_tests'
@@ -168,11 +168,14 @@ pipeline {
                 stage('Interim Stage: Test Firefox') {
                     steps {
                         script { env.BUILD_STAGE = 'Interim Stage: Test Firefox' }
-                        withDockerSandbox([
-                            images['ruby'],
-                            'selenium/hub:4.0.0-alpha-6-20200609',
-                            'selenium/node-chrome:4.0.0-alpha-6-20200609',
-                            'selenium/node-firefox:4.0.0-alpha-6-20200609' ]) {
+                        withCucumberNode('Interim Stage: Test Firefox (inner)',
+                            [
+                                images['ruby'],
+                                'selenium/hub:4.0.0-alpha-6-20200609',
+                                'selenium/node-chrome:4.0.0-alpha-6-20200609',
+                                'selenium/node-firefox:4.0.0-alpha-6-20200609'
+                            ]
+                        ) {
                             script {
                                 try {
                                     sh 'BROWSER=firefox bin/docker/grid_tests'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,6 +19,21 @@ def ecr_credential = 'ecr:eu-west-1:cita-devops'
 
 def images = [:]
 
+def withCucumberNode(String description, Boolean useBrowserStack = false, Closure body) {
+    node("docker && awsaccess") {
+        stage (description) {
+            checkout scm
+            docker.withRegistry(DOCKER_REGISTRY_URL, params.ecrCredentialId) {
+                docker.image("$DOCKER_IMAGE_ID").pull()
+            }
+            withDockerSandbox(["$DOCKER_IMAGE_ID"]) {
+                // Call closure
+                body()
+            } // withDockerSandbox
+        } // stage
+    } // node
+} // withCucumberNode
+
 pipeline {
     triggers { cron(cron_schedule) }
     agent {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -123,8 +123,8 @@ pipeline {
                 script { env.BUILD_STAGE = 'Visual Regression Tests' }
                 withDockerSandbox([
                     images['ca-styleguide'],
-                    'backstopjs/backstopjs',
-                    images['wcag'] ]) {
+                    'backstopjs/backstopjs'
+                ]) {
                     script {
                         try {
                             sh './bin/jenkins/visual_regression'
@@ -162,21 +162,23 @@ pipeline {
                 stage('Interim Stage: Test Chrome') {
                     steps {
                         script { env.BUILD_STAGE = 'Interim Stage: Test Chrome' }
-                        withCucumberNode('Interim Stage: Test Chrome (inner)',
-                            [
-                                images['ruby'],
-                                'selenium/hub:4.0.0-alpha-6-20200609',
-                                'selenium/node-chrome:4.0.0-alpha-6-20200609',
-                                'selenium/node-firefox:4.0.0-alpha-6-20200609'
-                            ]
-                        ) {
-                            script {
-                                try {
-                                    sh 'BROWSER=chrome bin/docker/grid_tests'
-                                } catch (Exception e) {
-                                    sh 'docker-compose logs --no-color'
-                                    currentBuild.result = 'FAILURE'
-                                    throw e
+                        script {
+                            withCucumberNode('Interim Stage: Test Chrome (inner)',
+                                [
+                                    images['ruby'],
+                                    'selenium/hub:4.0.0-alpha-6-20200609',
+                                    'selenium/node-chrome:4.0.0-alpha-6-20200609',
+                                    'selenium/node-firefox:4.0.0-alpha-6-20200609'
+                                ]
+                            ) {
+                                script {
+                                    try {
+                                        sh 'BROWSER=chrome bin/docker/grid_tests'
+                                    } catch (Exception e) {
+                                        sh 'docker-compose logs --no-color'
+                                        currentBuild.result = 'FAILURE'
+                                        throw e
+                                    }
                                 }
                             }
                         }
@@ -185,21 +187,23 @@ pipeline {
                 stage('Interim Stage: Test Firefox') {
                     steps {
                         script { env.BUILD_STAGE = 'Interim Stage: Test Firefox' }
-                        withCucumberNode('Interim Stage: Test Firefox (inner)',
-                            [
-                                images['ruby'],
-                                'selenium/hub:4.0.0-alpha-6-20200609',
-                                'selenium/node-chrome:4.0.0-alpha-6-20200609',
-                                'selenium/node-firefox:4.0.0-alpha-6-20200609'
-                            ]
-                        ) {
-                            script {
-                                try {
-                                    sh 'BROWSER=firefox bin/docker/grid_tests'
-                                } catch (Exception e) {
-                                    sh 'docker-compose logs --no-color'
-                                    currentBuild.result = 'FAILURE'
-                                    throw e
+                        script {
+                            withCucumberNode('Interim Stage: Test Firefox (inner)',
+                                [
+                                    images['ruby'],
+                                    'selenium/hub:4.0.0-alpha-6-20200609',
+                                    'selenium/node-chrome:4.0.0-alpha-6-20200609',
+                                    'selenium/node-firefox:4.0.0-alpha-6-20200609'
+                                ]
+                            ) {
+                                script {
+                                    try {
+                                        sh 'BROWSER=firefox bin/docker/grid_tests'
+                                    } catch (Exception e) {
+                                        sh 'docker-compose logs --no-color'
+                                        currentBuild.result = 'FAILURE'
+                                        throw e
+                                    }
                                 }
                             }
                         }


### PR DESCRIPTION
Same as sister PR for public-website-cucumber

NB: I added parallel functions for the grid tests. I will add parallelisation for the browserstack ones in the next sprint too.