### PR TITLE
fix: footer variables to allow for full styling

### DIFF
--- a/scss/1-settings/_colour-language.scss
+++ b/scss/1-settings/_colour-language.scss
@@ -42,5 +42,6 @@ $cads-footer__link-hover-colour: $cads-language__link-hover-colour !default;
 $cads-footer__hover-background-colour: $cads-language__hover-background-colour !default;
 $cads-footer__link-visited-colour: $cads-language__link-visited-colour !default;
 $cads-footer__link-active-colour: $cads-language__link-active-colour !default;
-$cads-footer__link-focus-highlight-colour: $cads-palette__black !default;
-$cads-footer__link-focus-colour: $cads-language__focus-colour !default;
+$cads-footer__link-focus-colour: $cads-palette__black !default;
+$cads-footer__link-focus-background-colour: $cads-language__focus-colour !default;
+$cads-footer__link-focus-border-colour: $cads-palette__black !default;

--- a/scss/6-components/_footer.scss
+++ b/scss/6-components/_footer.scss
@@ -52,9 +52,9 @@
     }
 
     &:focus {
-      color: $cads-palette__black;
-      background-color: $cads-footer__link-focus-colour;
-      border-bottom: 2px solid $cads-footer__link-focus-highlight-colour;
+      color: $cads-footer__link-focus-colour;
+      background-color: $cads-footer__link-focus-background-colour;
+      border-bottom: 2px solid $cads-footer__link-focus-border-colour;
     }
 
     &:visited {


### PR DESCRIPTION
Needed to add these variables to fully allow for advisernet footer styling

**(don't mention the logo!)**

<img width="1075" alt="Screenshot 2020-11-12 at 16 42 28" src="https://user-images.githubusercontent.com/45935/98968804-0e9af580-2506-11eb-9a23-b1283e2677ca.png">
