### PR TITLE
v3.2.0 alpha.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## <sub>v3.2.0-alpha.1</sub>
+
+#### _Nov. 27, 2020_
+
+**New**
+
+- Targeted content: Now uses accesible disclosure pattern instead of `details` and `summary`
+
 ## <sub>v3.2.0-alpha.0</sub>
 
 #### _Nov. 26, 2020_

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@citizensadvice/design-system",
-  "version": "3.2.0-alpha.0",
+  "version": "3.2.0-alpha.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@citizensadvice/design-system",
-  "version": "3.2.0-alpha.0",
+  "version": "3.2.0-alpha.1",
   "description": "Citizens Advice Design System",
   "repository": "https://github.com/citizensadvice/design-system",
   "author": "Citizens Advice",

--- a/stats/size.json
+++ b/stats/size.json
@@ -671,6 +671,15 @@
           "size": 57093
         }
       ]
+    },
+    {
+      "version": "3.2.0-alpha.1",
+      "stats": [
+        {
+          "filename": "lib.css",
+          "size": 56348
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
- Targeted content: Now uses accesible disclosure pattern instead of `details` and `summary`
