### PR TITLE
[bugfix] Updating input component to include name attribute [SMP-101]

### DIFF
--- a/haml/_input.html.haml
+++ b/haml/_input.html.haml
@@ -9,4 +9,4 @@
       %p.cads-form-field__hint= input["hint"]
     - if input["error_message"]
       %p.cads-form-field__error-message= input["error_message"]
-    %input.cads-input{ type: "text", id: "#{input['name']}-input", class: ("cads-input--#{input['size']}" if input["size"]) }
+    %input.cads-input{ type: "text", id: "#{input['name']}-input", name: input["name"], class: ("cads-input--#{input['size']}" if input["size"]) }


### PR DESCRIPTION
Using the input component in a rails form and realising the input values are not submitting with the form because the `name` attribute is not set.

This PR set the attribute `name: input['name']` on the Input component.

This change does not change the UI or the way it functions.