### PR TITLE
Bugfix/more friendly waiters

### DIFF
--- a/testing/features/step_definitions/oisc_warnings_steps.rb
+++ b/testing/features/step_definitions/oisc_warnings_steps.rb
@@ -24,7 +24,7 @@ When("I scroll to the top of the page") do
 end
 
 When("I close the sticky component") do
-  @component.wait_until_close_sticky_visible(wait: 5) if ios? || safari?
+  @component.wait_until_close_sticky_visible(wait: 5)
   @component.close_sticky.click
 end
 

--- a/testing/features/step_definitions/oisc_warnings_steps.rb
+++ b/testing/features/step_definitions/oisc_warnings_steps.rb
@@ -24,6 +24,7 @@ When("I scroll to the top of the page") do
 end
 
 When("I close the sticky component") do
+  @component.wait_until_close_sticky_visible(wait: 5) if ios?
   @component.close_sticky.click
 end
 

--- a/testing/features/step_definitions/oisc_warnings_steps.rb
+++ b/testing/features/step_definitions/oisc_warnings_steps.rb
@@ -24,7 +24,7 @@ When("I scroll to the top of the page") do
 end
 
 When("I close the sticky component") do
-  @component.wait_until_close_sticky_visible(wait: 5) if ios?
+  @component.wait_until_close_sticky_visible(wait: 5) if ios? || safari?
   @component.close_sticky.click
 end
 

--- a/testing/features/support/helpers/env_variables.rb
+++ b/testing/features/support/helpers/env_variables.rb
@@ -76,6 +76,10 @@ module Helpers
       ENV.fetch("BROWSERSTACK_CONFIGURATION_OPTIONS").split("_")[2]
     end
 
+    def ios?
+      ios12? || ios13?
+    end
+
     def ios13?
       browserstack? && browserstack_os_version == "13"
     end

--- a/testing/features/support/helpers/javascript.rb
+++ b/testing/features/support/helpers/javascript.rb
@@ -38,9 +38,6 @@ module Helpers
     end
 
     def js_delay_time
-      return 2.5 if ios12?
-      return 1 if device? || safari?
-
       0.5
     end
   end


### PR DESCRIPTION
Given we were using hard coded sleeps. This "inevitably" failed when the time wasn't long enough in a single situation (The one in which we stipulated the longest 2.5 second sleep).

Now we revert back to a 0.5 second sleep. But add an additional conditional 5 second sleep based on the element appearing in time.

This will have no effect on the fast browsers (They still have a 0.5s delay), but on the slower ones it will wait up to 5.5s +/- a tolerance. If they don't pass here, then I'm not sure what we can do. Probably need to tag them and go back to the drawing board!

:crossed_fingers: 