### PR TITLE
jenkins scripted pipeline

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -32,8 +32,8 @@ def images = [:]
 node(nodeLabel) {
   stage('Setup') {
     cleanWs()
-    //checkout scm
-    git credentialsId: 'jenkins-pipeline-gh-access', url: 'https://github.com/citizensadvice/design-system.git'
+    checkout scm
+
     slackNotifyReleaseOnly {
       stash 'source'
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,6 @@
 deployBranches = ['master']
+isRelease = deployBranches.contains(env.BRANCH_NAME)
+nodeLabel = 'docker && awsaccess'
 
 configurationTypes = [
     ['Windows_10_85', 'chrome'],
@@ -11,7 +13,15 @@ configurationTypes = [
     ['iPhone8_12', 'ios'],
 ]
 
-cron_schedule = deployBranches.contains(BRANCH_NAME) ? '0 2 * * *' : ''
+cron_schedule = isRelease ? '0 2 * * *' : ''
+
+properties([
+  parameters([
+    string(defaultValue: '#new_platform_builds', description: 'channel to print messages', name: 'slackChannel'),
+    string(defaultValue: 'slack-plugin', description: 'id of slack credentials used when posting a message', name: 'slackCredentialsId')
+    ]),
+    pipelineTriggers([cron(cron_schedule)])
+])
 
 def docker_registry = '979633842206.dkr.ecr.eu-west-1.amazonaws.com'
 def docker_registry_url = "https://${docker_registry}"
@@ -19,189 +29,211 @@ def ecr_credential = 'ecr:eu-west-1:cita-devops'
 
 def images = [:]
 
-pipeline {
-    triggers { cron(cron_schedule) }
-    agent {
-        label 'docker && awsaccess'
-    }
-    environment {
-        DOCKER_TAG = "${env.BRANCH_NAME}_${getSha()}"
-        // Using the commit SHA would mean that every build gets a different tag and this busts the cache between PR builds.
-        CA_STYLEGUIDE_VERSION_TAG = "${env.BRANCH_NAME}"
-        BUILD_STAGE = ''
-    }
-    parameters {
-        string(name: 'slackChannel', defaultValue: '#new_platform_builds',
-            description: 'channel to print messages')
-        string(name: 'slackCredentialsId', defaultValue: 'slack-plugin',
-            description: 'id of slack credentials used when posting a message')
-    }
+node(nodeLabel) {
+  stage('Setup') {
+    cleanWs()
+    //checkout scm
+    git credentialsId: 'jenkins-pipeline-gh-access', url: 'https://github.com/citizensadvice/design-system.git'
+    slackNotifyReleaseOnly {
+      stash 'source'
 
-    stages {
-        stage('Setup') {
-            steps {
-                script { env.BUILD_STAGE = 'Setup' }
-                script {
-                    currentBuild.displayName = "$BUILD_NUMBER: $DOCKER_TAG"
-                }
-                script {
-                    docker.withRegistry(docker_registry_url, ecr_credential) {
-                        // Pull the master images and any previous builds if we're on a different branch
-                        // docker-compose only looks in the local images and doesn't try to pull when building
-                        ['ca-styleguide', 'wcag', 'ruby'].each {
-                            images[it] = "${docker_registry}/design-system:dev_${it}_${env.CA_STYLEGUIDE_VERSION_TAG}"
-                            // Ignore failures from docker - it's probably an Image Not Found.
-                            // Other errors like out of disk space will cause problems in other commands
-                            try {
-                                docker.image("${docker_registry}/design-system:${it}").pull()
-                                if (env.BRANCH_NAME != 'master') {
-                                        docker.image(images[it]).pull()
-                                }
-                            } catch (Exception e) {
-                                    echo "Error pulling ${images[it]}"
-                            }
-                        }
-                    }
-                }
-                script { sh 'docker-compose build' }
-                script {
-                    docker.withRegistry(docker_registry_url, ecr_credential) {
-                        // Push updated containers so they can be used on the next run
-                        ['ca-styleguide', 'wcag', 'ruby'].each {
-                            if (env.BRANCH_NAME == 'master') {
-                                // If we're building on master, update the master images.
-                                // The tag function only changes the last part of the image name (unlike docker tag)
-                                docker.image("${images[it]}").tag("${it}")
-                                docker.image("${docker_registry}/design-system:${it}").push()
-                            } else {
-                                docker.image("${images[it]}").push()
-                            }
-                        }
-                    }
-                }
-            }
-        }
-        stage('Lint') {
-            environment {
-                PRODUCTION="true"
-                NODE_ENV="test"
-            }
-            steps {
-                script { env.BUILD_STAGE = 'Lint' }
-                withDockerSandbox([ images['ca-styleguide'], images['ruby'] ]) {
-                    sh 'docker-compose run ruby-tests bundle exec rake ruby:lint'
-                    sh 'docker-compose run ca-styleguide bundle exec rake npm:lint'
-                }
-            }
-        }
-        stage('Unit test') {
-            environment {
-                PRODUCTION="true"
-                NODE_ENV="test"
-            }
-            steps {
-                script { env.BUILD_STAGE = 'Unit test' }
-                withDockerSandbox([ images['ca-styleguide'] ]) {
-                    sh 'docker-compose run ca-styleguide bundle exec rake npm:jest'
-                }
-            }
-        }
-        stage('Sanity Test') {
-            steps {
-                script { env.BUILD_STAGE = 'Sanity Test' }
-                withDockerSandbox([
-                    images['ca-styleguide'],
-                    'backstopjs/backstopjs',
-                    images['ruby'],
-                    images['wcag'],
-                    'selenium/hub:4.0.0-alpha-6-20200609',
-                    'selenium/node-chrome:4.0.0-alpha-6-20200609',
-                    'selenium/node-firefox:4.0.0-alpha-6-20200609' ]) {
-                    script {
-                        try {
-                            sh './bin/jenkins/visual_regression'
-                            sh './bin/docker/a11y-test'
-                            sh './bin/docker/grid_tests'
-                        } catch (Exception e) {
-                            sh 'docker-compose logs --no-color'
-                            currentBuild.result = 'FAILURE'
-                            throw e
-                        }
-                    }
-                }
-            }
-        }
-        stage('Full Regression Test') {
-            steps {
-                script {
-                    if (deployBranches.contains(BRANCH_NAME)) {
-                        env.BUILD_STAGE = 'Full Regression Test'
-                        withVaultSecrets([
-                            BROWSERSTACK_USERNAME: '/secret/devops/public-website/develop/env, BROWSERSTACK_USERNAME',
-                            BROWSERSTACK_ACCESS_KEY: '/secret/devops/public-website/develop/env, BROWSERSTACK_ACCESS_KEY',
-                        ])
-                        {
-                            withDockerSandbox {
-                                configurationTypes.each { opts ->
-                                    def (config, browser) = opts
-                                    sh "BROWSERSTACK_CONFIGURATION_OPTIONS=$config BROWSER=$browser ./bin/docker/browserstack_tests"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
-    }
+      withEnv(["DOCKER_TAG=${dockerTag()}",
+              // Using the commit SHA would mean that every build
+              // gets a different tag and this busts the cache between PR builds.
+              "CA_STYLEGUIDE_VERSION_TAG=${env.BRANCH_NAME}"
+            ]) {
+        currentBuild.displayName = "$BUILD_NUMBER: $DOCKER_TAG"
 
-    post {
-        always {
-            step([$class: 'JUnitResultArchiver',
-                testResults: 'testing/visual-regression/backstop_data/ci_report/*.xml',
-                allowEmptyResults: true,
-            ])
-            sh './bin/jenkins/fix_visual_test_report'
-            publishHTML([
-                allowMissing: true,
-                alwaysLinkToLastBuild: true,
-                keepAll: true,
-                reportDir: 'reports/html_report',
-                reportFiles: 'index.html',
-                reportName: 'BackstopJS Report',
-            ])
-            archiveArtifacts([
-                artifacts: 'testing/artifacts/screenshots/*.png, ' +
-                'testing/artifacts/reports/report.html, ' +
-                'testing/artifacts/reports/*.xml, ' +
-                'testing/artifacts/reports/report.json, ' +
-                'testing/artifacts/html_pages/*.html, ' +
-                'testing/artifacts/logs/*.log',
-                allowEmptyArchive: true,
-                caseSensitive: false
-            ])
-            script {
-                if (deployBranches.contains(BRANCH_NAME)) {
-                    try {
-                        withSlackNotifier([
-                            stage: env.BUILD_STAGE,
-                            channel: params.slackChannel,
-                            credentialsId: params.slackCredentialsId,
-                            message: "${sh(returnStdout: true, script: 'git log -1')}" +
-                                     "\nBackstop: ${BUILD_URL}BackstopJS_20Report/",]) {
-                            if (currentBuild.currentResult != 'SUCCESS') {
-                                throw new Exception("Build Failed: ${currentBuild.currentResult}")
-                            }
-                                     }
+        docker.withRegistry(docker_registry_url, ecr_credential) {
+          // Pull the master images and any previous builds if we're on a different branch
+          // docker-compose only looks in the local images and doesn't try to pull when building
+          ['ca-styleguide', 'wcag', 'ruby'].each {
+            images[it] = "${docker_registry}/design-system:dev_${it}_${env.CA_STYLEGUIDE_VERSION_TAG}"
+            // Ignore failures from docker - it's probably an Image Not Found.
+            // Other errors like out of disk space will cause problems in other commands
+            try {
+              docker.image("${docker_registry}/design-system:${it}").pull()
+              if (env.BRANCH_NAME != 'master') {
+                docker.image(images[it]).pull()
+              }
+            } catch (Exception e) {
+              echo "Error pulling ${images[it]}"
+            }
+          }
+        }
+        sh 'docker-compose build'
+        docker.withRegistry(docker_registry_url, ecr_credential) {
+          // Push updated containers so they can be used on the next run
+          ['ca-styleguide', 'wcag', 'ruby'].each {
+            if (env.BRANCH_NAME == 'master') {
+              // If we're building on master, update the master images.
+              // The tag function only changes the last part of the image name (unlike docker tag)
+              docker.image("${images[it]}").tag("${it}")
+              docker.image("${docker_registry}/design-system:${it}").push()
+            } else {
+              docker.image("${images[it]}").push()
+            }
+          }
+        }
+      }
+    }
+  }
+
+  stage('Lint') {
+    slackNotifyReleaseOnly {
+      withDockerSandbox([ images['ca-styleguide'], images['ruby'] ]) {
+        withEnv(['PRODUCTION=true', 'NODE_ENV=test']) {
+          sh 'docker-compose run ruby-tests bundle exec rake ruby:lint'
+          sh 'docker-compose run ca-styleguide bundle exec rake npm:lint'
+        }
+      }
+    }
+  }
+  stage('Unit test') {
+    slackNotifyReleaseOnly {
+      withDockerSandbox([ images['ca-styleguide'] ]) {
+        withEnv(['PRODUCTION=true', 'NODE_ENV=test']) {
+          sh 'docker-compose run ca-styleguide bundle exec rake npm:jest'
+        }
+      }
+      step([$class: 'JUnitResultArchiver',
+                  testResults: 'testing/visual-regression/backstop_data/ci_report/*.xml',
+                  allowEmptyResults: true,
+              ])
+    }
+  }
+  stage('Visual Regression Tests') {
+    slackNotifyReleaseOnly {
+      withDockerSandbox([
+                images['ca-styleguide'],
+                'backstopjs/backstopjs'
+            ]) {
+        try {
+          sh './bin/jenkins/visual_regression'
                     } catch (Exception e) {
-                    // do nothing, exception just used to trigger failure message.
-                    }
+          sh 'docker-compose logs --no-color'
+          currentBuild.result = 'FAILURE'
+          throw e
+        } finally {
+          sh './bin/jenkins/fix_visual_test_report'
+          publishHTML([
+                          allowMissing: true,
+                          alwaysLinkToLastBuild: true,
+                          keepAll: true,
+                          reportDir: 'reports/html_report',
+                          reportFiles: 'index.html',
+                          reportName: 'BackstopJS Report',
+                      ])
+        }
+      }
+    }
+  }
+  stage('Accessibility Tests') {
+    slackNotifyReleaseOnly {
+      withDockerSandbox([
+                images['ca-styleguide'],
+                images['ruby'],
+                images['wcag'] ]) {
+        try {
+          sh './bin/docker/a11y-test'
+        } catch (Exception e) {
+          sh 'docker-compose logs --no-color'
+          currentBuild.result = 'FAILURE'
+          throw e
+        }
+      }
+    }
+  }
+}
+
+grid_tests = [:]
+['chrome', 'firefox'].each { browser ->
+  grid_tests[browser] = {
+     withCucumberNode("Interim Stage: Test ${browser}",
+                [
+                    images['ruby'],
+                    'selenium/hub:4.0.0-alpha-6-20200609',
+                    "selenium/node-${browser}:4.0.0-alpha-6-20200609"
+                ]
+            ) {
+                try {
+                    sh "BROWSER=${browser} bin/docker/grid_tests"
+                } catch (Exception e) {
+                    sh 'docker-compose logs --no-color'
+                    currentBuild.result = 'FAILURE'
+                    throw e
                 }
             }
+  }
+}
+grid_tests['regression'] = {
+          stage('Full Regression Test') {
+            node(nodeLabel) {
+              unstash 'source'
+              if (deployBranches.contains(env.BRANCH_NAME)) {
+                  env.BUILD_STAGE = 'Full Regression Test'
+                  withVaultSecrets([
+                      BROWSERSTACK_USERNAME: '/secret/devops/public-website/develop/env, BROWSERSTACK_USERNAME',
+                      BROWSERSTACK_ACCESS_KEY: '/secret/devops/public-website/develop/env, BROWSERSTACK_ACCESS_KEY',
+                  ])
+                  {
+                      withDockerSandbox {
+                          configurationTypes.each { opts ->
+                              def (config, browser) = opts
+                              sh "BROWSERSTACK_CONFIGURATION_OPTIONS=$config BROWSER=$browser ./bin/docker/browserstack_tests"
+                          }
+                      }
+                  }
+              }
+            }
+          }
+        }
 
-            cleanWs()
-        }
-        cleanup {
-            sh 'rm -rf reports'
-        }
-    }
+grid_tests.failFast = false
+
+parallel grid_tests
+
+
+def withCucumberNode(def description, def imageMap, Closure body) {
+  node('docker && awsaccess') {
+        stage(description) {
+          unstash 'source'
+          slackNotifyReleaseOnly {
+            withDockerSandbox(imageMap) {
+              // Call closure
+              body()
+            } // withDockerSandbox
+          } //slack
+    } // stage
+  } // node
+} // withCucumberNode
+
+def dockerTag() {
+  "${env.BRANCH_NAME}_${getSha()}"
+}
+
+
+// archiveArtifacts([
+//                 artifacts: 'testing/artifacts/screenshots/*.png, ' +
+//                 'testing/artifacts/reports/report.html, ' +
+//                 'testing/artifacts/reports/*.xml, ' +
+//                 'testing/artifacts/reports/report.json, ' +
+//                 'testing/artifacts/html_pages/*.html, ' +
+//                 'testing/artifacts/logs/*.log',
+//                 allowEmptyArchive: true,
+//                 caseSensitive: false
+//             ])
+
+def slackNotifyReleaseOnly(Closure body) {
+  if (!isRelease) {
+    body()
+    return
+  }
+  withSlackNotifier([
+                      channel: params.slackChannel,
+                      credentialsId: params.slackCredentialsId,
+                      message: "${sh(returnStdout: true, script: 'git log -1')}" +
+                                "\nBackstop: ${BUILD_URL}BackstopJS_20Report/",]) {
+    body()
+  }
 }


### PR DESCRIPTION
rewrite of https://github.com/citizensadvice/design-system/pull/482 which uses scripted pipeline. Mixing declarative with scripted code in the Jenkinsfile is not a good idea.

Feel free to ignore this PR or use bits and bobs from it as needed.

Copy / pasting my slack message to @luke-hill here:

> I converted to scripted because mixing scripted / declarative is not recommended.
> 13:13
> couple of things
> 13:13
> archiving artefacts is commented out as I didn’t know which stage it applies to.
> 13:15
> the code can be cleaned up quite a lot more to abstract things away
> 13:16
> not sure if stash 'sources' stashes the .git folder. slackNotifyReleaseOnly relies on it
> 13:20
> and lastly - not sure if the different stages need the image you build in Setup. If they do - you need to
> 13:20
> docker.withRegistry(docker_registry_url, ecr_credential) { docker.image(........).pull()
> 13:21
> if the stage runs on different node. Otherwise docker-compose will rebuild it