### PR TITLE
feat: Set logo links in header and footer via template local [NP-1274]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+**New**
+- Footer: Logo link can be set by haml template locals
+- Header: Logo link can be set by haml template locals
+
 ## <sub>v3.1.0</sub>
 
 #### _Nov. 26, 2020_

--- a/haml/_footer.html.haml
+++ b/haml/_footer.html.haml
@@ -1,5 +1,8 @@
-- feedback_url ||= false
-- links ||= {}
+:ruby
+  feedback_url ||= false
+  links ||= {}
+  homepage_url ||= "/"
+
 %footer#cads-footer.cads-footer
   - if feedback_url
     %p.cads-footer__feedback
@@ -21,7 +24,7 @@
                       %span{ class: "cads-footer__icon cads-icon_#{link['icon']}" }
     .cads-footer__company-info
       .cads-footer__logo
-        %a.cads-logo{ href: root_path, title: t("cads.shared.logo_title") }
+        %a.cads-logo{ href: homepage_url, title: t("cads.shared.logo_title") }
       .cads-footer__meta
         %p.cads-footer__meta-text= t("cads.shared.copyright")
         %p.cads-footer__meta-text= t("cads.shared.legal_summary")

--- a/haml/_header.html.haml
+++ b/haml/_header.html.haml
@@ -2,6 +2,7 @@
   links ||= []
   sign_in_out ||= {}
   main_content_anchor_link ||= "#cads-main-content"
+  homepage_url ||= "/"
 
 %header.cads-header
   .cads-grid-container
@@ -14,7 +15,7 @@
         %a.cads-skip-links__link{ href: "#cads-footer" }
           = t("cads.header.skip_to_footer")
       .cads-grid-col-md-6.cads-header__logo-row
-        %a.cads-logo{ href: root_path, title: t("cads.shared.logo_title") }
+        %a.cads-logo{ href: homepage_url, title: t("cads.shared.logo_title") }
         %button.cads-header__search-reveal.js-cads-search-reveal.cads-icon_search{ title: t("cads.header.search_mobile"), "aria-expanded": "false" }
       .cads-grid-col-md-6.cads-header__search-row
         %ul.cads-header__links

--- a/styleguide/components/footer/footer.stories.mdx
+++ b/styleguide/components/footer/footer.stories.mdx
@@ -41,6 +41,7 @@ The Haml partial the following locals:
 | `links[url]`    | &rarr; Required, url for the sign in link                  |
 | `links[label] ` | &rarr; Required, title for the sign in link                |
 | `links[icon] `  | &rarr; Optional, display an icon next to the link          |
+| `homepage_url`  | Optional, defaults to `/`                                  |
 
 ### links
 

--- a/styleguide/components/header/header.stories.mdx
+++ b/styleguide/components/header/header.stories.mdx
@@ -28,7 +28,7 @@ import linksVariable from '!!raw-loader!./links_example.rb';
 
 ## Haml template options
 
-The Haml partial the following locals:
+The Haml partial supports the following locals:
 
 | Property                   | Description                                             |
 | -------------------------- | ------------------------------------------------------- |
@@ -39,6 +39,7 @@ The Haml partial the following locals:
 | `sign_in_out[title] `      | &rarr; Required, title for the sign in link             |
 | `search_action_url`        | Required, URL for the search form                       |
 | `main_content_anchor_link` | Optional, defaults to `#cads-main-content`              |
+| `homepage_url`             | Optional, defaults to `/`                               |
 
 ### `links` template option
 

--- a/styleguide/haml_locals.rb
+++ b/styleguide/haml_locals.rb
@@ -120,7 +120,8 @@
     "root_path" => "#",
     "links" => [{ "title" => "AdviserNet", "url" => "?advisernet" }, { "title" => "Cymraeg", "url" => "?lang=cy" }],
     "sign_in_out" => { "title" => "Sign out", "url" => "/sign-out/out" },
-    "search_action_url" => "/search"
+    "search_action_url" => "/search",
+    "homepage_url" => "/"
   },
 
   "alt_language" => {
@@ -185,7 +186,7 @@
 
   "footer" => {
     "feedback_url" => "https://www.research.net/r/J8PLH2H",
-
+    "homepage_url" => "/",
     "links" => {
       "column_one" => {
         "title" => "Advice",


### PR DESCRIPTION
This PR updates the header and footer to accept a "homepage_url" which
allows the consuming code to configure it appropriately.