### PR TITLE
feature: Page Review Spec [NP-1183]

### DIFF
--- a/testing/features/page_review.feature
+++ b/testing/features/page_review.feature
@@ -1,0 +1,12 @@
+Feature: Page Review component
+
+  The Page Review component reassures the public that the content
+  they are viewing is up to date
+
+  Rule: Standard Page Review text
+    Background:
+      Given a Default Page Review component is on the page
+
+    Scenario: Label includes the date
+      Then the date that the page was last updated is present
+      And the date is bold

--- a/testing/features/page_review.feature
+++ b/testing/features/page_review.feature
@@ -5,8 +5,8 @@ Feature: Page Review component
 
   Rule: Standard Page Review text
     Background:
-      Given a Default Page Review component is on the page
+      Given a Standard Page Review component is on the page
 
     Scenario: Label includes the date
-      Then the date that the page was last updated is present
+      Then the date that the page was last reviewed is present
       And the date is bold

--- a/testing/features/step_definitions/page_review_steps.rb
+++ b/testing/features/step_definitions/page_review_steps.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+Given("a Default Page Review component is on the page") do
+  @component = DesignSystem::PageReview.new.tap(&:load)
+end
+
+Then("the date that the page was last updated is present") do
+  expect(@component.initial_form).to have_website_feedback
+end
+
+Then("the date is bold") do
+  expect(@component.category_titles).to all have_links
+end

--- a/testing/features/step_definitions/page_review_steps.rb
+++ b/testing/features/step_definitions/page_review_steps.rb
@@ -1,13 +1,13 @@
 # frozen_string_literal: true
 
-Given("a Default Page Review component is on the page") do
-  @component = DesignSystem::PageReview.new.tap(&:load)
+Given("a Standard Page Review component is on the page") do
+  @component = PageReview::Standard.new.tap(&:load)
 end
 
-Then("the date that the page was last updated is present") do
-  expect(@component.initial_form).to have_website_feedback
+Then("the date that the page was last reviewed is present") do
+  expect(@component).to have_reviewed_on
 end
 
 Then("the date is bold") do
-  expect(@component.category_titles).to all have_links
+  expect(@component).to have_bold_date
 end

--- a/testing/features/support/components/asset_hyperlink.rb
+++ b/testing/features/support/components/asset_hyperlink.rb
@@ -14,5 +14,9 @@ module DesignSystem
         before_content(".cads-icon_file").delete('\\"')
       end
     end
+
+    def validate_initial_state!
+      has_initial_form?(wait: 5)
+    end
   end
 end

--- a/testing/features/support/components/base.rb
+++ b/testing/features/support/components/base.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class Base < SitePrism::Page
+  element :root, "#root"
+
   load_validation do
     AutomationLogger.debug("Waiting for #{self.class} component.")
     [validate_initial_state!, "Initial #{self.class} component didn't load correctly!"]
@@ -14,6 +16,6 @@ class Base < SitePrism::Page
   end
 
   def validate_initial_state!
-    has_initial_form?(wait: 5)
+    has_root?(wait: 5) && !text.empty?
   end
 end

--- a/testing/features/support/components/contact_details.rb
+++ b/testing/features/support/components/contact_details.rb
@@ -8,5 +8,9 @@ module DesignSystem
       elements :paragraphs, "p"
       element :first_bold_paragraph, "p:nth-of-type(1) strong"
     end
+
+    def validate_initial_state!
+      has_initial_form?(wait: 5)
+    end
   end
 end

--- a/testing/features/support/components/footer.rb
+++ b/testing/features/support/components/footer.rb
@@ -14,5 +14,9 @@ module DesignSystem
       element :copyright, ".cads-footer__company-info div p:nth-of-type(1)"
       element :company_info, ".cads-footer__company-info div p:nth-of-type(2)"
     end
+
+    def validate_initial_state!
+      has_initial_form?(wait: 5)
+    end
   end
 end

--- a/testing/features/support/components/page_review/standard.rb
+++ b/testing/features/support/components/page_review/standard.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module PageReview
+  class Standard < ::Base
+    set_url "/iframe.html?id=components-page-review--page-review&viewMode=story"
+
+    element :reviewed_on, ".cads-page-review"
+    element :bold_date, "strong"
+  end
+end


### PR DESCRIPTION
This is a new spec, but a really simple one - As the component is just plain text.

As part of this I refactored all "old" style components to validate the initial form, but the base validation is just the root element is present (And again this is overloaded with most new components).

I did this, as for Page Review there is literally nothing we can wait on we don't already validate on. Because it's such a threadbare component.

NB: I didn't validate date format, as I wasn't sure if we wanted to do this. cc/ @sheldonsmiltnieks Maybe one for you to rule on?