### PR TITLE
feat: add variables to allow footer to be styled [NP-662]

### DIFF
--- a/haml/_footer.html.haml
+++ b/haml/_footer.html.haml
@@ -3,7 +3,7 @@
 %footer.cads-footer
   - if feedback_url
     %p.cads-footer__feedback
-      %a{ href: feedback_url, target: "_blank", rel: "noopener" }= t("cads.footer.website_feedback")
+      %a.cads-footer__hyperlink{ href: feedback_url, target: "_blank", rel: "noopener" }= t("cads.footer.website_feedback")
       %span.cads-footer__feedback-icon.cads-icon_external-link
   .cads-grid-container
     .cads-grid-row
@@ -14,7 +14,7 @@
             %ul.cads-footer__links
               - links["column_one"]["links"].each do |link|
                 %li.cads-footer__link
-                  %a{ href: link["url"] }= link["label"]
+                  %a.cads-footer__hyperlink{ href: link["url"] }= link["label"]
       - if links["column_two"]
         .cads-grid-col-md-3
           %h2.cads-footer__section-title= links["column_two"]["title"]
@@ -22,7 +22,7 @@
             %ul.cads-footer__links
               - links["column_two"]["links"].each do |link|
                 %li.cads-footer__link
-                  %a{ href: link["url"] }= link["label"]
+                  %a.cads-footer__hyperlink{ href: link["url"] }= link["label"]
       - if links["column_three"]
         .cads-grid-col-md-3
           %h2.cads-footer__section-title= links["column_three"]["title"]
@@ -30,7 +30,7 @@
             %ul.cads-footer__links
               - links["column_three"]["links"].each do |link|
                 %li.cads-footer__link
-                  %a{ href: link["url"] }= link["label"]
+                  %a.cads-footer__hyperlink{ href: link["url"] }= link["label"]
       - if links["column_four"]
         .cads-grid-col-md-3
           %h2.cads-footer__section-title= links["column_four"]["title"]
@@ -38,7 +38,7 @@
             %ul.cads-footer__links
               - links["column_four"]["links"].each do |link|
                 %li.cads-footer__link
-                  %a{ href: link["url"] }= link["label"]
+                  %a.cads-footer__hyperlink{ href: link["url"] }= link["label"]
 
     .cads-footer__company-info
       .cads-footer__logo

--- a/scss/1-settings/_colour-language.scss
+++ b/scss/1-settings/_colour-language.scss
@@ -31,3 +31,16 @@ $cads-header__link-visited-colour: $cads-language__link-visited-colour !default;
 $cads-header__link-active-colour: $cads-language__link-active-colour !default;
 $cads-header__link-focus-highlight-colour: $cads-palette__black !default;
 $cads-header__link-focus-colour: $cads-language__focus-colour !default;
+
+// Footer colours
+$cads-footer__divider-colour: $cads-language__brand-primary !default;
+$cads-footer__background-colour: $cads-palette__blue-light !default;
+$cads-footer__text-colour: $cads-palette__black !default;
+$cads-footer__text-secondary-colour: $cads-language__brand-primary !default;
+$cads-footer__link-colour: $cads-language__link-colour !default;
+$cads-footer__link-hover-colour: $cads-language__link-hover-colour !default;
+$cads-footer__hover-background-colour: $cads-language__hover-background-colour !default;
+$cads-footer__link-visited-colour: $cads-language__link-visited-colour !default;
+$cads-footer__link-active-colour: $cads-language__link-active-colour !default;
+$cads-footer__link-focus-highlight-colour: $cads-palette__black !default;
+$cads-footer__link-focus-colour: $cads-language__focus-colour !default;

--- a/scss/6-components/_footer.scss
+++ b/scss/6-components/_footer.scss
@@ -6,12 +6,13 @@
 .cads-footer {
   @include cads-typographic-scale-text-small();
 
-  background-color: $cads-palette__blue-light;
+  background-color: $cads-footer__background-colour;
   padding: $cads-spacing-4;
 
   .cads-footer__section-title {
     @extend %cads-h4;
 
+    color: $cads-footer__text-colour;
     margin: 0 0 $cads-spacing-2 0;
   }
   .cads-footer__feedback {
@@ -19,8 +20,8 @@
 
     width: 100%;
     text-align: center;
-    color: $cads-language__brand-primary;
-    border-bottom: 1px solid $cads-language__brand-primary;
+    color: $cads-footer__text-secondary-colour;
+    border-bottom: 1px solid $cads-footer__divider-colour;
     padding-bottom: $cads-spacing-4;
     margin: 0 0 $cads-spacing-4 0;
 
@@ -33,8 +34,32 @@
       margin-left: 0.5ch;
     }
   }
+
   .cads-footer__links {
     @extend %cads-list-no-bullet;
+  }
+
+  .cads-footer__hyperlink {
+    color: $cads-footer__link-colour;
+
+    &:hover {
+      color: $cads-footer__link-hover-colour;
+      background-color: $cads-footer__hover-background-colour;
+    }
+
+    &:active {
+      color: $cads-footer__link-active-colour;
+    }
+
+    &:focus {
+      color: $cads-palette__black;
+      background-color: $cads-footer__link-focus-colour;
+      border-bottom: 2px solid $cads-footer__link-focus-highlight-colour;
+    }
+
+    &:visited {
+      color: $cads-footer__link-visited-colour;
+    }
   }
 
   .cads-footer__links .cads-footer__link {
@@ -45,6 +70,7 @@
   .cads-footer__company-info {
     @include cads-restrict-content-width();
 
+    color: $cads-footer__text-colour;
     padding-top: $cads-spacing-5;
     border-top: 1px solid $cads-language__border-colour;
 


### PR DESCRIPTION
This PR adds variables to the footer to allow it to be styled correctly for AdviserNet.

**The logo is wrong in this screenshot, but here's an example of what's possible**

<img width="916" alt="Screenshot 2020-11-11 at 15 46 05" src="https://user-images.githubusercontent.com/45935/98833023-70d7f580-2435-11eb-9323-2de5ff4f740b.png">
