### PR TITLE
Fix button animation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+**Bugfixes:**
+
+- Buttons: Limit transition to just the `background` property to avoid unwanted transition animations (NP-1372)
+
 ## <sub>v3.2.0-alpha.1</sub>
 
 #### _Nov. 27, 2020_

--- a/scss/4-elements/_buttons.scss
+++ b/scss/4-elements/_buttons.scss
@@ -8,7 +8,7 @@
 $button-shadow-size: 4px;
 
 @mixin cads-button-defaults() {
-  @include cads-transition-animation(background, box-shadow, border-color);
+  @include cads-transition-animation(background);
 
   -webkit-appearance: none;
   box-sizing: border-box;


### PR DESCRIPTION
Limit transition to just the `background` property to avoid unwanted transition animations. Probably hard to see in GIF form but:

**Before:**

![button-bug](https://user-images.githubusercontent.com/123386/100772860-0ee92b00-33f8-11eb-8b23-1d556bc346bd.gif)

**After:**

![button-bug-fixed](https://user-images.githubusercontent.com/123386/100772889-18729300-33f8-11eb-9278-a176a7eb9291.gif)

https://citizensadvice.atlassian.net/browse/NP-1372
