### PR TITLE
Feature: /np 1263 ds footer migration

### DIFF
--- a/testing/features/footer.feature
+++ b/testing/features/footer.feature
@@ -1,20 +1,29 @@
-@failing @NP-1263
 Feature: Footer component
 
   The footer component shows users of the site useful links
   in different categories. It also shows legal information
   and a way to submit feedback about the page you are on.
 
-  Background:
-    Given a Footer component is on the page
+  Rule: Default Footer
+    Background:
+      Given the Default Footer component is on the page
 
-  Scenario: Footer contains a variety of links / content
-    Then a report problem with this page link is present
-    And each header item has at least 1 link below it
-    And a footer logo is present
-    And a copyright notice is present
-    And a company info is present
+    Scenario: Footer contains a variety of links / content
+      Then a report problem with this page link is present
+      And each header item has at least 1 link below it
+      And a footer logo is present
+      And a copyright notice is present
+      And a company info is present
 
-  Scenario: Users can report a problem about the specific page they are on
-    When I report a problem with this page
-    Then I am presented with a form to report the issue about the page I am on
+    Scenario: Users can report a problem about the specific page they are on
+      When I report a problem with this page
+      Then I am presented with a form to report the issue about the page I am on
+
+  Rule: Minimal Footer
+    Background:
+      Given the Minimal Footer component is on the page
+
+    Scenario: Footer contains a variety of links / content
+      Then a footer logo is present
+      And a copyright notice is present
+      And a company info is present

--- a/testing/features/step_definitions/footer_steps.rb
+++ b/testing/features/step_definitions/footer_steps.rb
@@ -21,15 +21,15 @@ Then("each header item has at least 1 link below it") do
 end
 
 Then("a footer logo is present") do
-  expect(@component.initial_form).to have_logo
+  expect(@component).to have_logo
 end
 
 Then("a copyright notice is present") do
-  expect(@component.initial_form).to have_copyright
+  expect(@component).to have_copyright
 end
 
 Then("a company info is present") do
-  expect(@component.initial_form).to have_company_info
+  expect(@component).to have_company_info
 end
 
 Then("I am presented with a form to report the issue about the page I am on") do

--- a/testing/features/step_definitions/footer_steps.rb
+++ b/testing/features/step_definitions/footer_steps.rb
@@ -1,7 +1,12 @@
 # frozen_string_literal: true
 
-Given("a Footer component is on the page") do
-  @component = DesignSystem::Footer.new
+Given("the Default Footer component is on the page") do
+  @component = Footer::Default.new
+  @component.load
+end
+
+Given('the Minimal Footer component is on the page') do
+  @component = Footer::Minimal.new
   @component.load
 end
 
@@ -10,7 +15,7 @@ When("I report a problem with this page") do
 end
 
 Then("a report problem with this page link is present") do
-  expect(@component.initial_form).to have_website_feedback
+  expect(@component).to have_website_feedback
 end
 
 Then("each header item has at least 1 link below it") do

--- a/testing/features/step_definitions/footer_steps.rb
+++ b/testing/features/step_definitions/footer_steps.rb
@@ -5,7 +5,7 @@ Given("the Default Footer component is on the page") do
   @component.load
 end
 
-Given('the Minimal Footer component is on the page') do
+Given("the Minimal Footer component is on the page") do
   @component = Footer::Minimal.new
   @component.load
 end

--- a/testing/features/step_definitions/footer_steps.rb
+++ b/testing/features/step_definitions/footer_steps.rb
@@ -1,13 +1,11 @@
 # frozen_string_literal: true
 
 Given("the Default Footer component is on the page") do
-  @component = Footer::Default.new
-  @component.load
+  @component = Footer::Default.new.tap(&:load)
 end
 
 Given("the Minimal Footer component is on the page") do
-  @component = Footer::Minimal.new
-  @component.load
+  @component = Footer::Minimal.new.tap(&:load)
 end
 
 When("I report a problem with this page") do

--- a/testing/features/step_definitions/footer_steps.rb
+++ b/testing/features/step_definitions/footer_steps.rb
@@ -11,7 +11,7 @@ Given('the Minimal Footer component is on the page') do
 end
 
 When("I report a problem with this page") do
-  @component.initial_form.website_feedback.click
+  @component.website_feedback.click
 end
 
 Then("a report problem with this page link is present") do

--- a/testing/features/support/components/footer/default.rb
+++ b/testing/features/support/components/footer/default.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Footer
+  class Default < Minimal
+    set_url "/iframe.html?id=components-footer--default-story&viewMode=story"
+
+    sections :category_titles, ".cads-grid-col-md-3 > h2" do
+      elements :links, :xpath, "./following-sibling::ul[1]/li/a"
+    end
+
+    element :website_feedback, ".cads-footer__feedback a"
+  end
+end

--- a/testing/features/support/components/footer/default.rb
+++ b/testing/features/support/components/footer/default.rb
@@ -9,5 +9,9 @@ module Footer
     end
 
     element :website_feedback, ".cads-footer__feedback a"
+
+    def validate_initial_state!
+      has_category_titles?(wait: 5)
+    end
   end
 end

--- a/testing/features/support/components/footer/minimal.rb
+++ b/testing/features/support/components/footer/minimal.rb
@@ -4,14 +4,12 @@ module Footer
   class Minimal < ::Base
     set_url "/iframe.html?id=components-footer--minimal&viewMode=story"
 
-    section :initial_form, ".cads-footer" do
-      element :logo, ".cads-logo"
-      element :copyright, ".cads-footer__company-info div p:nth-of-type(1)"
-      element :company_info, ".cads-footer__company-info div p:nth-of-type(2)"
-    end
+    element :logo, ".cads-logo"
+    element :copyright, ".cads-footer__company-info div p:nth-of-type(1)"
+    element :company_info, ".cads-footer__company-info div p:nth-of-type(2)"
 
     def validate_initial_state!
-      has_initial_form?(wait: 5)
+      has_logo?(wait: 5)
     end
   end
 end

--- a/testing/features/support/components/footer/minimal.rb
+++ b/testing/features/support/components/footer/minimal.rb
@@ -4,13 +4,8 @@ module Footer
   class Minimal < ::Base
     set_url "/iframe.html?id=components-footer--minimal&viewMode=story"
 
-    element :footer, "footer"
     element :logo, ".cads-logo"
     element :copyright, ".cads-footer__company-info div p:nth-of-type(1)"
     element :company_info, ".cads-footer__company-info div p:nth-of-type(2)"
-
-    def validate_initial_state!
-      has_footer?(wait: 5)
-    end
   end
 end

--- a/testing/features/support/components/footer/minimal.rb
+++ b/testing/features/support/components/footer/minimal.rb
@@ -4,12 +4,13 @@ module Footer
   class Minimal < ::Base
     set_url "/iframe.html?id=components-footer--minimal&viewMode=story"
 
+    element :footer, "footer"
     element :logo, ".cads-logo"
     element :copyright, ".cads-footer__company-info div p:nth-of-type(1)"
     element :company_info, ".cads-footer__company-info div p:nth-of-type(2)"
 
     def validate_initial_state!
-      has_logo?(wait: 5)
+      has_footer?(wait: 5)
     end
   end
 end

--- a/testing/features/support/components/footer/minimal.rb
+++ b/testing/features/support/components/footer/minimal.rb
@@ -1,15 +1,10 @@
 # frozen_string_literal: true
 
-module DesignSystem
-  class Footer < ::Base
-    set_url "/iframe.html?id=components-footer--default-story&viewMode=story"
-
-    sections :category_titles, ".cads-grid-col-md-3 > h2" do
-      elements :links, :xpath, "./following-sibling::ul[1]/li/a"
-    end
+module Footer
+  class Minimal < ::Base
+    set_url "/iframe.html?id=components-footer--minimal&viewMode=story"
 
     section :initial_form, ".cads-footer" do
-      element :website_feedback, ".cads-website-feedback a"
       element :logo, ".cads-logo"
       element :copyright, ".cads-footer__company-info div p:nth-of-type(1)"
       element :company_info, ".cads-footer__company-info div p:nth-of-type(2)"


### PR DESCRIPTION
Migrate the existing Footer scenario into a new variant scenario.
- create a folder footer in support/components;
- separate each type of footer in a different file, default.rb and minimal.rb;
- change elements and sections to its respective support file;
- create a new scenario for minimal footer
- adjust some step_definitions