### PR TITLE
fix: link pseudo selector ordering and wrap footer in nav element [NP-662]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+**Bugfixes:**
+
+- Links: pseudo selector order fixed for generic links and footer links
+- Footer: links are wrapped in a `nav` element and aria labelled as "Footer Navigation"
 ## <sub>v2.1.0-alpha.3</sub>
 
 #### _Nov. 19, 2020_

--- a/haml/_footer.html.haml
+++ b/haml/_footer.html.haml
@@ -5,7 +5,7 @@
     %p.cads-footer__feedback
       %a.cads-footer__hyperlink{ href: feedback_url, target: "_blank", rel: "noopener" }= t("cads.footer.website_feedback")
       %span.cads-footer__feedback-icon.cads-icon_external-link
-  .cads-grid-container
+  %nav.cads-grid-container{"aria-label": t("cads.footer.navigation_title") }
     .cads-grid-row
       - if links["column_one"]
         .cads-grid-col-md-3

--- a/locales/cy.yml
+++ b/locales/cy.yml
@@ -17,6 +17,7 @@ cy:
       skip_to_nav: Neidio i’r llywio
       skip_to_footer: Neidio i’r troedyn
     footer:
+      navigation_title: Footer Navigation
       website_feedback: A oes unrhyw beth o'i le ar y dudalen hon? Gadewch i ni wybod
     page_review:
       body_html: Adolygwyd y dudalen ar <strong>%{date}</strong>

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -17,6 +17,7 @@ en:
       skip_to_nav: Skip to navigation
       skip_to_footer: Skip to footer
     footer:
+      navigation_title: Footer Navigation
       website_feedback: Is there anything wrong with this page? Let us know
     page_review:
       body_html: Page last reviewed on <strong>%{date}</strong>

--- a/scss/4-elements/_links.scss
+++ b/scss/4-elements/_links.scss
@@ -7,7 +7,6 @@ a,
   color: $cads-language__link-colour;
   text-decoration: underline;
 
-  // Note :visited links should be browser default
   &:visited {
     color: $cads-language__link-visited-colour;
   }

--- a/scss/4-elements/_links.scss
+++ b/scss/4-elements/_links.scss
@@ -8,6 +8,9 @@ a,
   text-decoration: underline;
 
   // Note :visited links should be browser default
+  &:visited {
+    color: $cads-language__link-visited-colour;
+  }
 
   &:hover {
     color: $cads-language__link-hover-colour;
@@ -23,10 +26,6 @@ a,
     background-color: $cads-language__focus-colour;
     text-decoration: none;
     border-bottom: 2px solid $cads-palette__black;
-  }
-
-  &:visited {
-    color: $cads-language__link-visited-colour;
   }
 }
 

--- a/scss/6-components/_footer.scss
+++ b/scss/6-components/_footer.scss
@@ -42,6 +42,10 @@
   .cads-footer__hyperlink {
     color: $cads-footer__link-colour;
 
+    &:visited {
+      color: $cads-footer__link-visited-colour;
+    }
+
     &:hover {
       color: $cads-footer__link-hover-colour;
       background-color: $cads-footer__hover-background-colour;
@@ -55,10 +59,6 @@
       color: $cads-footer__link-focus-colour;
       background-color: $cads-footer__link-focus-background-colour;
       border-bottom: 2px solid $cads-footer__link-focus-border-colour;
-    }
-
-    &:visited {
-      color: $cads-footer__link-visited-colour;
     }
   }
 


### PR DESCRIPTION
This PR is connected to the footer work. The link pseudo selectors need to be defined in this order to correctly style visited links which are focused.

Whilst here also wrapped the footer in a nav element. I'm waiting on translations.