### PR TITLE
bugfix: Corrected path for grid test artifacts [NP-1273]

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -233,12 +233,12 @@ def define_grid_tests() {
           sh "BROWSER=${browser} bin/docker/grid_tests"
           archiveArtifacts(
             [ // The ?* is to get around an annoying warning from the syntax highlighter which doesn't realise that /* in a string isn't the start comment token.
-              artifacts: "testing/artifacts/${browser}/grid/screenshots/?*.png, " +
-                         "testing/artifacts/${browser}/grid/reports/report.html, " +
-                         "testing/artifacts/${browser}/grid/reports/?*.xml, " +
-                         "testing/artifacts/${browser}/grid/reports/report.json, " +
-                         "testing/artifacts/${browser}/grid/html_pages/?*.html, " +
-                         "testing/artifacts/${browser}/grid/logs/?*.log",
+              artifacts: "testing/artifacts/${browser}/other/screenshots/?*.png, " +
+                         "testing/artifacts/${browser}/other/reports/report.html, " +
+                         "testing/artifacts/${browser}/other/reports/?*.xml, " +
+                         "testing/artifacts/${browser}/other/reports/report.json, " +
+                         "testing/artifacts/${browser}/other/html_pages/?*.html, " +
+                         "testing/artifacts/${browser}/other/logs/?*.log",
               allowEmptyArchive: true,
               caseSensitive: false
             ]

--- a/Rakefile
+++ b/Rakefile
@@ -15,7 +15,7 @@ def collect_task_errors(tasks)
 end
 
 def base_cucumber_path
-  "artifacts/#{ENV['BROWSER']}/#{ENV.fetch('BROWSERSTACK', 'false') != 'false' ? ENV['BROWSERSTACK_CONFIGURATION_OPTIONS'] : 'other'}"
+  "artifacts/#{ENV['BROWSER']}/#{ENV['BROWSERSTACK'] == 'true' ? ENV['BROWSERSTACK_CONFIGURATION_OPTIONS'] : 'other'}"
 end
 
 namespace :design_system do

--- a/Rakefile
+++ b/Rakefile
@@ -15,7 +15,7 @@ def collect_task_errors(tasks)
 end
 
 def base_cucumber_path
-  "artifacts/#{ENV['BROWSER']}/#{ENV['BROWSERSTACK'] ? ENV['BROWSERSTACK_CONFIGURATION_OPTIONS'] : 'other'}"
+  "artifacts/#{ENV['BROWSER']}/#{ENV.fetch('BROWSERSTACK', 'false') != 'false' ? ENV['BROWSERSTACK_CONFIGURATION_OPTIONS'] : 'other'}"
 end
 
 namespace :design_system do

--- a/testing/cucumber.yml
+++ b/testing/cucumber.yml
@@ -1,6 +1,6 @@
 passing: --tags 'not @failing and not @future_release'
 
-<% base_path = "artifacts/#{ENV['BROWSER']}/#{ENV.fetch('BROWSERSTACK', 'false') != 'false' ? ENV['BROWSERSTACK_CONFIGURATION_OPTIONS'] : 'other'}" %>
+<% base_path = "artifacts/#{ENV['BROWSER']}/#{ENV['BROWSERSTACK'] == 'true' ? ENV['BROWSERSTACK_CONFIGURATION_OPTIONS'] : 'other'}" %>
 
 html: --format html --out "<%= base_path %>/reports/report.html" BASE_ARTIFACTS_PATH="<%= base_path%>"
 junit: --format junit --out "<%= base_path %>/reports" BASE_ARTIFACTS_PATH="<%= base_path%>"

--- a/testing/cucumber.yml
+++ b/testing/cucumber.yml
@@ -1,6 +1,6 @@
 passing: --tags 'not @failing and not @future_release'
 
-<% base_path = "artifacts/#{ENV['BROWSER']}/#{ENV['BROWSERSTACK'] ? ENV['BROWSERSTACK_CONFIGURATION_OPTIONS'] : 'other'}" %>
+<% base_path = "artifacts/#{ENV['BROWSER']}/#{ENV.fetch('BROWSERSTACK', 'false') != 'false' ? ENV['BROWSERSTACK_CONFIGURATION_OPTIONS'] : 'other'}" %>
 
 html: --format html --out "<%= base_path %>/reports/report.html" BASE_ARTIFACTS_PATH="<%= base_path%>"
 junit: --format junit --out "<%= base_path %>/reports" BASE_ARTIFACTS_PATH="<%= base_path%>"


### PR DESCRIPTION
The change from grid to other was late in the previous PR, and the update to the Jenkinsfile was missed.

- Updated artifact search path to use the correct other path when running grid tests

<!--
# PR template for Design System

These steps are designed to show what to do. After doing each step, delete all the placeholder lines
1) Rename title of PR to: feature/bugfix/refactor: TITLE OF PR [NP-XXX]
2) Add initial Reasons for Change: If you feel it easier to describe the change with code blocks feel free
3) Then add a bullet point for each "thing" you've changed with a brief explanation i.e.

- Refactored code in `directory/file.js`
  - This code was previously very messy
  - Now you can call this code all over the suite
- Opted to refactor constant `otherThing`
  - This should now allow users to write less code in css files

4a) If the PR is ready for review, assign the reviewers to it once the build has passed
4b) If the PR is not ready for review, do not assign any reviewers and attach a "do not merge" label
-->
