### PR TITLE
Release/v2.1.0 alpha.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## <sub>v2.1.0-alpha.2</sub>
+
+#### _Nov. 12, 2020_
+
 **Bugfixes**:
 
 - Forms: Fix error message display on inline radio buttons and fixed width inputs (NP-1275)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@citizensadvice/design-system",
-  "version": "2.1.0-alpha.1",
+  "version": "2.1.0-alpha.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@citizensadvice/design-system",
-  "version": "2.1.0-alpha.1",
+  "version": "2.1.0-alpha.2",
   "description": "Citizens Advice Design System",
   "files": [
     "scss",

--- a/stats/size.json
+++ b/stats/size.json
@@ -608,6 +608,15 @@
           "size": 73324
         }
       ]
+    },
+    {
+      "version": "2.1.0-alpha.2",
+      "stats": [
+        {
+          "filename": "lib.css",
+          "size": 58327
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
```
lib.css decreased by 20%/14997b (58327 vs 73324)
These files have changed size over 10%:
```

(for once!)

This is just a patch release on previous alphas to add more styling variables to header, footer and search button.