### PR TITLE
feature: Re-validate and re-enable Header tests [NP-761]

### DIFF
--- a/testing/.env.example
+++ b/testing/.env.example
@@ -41,3 +41,6 @@ LOG_LEVEL=INFO
 
 # The base url you want to hit
 APP_URL=https://citizensadvice.github.io/design-system
+
+# The base artifacts path to store your artifacts in
+BASE_ARTIFACTS_PATH=testing/artifacts

--- a/testing/.env.example
+++ b/testing/.env.example
@@ -43,4 +43,5 @@ LOG_LEVEL=INFO
 APP_URL=https://citizensadvice.github.io/design-system
 
 # The base artifacts path to store your artifacts in
-BASE_ARTIFACTS_PATH=testing/artifacts
+# Set to artifacts if running locally, otherwise leave blank
+BASE_ARTIFACTS_PATH=artifacts

--- a/testing/features/header.feature
+++ b/testing/features/header.feature
@@ -1,4 +1,3 @@
-@future_release @v2.1.0+
 Feature: Header component
 
   The Header component allows users to perform some quick tasks
@@ -11,10 +10,9 @@ Feature: Header component
       Given a Standard Header component is on the page
 
     Scenario: Header has some quick links
-      Then a language change link is present
+      Then a link to change language is present
       And a login link is present
       And a header logo is present
 
     Scenario: Header has a search option
-      When I type "Immigration" into the search box
-      Then I can search for "Immigration"
+      Then I am able to search for "Anything"

--- a/testing/features/step_definitions/header_steps.rb
+++ b/testing/features/step_definitions/header_steps.rb
@@ -1,11 +1,10 @@
 # frozen_string_literal: true
 
 Given("a Standard Header component is on the page") do
-  @component = Header::Standard.new
-  @component.load
+  @component = Header::Standard.new.tap(&:load)
 end
 
-Then("a language change link is present") do
+Then("a link to change language is present") do
   expect(@component).to have_change_language
 end
 
@@ -23,7 +22,9 @@ When("I type {string} into the search box") do |search_term|
   @component.search_field.send_keys(search_term)
 end
 
-Then("I can search for {string}") do |search_term|
+Then("I am able to search for {string}") do |search_term|
+  @component.search_field.send_keys(search_term)
+
   expect(@component.search_field.value).to eq(search_term)
 
   expect(@component).to have_search_button


### PR DESCRIPTION
After all refactor work the header tests are now stable and can be re-enabled.

I've tacked on a slight bug-fix to the `env.example` file to enable local running. Users should set the new variable to `artifacts` locally.