### PR TITLE
feature: Spec: Skip links (Header only) [NP-1181]

### DIFF
--- a/haml/_header.html.haml
+++ b/haml/_header.html.haml
@@ -8,11 +8,11 @@
   .cads-grid-container
     .cads-grid-row
       %nav.cads-skip-links
-        %a.cads-skip-links__link{ href: "#cads-navigation", data: {test_id: "skip-link" } }
+        %a.cads-skip-links__link{ href: "#cads-navigation" }
           = t("cads.header.skip_to_navigation")
-        %a.cads-skip-links__link{ href: main_content_anchor_link, data: {test_id: "skip-link" } }
+        %a.cads-skip-links__link{ href: main_content_anchor_link }
           = t("cads.header.skip_to_content")
-        %a.cads-skip-links__link{ href: "#cads-footer", data: {test_id: "skip-link" } }
+        %a.cads-skip-links__link{ href: "#cads-footer" }
           = t("cads.header.skip_to_footer")
       .cads-grid-col-md-6.cads-header__logo-row
         %a.cads-logo{ href: homepage_url, title: t("cads.shared.logo_title") }

--- a/haml/_header.html.haml
+++ b/haml/_header.html.haml
@@ -8,11 +8,11 @@
   .cads-grid-container
     .cads-grid-row
       %nav.cads-skip-links
-        %a.cads-skip-links__link{ href: "#cads-navigation" }
+        %a.cads-skip-links__link{ data: { test_id: "skip_link", test_id: "skip_to_navigation" }, href: "#cads-navigation" }
           = t("cads.header.skip_to_nav")
-        %a.cads-skip-links__link{ href: main_content_anchor_link }
+        %a.cads-skip-links__link{ data: { test_id: "skip_link", test_id: "skip_to_content" }, href: main_content_anchor_link }
           = t("cads.header.skip_to_content")
-        %a.cads-skip-links__link{ href: "#cads-footer" }
+        %a.cads-skip-links__link{ data: { test_id: "skip_link", test_id: "skip_to_footer" }, href: "#cads-footer" }
           = t("cads.header.skip_to_footer")
       .cads-grid-col-md-6.cads-header__logo-row
         %a.cads-logo{ href: homepage_url, title: t("cads.shared.logo_title") }

--- a/haml/_header.html.haml
+++ b/haml/_header.html.haml
@@ -8,11 +8,11 @@
   .cads-grid-container
     .cads-grid-row
       %nav.cads-skip-links
-        %a.cads-skip-links__link{ href: "#cads-navigation" }
+        %a.cads-skip-links__link{ href: "#cads-navigation", data: {test_id: "skip-link" } }
           = t("cads.header.skip_to_navigation")
-        %a.cads-skip-links__link{ href: main_content_anchor_link }
+        %a.cads-skip-links__link{ href: main_content_anchor_link, data: {test_id: "skip-link" } }
           = t("cads.header.skip_to_content")
-        %a.cads-skip-links__link{ href: "#cads-footer" }
+        %a.cads-skip-links__link{ href: "#cads-footer", data: {test_id: "skip-link" } }
           = t("cads.header.skip_to_footer")
       .cads-grid-col-md-6.cads-header__logo-row
         %a.cads-logo{ href: homepage_url, title: t("cads.shared.logo_title") }

--- a/haml/_header.html.haml
+++ b/haml/_header.html.haml
@@ -8,11 +8,11 @@
   .cads-grid-container
     .cads-grid-row
       %nav.cads-skip-links
-        %a.cads-skip-links__link{ data: { test_id: "skip_link" }, href: "#cads-navigation" }
+        %a.cads-skip-links__link{ href: "#cads-navigation" }
           = t("cads.header.skip_to_navigation")
-        %a.cads-skip-links__link{ data: { test_id: "skip_link" }, href: main_content_anchor_link }
+        %a.cads-skip-links__link{ href: main_content_anchor_link }
           = t("cads.header.skip_to_content")
-        %a.cads-skip-links__link{ data: { test_id: "skip_link" }, href: "#cads-footer" }
+        %a.cads-skip-links__link{ href: "#cads-footer" }
           = t("cads.header.skip_to_footer")
       .cads-grid-col-md-6.cads-header__logo-row
         %a.cads-logo{ href: homepage_url, title: t("cads.shared.logo_title") }

--- a/haml/_header.html.haml
+++ b/haml/_header.html.haml
@@ -8,11 +8,11 @@
   .cads-grid-container
     .cads-grid-row
       %nav.cads-skip-links
-        %a.cads-skip-links__link{ data: { test_id: "skip_link", test_id: "skip_to_navigation" }, href: "#cads-navigation" }
+        %a.cads-skip-links__link{ data: { test_id: "skip_link" }, href: "#cads-navigation" }
           = t("cads.header.skip_to_navigation")
-        %a.cads-skip-links__link{ data: { test_id: "skip_link", test_id: "skip_to_content" }, href: main_content_anchor_link }
+        %a.cads-skip-links__link{ data: { test_id: "skip_link" }, href: main_content_anchor_link }
           = t("cads.header.skip_to_content")
-        %a.cads-skip-links__link{ data: { test_id: "skip_link", test_id: "skip_to_footer" }, href: "#cads-footer" }
+        %a.cads-skip-links__link{ data: { test_id: "skip_link" }, href: "#cads-footer" }
           = t("cads.header.skip_to_footer")
       .cads-grid-col-md-6.cads-header__logo-row
         %a.cads-logo{ href: homepage_url, title: t("cads.shared.logo_title") }

--- a/haml/_header.html.haml
+++ b/haml/_header.html.haml
@@ -9,7 +9,7 @@
     .cads-grid-row
       %nav.cads-skip-links
         %a.cads-skip-links__link{ data: { test_id: "skip_link", test_id: "skip_to_navigation" }, href: "#cads-navigation" }
-          = t("cads.header.skip_to_nav")
+          = t("cads.header.skip_to_navigation")
         %a.cads-skip-links__link{ data: { test_id: "skip_link", test_id: "skip_to_content" }, href: main_content_anchor_link }
           = t("cads.header.skip_to_content")
         %a.cads-skip-links__link{ data: { test_id: "skip_link", test_id: "skip_to_footer" }, href: "#cads-footer" }

--- a/locales/cy.yml
+++ b/locales/cy.yml
@@ -14,7 +14,7 @@ cy:
     header:
       search_mobile: Ymchwiliad agored
       skip_to_content: Neidio i’r cynnwys
-      skip_to_nav: Neidio i’r llywio
+      skip_to_navigation: Neidio i’r llywio
       skip_to_footer: Neidio i’r troedyn
     footer:
       navigation_title: Footer Navigation

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -14,7 +14,7 @@ en:
     header:
       search_mobile: Open search
       skip_to_content: Skip to content
-      skip_to_nav: Skip to navigation
+      skip_to_navigation: Skip to navigation
       skip_to_footer: Skip to footer
     footer:
       navigation_title: Footer Navigation

--- a/testing/features/header.feature
+++ b/testing/features/header.feature
@@ -48,7 +48,7 @@ Feature: Header component
       Examples:
         | area       |
         | navigation |
-        | header     |
+        | content    |
         | footer     |
 
     Scenario Outline: Welsh Users can quickly navigate to various areas of the page
@@ -59,5 +59,5 @@ Feature: Header component
       Examples:
         | area       |
         | navigation |
-        | header     |
+        | content    |
         | footer     |

--- a/testing/features/header.feature
+++ b/testing/features/header.feature
@@ -5,6 +5,10 @@ Feature: Header component
   - Change Language Between English and Welsh
   - Make a search
 
+  It also allows the user as per new WCAG Guidelines to skip the top part
+  of the page and move straight to the Navigation/Content/Footer by using
+  their "Tab" key on the keyboard
+
   Rule: A Standard Header
     Background:
       Given a Standard Header component is on the page
@@ -17,3 +21,8 @@ Feature: Header component
 
     Scenario: Header has a search option
       Then I am able to search for "Anything"
+
+    Scenario: User can Quickly Navigate to various Sections of the page
+      When I skip to the <area> part of the page
+      Then the URL will link me to the <area> part of the page
+      

--- a/testing/features/header.feature
+++ b/testing/features/header.feature
@@ -38,7 +38,7 @@ Feature: Header component
       Examples:
         | area       |
         | navigation |
-        | header     |
+        | content    |
         | footer     |
 
     Scenario Outline: English Users can quickly navigate to various areas of the page

--- a/testing/features/header.feature
+++ b/testing/features/header.feature
@@ -22,7 +22,42 @@ Feature: Header component
     Scenario: Header has a search option
       Then I am able to search for "Anything"
 
-    Scenario: User can Quickly Navigate to various Sections of the page
+    Scenario Outline: English Users are able to navigate to various areas of the page
+      Then there is a hidden link to quickly skip to the <area> part of the page
+
+      Examples:
+        | area       |
+        | navigation |
+        | header     |
+        | footer     |
+
+    Scenario Outline: Welsh Users are able to navigate to various areas of the page
+      Given the language is Welsh
+      Then there is a hidden link to quickly skip to the <area> part of the page
+
+      Examples:
+        | area       |
+        | navigation |
+        | header     |
+        | footer     |
+
+    Scenario Outline: English Users can quickly navigate to various areas of the page
       When I skip to the <area> part of the page
-      Then the URL will link me to the <area> part of the page
-      
+      Then the URL will have linked me to the <area> part of the page
+
+      Examples:
+        | area       |
+        | navigation |
+        | header     |
+        | footer     |
+
+    Scenario Outline: Welsh Users can quickly navigate to various areas of the page
+      Given the language is Welsh
+      When I skip to the <area> part of the page
+      Then the URL will have linked me to the <area> part of the page
+
+      Examples:
+        | area       |
+        | navigation |
+        | header     |
+        | footer     |

--- a/testing/features/header.feature
+++ b/testing/features/header.feature
@@ -24,7 +24,7 @@ Feature: Header component
 
     @future_release @v3.1.0+ @not_mobile
     Scenario Outline: English Users can quickly navigate to various areas of the page
-      Then I can skip to the <area> area
+      Then I am able to skip to the <area> part of the page
 
       Examples:
         | area       |
@@ -35,7 +35,7 @@ Feature: Header component
     @future_release @v3.1.0+ @not_mobile
     Scenario Outline: Welsh Users can quickly navigate to various areas of the page
       Given the language is Welsh
-      Then I can skip to the <area> area
+      Then I am able to skip to the <area> part of the page
 
       Examples:
         | area       |

--- a/testing/features/header.feature
+++ b/testing/features/header.feature
@@ -22,28 +22,9 @@ Feature: Header component
     Scenario: Header has a search option
       Then I am able to search for "Anything"
 
-    Scenario Outline: English Users are able to navigate to various areas of the page
-      Then there is a hidden link to quickly skip to the <area> part of the page
-
-      Examples:
-        | area       |
-        | navigation |
-        | content    |
-        | footer     |
-
-    Scenario Outline: Welsh Users are able to navigate to various areas of the page
-      Given the language is Welsh
-      Then there is a hidden link to quickly skip to the <area> part of the page
-
-      Examples:
-        | area       |
-        | navigation |
-        | content    |
-        | footer     |
-
+    @future_release @v3.1.0+ @not_mobile
     Scenario Outline: English Users can quickly navigate to various areas of the page
-      When I skip to the <area> part of the page
-      Then the URL will have linked me to the <area> part of the page
+      Then I can skip to the <area> area
 
       Examples:
         | area       |
@@ -51,10 +32,10 @@ Feature: Header component
         | content    |
         | footer     |
 
+    @future_release @v3.1.0+ @not_mobile
     Scenario Outline: Welsh Users can quickly navigate to various areas of the page
       Given the language is Welsh
-      When I skip to the <area> part of the page
-      Then the URL will have linked me to the <area> part of the page
+      Then I can skip to the <area> area
 
       Examples:
         | area       |

--- a/testing/features/header.feature
+++ b/testing/features/header.feature
@@ -28,7 +28,7 @@ Feature: Header component
       Examples:
         | area       |
         | navigation |
-        | header     |
+        | content    |
         | footer     |
 
     Scenario Outline: Welsh Users are able to navigate to various areas of the page

--- a/testing/features/step_definitions/common_steps.rb
+++ b/testing/features/step_definitions/common_steps.rb
@@ -1,0 +1,1 @@
+# frozen_string_literal: true

--- a/testing/features/step_definitions/common_steps.rb
+++ b/testing/features/step_definitions/common_steps.rb
@@ -1,24 +1,7 @@
 # frozen_string_literal: true
 
-When("I skip to the {skip-link-area} part of the page") do |area|
+When("I am able to skip to the {skip-link-area} part of the page") do |area|
   @component.tab_to(area)
-  @component.active_element.text
-end
 
-Then("the URL will have linked me to the {skip-link-area} part of the page") do |area|
-  area = "main-#{area}" if area == :content
-
-  expect(page.current_url).to end_with("#cads-#{area}")
-end
-
-Then("there are 3 hidden links that allow you to quickly skip to various parts of the page") do
-  link_labels =
-    [
-      I18n.t("cads.header.skip_to_navigation"),
-      I18n.t("cads.header.skip_to_content"),
-      I18n.t("cads.header.skip_to_footer")
-    ]
-  expect(@component.skip_links.length).to eq(3)
-
-  expect(@component.skip_links.map(&:text)).to eq(link_labels)
+  expect(@component.active_element.text).to eq(I18n.t("cads.header.skip_to_#{area}"))
 end

--- a/testing/features/step_definitions/common_steps.rb
+++ b/testing/features/step_definitions/common_steps.rb
@@ -14,5 +14,5 @@ end
 Then("there is a hidden link to quickly skip to the {skip-link-area} part of the page") do |area|
   @component.tab_to(area)
 
-  expect(@component.active_skip_link_text).to eq(I18n.t("cads.header.skip_to_#{area}"))
+  expect(@component.active_element.text).to eq(I18n.t("cads.header.skip_to_#{area}"))
 end

--- a/testing/features/step_definitions/common_steps.rb
+++ b/testing/features/step_definitions/common_steps.rb
@@ -1,5 +1,16 @@
 # frozen_string_literal: true
 
+When("I skip to the {skip-link-area} part of the page") do |area|
+  @component.tab_to(area)
+  @component.active_element.send_keys(:enter)
+end
+
+Then("the URL will have linked me to the {skip-link-area} part of the page") do |area|
+  area = "main-#{area}" if area == :content
+
+  expect(page.current_url).to end_with("#cads-#{area}")
+end
+
 Then("there is a hidden link to quickly skip to the {skip-link-area} part of the page") do |area|
   @component.tab_to(area)
 

--- a/testing/features/step_definitions/common_steps.rb
+++ b/testing/features/step_definitions/common_steps.rb
@@ -1,1 +1,7 @@
 # frozen_string_literal: true
+
+Then("there is a hidden link to quickly skip to the {skip-link-area} part of the page") do |area|
+  @component.tab_to(area)
+
+  expect(@component.text).to include('abc')
+end

--- a/testing/features/step_definitions/common_steps.rb
+++ b/testing/features/step_definitions/common_steps.rb
@@ -3,5 +3,5 @@
 Then("there is a hidden link to quickly skip to the {skip-link-area} part of the page") do |area|
   @component.tab_to(area)
 
-  expect(@component.active_skip_link_text).to eq("Skip to #{area}")
+  expect(@component.active_skip_link_text).to eq(I18n.t("cads.header.skip_to_#{area}"))
 end

--- a/testing/features/step_definitions/common_steps.rb
+++ b/testing/features/step_definitions/common_steps.rb
@@ -3,5 +3,5 @@
 Then("there is a hidden link to quickly skip to the {skip-link-area} part of the page") do |area|
   @component.tab_to(area)
 
-  expect(@component.text).to include('abc')
+  expect(@component.active_skip_link_text).to eq("Skip to #{area}")
 end

--- a/testing/features/step_definitions/common_steps.rb
+++ b/testing/features/step_definitions/common_steps.rb
@@ -2,7 +2,7 @@
 
 When("I skip to the {skip-link-area} part of the page") do |area|
   @component.tab_to(area)
-  @component.active_element.send_keys(:enter)
+  @component.active_element.text
 end
 
 Then("the URL will have linked me to the {skip-link-area} part of the page") do |area|
@@ -11,8 +11,14 @@ Then("the URL will have linked me to the {skip-link-area} part of the page") do 
   expect(page.current_url).to end_with("#cads-#{area}")
 end
 
-Then("there is a hidden link to quickly skip to the {skip-link-area} part of the page") do |area|
-  @component.tab_to(area)
+Then("there are 3 hidden links that allow you to quickly skip to various parts of the page") do
+  link_labels =
+    [
+      I18n.t("cads.header.skip_to_navigation"),
+      I18n.t("cads.header.skip_to_content"),
+      I18n.t("cads.header.skip_to_footer")
+    ]
+  expect(@component.skip_links.length).to eq(3)
 
-  expect(@component.active_element.text).to eq(I18n.t("cads.header.skip_to_#{area}"))
+  expect(@component.skip_links.map(&:text)).to eq(link_labels)
 end

--- a/testing/features/support/components/header/standard.rb
+++ b/testing/features/support/components/header/standard.rb
@@ -4,11 +4,27 @@ module Header
   class Standard < ::Base
     set_url "/iframe.html?id=components-header--default&viewMode=story"
 
+    include Helpers::Page
+
     element :change_language, "a", text: "Cymraeg"
     element :login, "[data-testid='account-link']"
     element :logo, ".cads-logo"
     element :search_field, "[type='search']"
     element :search_button, "[title='Submit search query']"
     element :open_search_pane, "[title='Open search']"
+    element :skip_link_text, ".cads-skip-links__link", visible: false
+
+    def tab_to(desired_area)
+      tab_quantity_for_skip_link(desired_area).times do
+        # This next line is a hack until capybara cut a new version containing
+        # https://github.com/teamcapybara/capybara/pull/2422
+        # ETA Early December based on previous releases
+        #
+        # LH - Nov 2020
+        fake_active_element = page.find('body')
+        fake_active_element.send_keys(:tab)
+        sleep 0.5
+      end
+    end
   end
 end

--- a/testing/features/support/components/header/standard.rb
+++ b/testing/features/support/components/header/standard.rb
@@ -21,7 +21,7 @@ module Header
         # ETA Early December based on previous releases
         #
         # LH - Nov 2020
-        fake_active_element = page.find('body')
+        fake_active_element = page.find("body")
         fake_active_element.send_keys(:tab)
         sleep 0.25
       end

--- a/testing/features/support/components/header/standard.rb
+++ b/testing/features/support/components/header/standard.rb
@@ -13,7 +13,6 @@ module Header
     element :search_field, "[type='search']"
     element :search_button, "[title='Submit search query']"
     element :open_search_pane, "[title='Open search']"
-    elements :skip_links, "[data-testid='skip-link']"
 
     def tab_to(desired_area)
       tab_quantity_for_skip_link(desired_area).times do

--- a/testing/features/support/components/header/standard.rb
+++ b/testing/features/support/components/header/standard.rb
@@ -13,6 +13,7 @@ module Header
     element :search_field, "[type='search']"
     element :search_button, "[title='Submit search query']"
     element :open_search_pane, "[title='Open search']"
+    elements :skip_links, "[data-testid='skip-link']"
 
     def tab_to(desired_area)
       tab_quantity_for_skip_link(desired_area).times do
@@ -23,7 +24,7 @@ module Header
         # LH - Nov 2020
         fake_active_element = page.find("body")
         fake_active_element.send_keys(:tab)
-        sleep 0.25
+        sleep 0.1
       end
     end
   end

--- a/testing/features/support/components/header/standard.rb
+++ b/testing/features/support/components/header/standard.rb
@@ -13,7 +13,6 @@ module Header
     element :search_field, "[type='search']"
     element :search_button, "[title='Submit search query']"
     element :open_search_pane, "[title='Open search']"
-    element :skip_link_text, ".cads-skip-links__link", visible: false
 
     def tab_to(desired_area)
       tab_quantity_for_skip_link(desired_area).times do
@@ -24,12 +23,8 @@ module Header
         # LH - Nov 2020
         fake_active_element = page.find('body')
         fake_active_element.send_keys(:tab)
-        sleep 0.5
+        sleep 0.25
       end
-    end
-
-    def active_skip_link_text
-      active_element.text
     end
   end
 end

--- a/testing/features/support/components/header/standard.rb
+++ b/testing/features/support/components/header/standard.rb
@@ -5,6 +5,7 @@ module Header
     set_url "/iframe.html?id=components-header--default&viewMode=story"
 
     include Helpers::Page
+    include Helpers::Javascript
 
     element :change_language, "a", text: "Cymraeg"
     element :login, "[data-testid='account-link']"
@@ -28,7 +29,7 @@ module Header
     end
 
     def active_skip_link_text
-      evaluate_script("document.activeElement").text
+      active_element.text
     end
   end
 end

--- a/testing/features/support/components/header/standard.rb
+++ b/testing/features/support/components/header/standard.rb
@@ -26,5 +26,9 @@ module Header
         sleep 0.5
       end
     end
+
+    def active_skip_link_text
+      evaluate_script("document.activeElement").text
+    end
   end
 end

--- a/testing/features/support/helpers/javascript.rb
+++ b/testing/features/support/helpers/javascript.rb
@@ -12,6 +12,10 @@ module Helpers
       session.execute_script("return document.documentElement.outerHTML")
     end
 
+    def active_element
+      session.evaluate_script("document.activeElement")
+    end
+
     def before_content(selector)
       session.evaluate_script(
         <<~JS

--- a/testing/features/support/helpers/page.rb
+++ b/testing/features/support/helpers/page.rb
@@ -34,7 +34,7 @@ module Helpers
     def tab_quantity_for_skip_link(desired_area)
       case desired_area
       when :navigation; then 1
-      when :header;     then 2
+      when :content;    then 2
       when :footer;     then 3
       else raise "Invalid Input argument for tabbing!"
       end

--- a/testing/features/support/helpers/page.rb
+++ b/testing/features/support/helpers/page.rb
@@ -31,6 +31,15 @@ module Helpers
       wait_for_new_url if firefox? && new_page
     end
 
+    def tab_quantity_for_skip_link(desired_area)
+      case desired_area
+      when :navigation; then 1
+      when :header;     then 2
+      when :footer;     then 3
+      else raise "Invalid Input argument for tabbing!"
+      end
+    end
+
     private
 
     def resize_page_to_fullsize

--- a/testing/features/support/parameter_types.rb
+++ b/testing/features/support/parameter_types.rb
@@ -5,3 +5,9 @@ ParameterType(
   regexp: /(Primary|Secondary|Tertiary)/,
   transformer: ->(button) { button.downcase }
 )
+
+ParameterType(
+  name: "skip-link-area",
+  regexp: /(navigation|header|footer)/,
+  transformer: ->(area) { area.to_sym }
+)

--- a/testing/features/support/parameter_types.rb
+++ b/testing/features/support/parameter_types.rb
@@ -8,6 +8,6 @@ ParameterType(
 
 ParameterType(
   name: "skip-link-area",
-  regexp: /(navigation|header|footer)/,
+  regexp: /(navigation|content|footer)/,
   transformer: ->(area) { area.to_sym }
 )


### PR DESCRIPTION
I have added spec validation for skip-links. However as this wasn't something directly I fleshed out. I'm not 100% sure I've covered it well. (Hence tagging sheldon as well to look at Business cases).

There's a tiny bit of tech-debt in this PR - Which will be fixed soon (It's in capybara master, but not a versioned candidate). It's something a lot of people have got fixed up in Capybara and it will filter to selenium (When you tell a page to do something native, do it, don't complain).

NB: I've altered a tiny bit of haml/labels. Let me know if this is ok!