### PR TITLE
Correctly guard for when header is not present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+**Bugfixes**:
+
+- Header: Correctly guard for when header is not present
+
 ## <sub>v2.1.0-alpha.2</sub>
 
 #### _Nov. 12, 2020_

--- a/src/js/header.js
+++ b/src/js/header.js
@@ -6,9 +6,9 @@ const initHeader = () => {
   };
 
   const header = document.querySelector('.cads-header');
-  const controlButton = header.querySelector('.js-cads-search-reveal');
 
-  if (header && controlButton) {
+  if (header) {
+    const controlButton = header.querySelector('.js-cads-search-reveal');
     controlButton.addEventListener('click', () => {
       if (header.classList.contains(CLASS_NAMES.showSearch)) {
         header.classList.remove(CLASS_NAMES.showSearch);
@@ -24,9 +24,6 @@ const initHeader = () => {
         controlButton.title = 'Close search';
       }
     });
-  } else {
-    // eslint-disable-next-line no-console
-    console.warn('Header: no search toggle button found');
   }
 };
 

--- a/src/js/header.test.js
+++ b/src/js/header.test.js
@@ -44,3 +44,8 @@ test('allow toggling search', () => {
   expect(controlButtonEl).toHaveAttribute('aria-expanded', 'true');
   expect(controlButtonEl).toHaveClass('cads-icon_close');
 });
+
+test('only initialises when header is present', () => {
+  document.body.innerHTML = '';
+  expect(() => initHeader()).not.toThrow();
+});


### PR DESCRIPTION
Spotted in https://github.com/citizensadvice/public-website/pull/531

Correctly guard for when header is not present.