### PR TITLE
Add the tag not_mobile for Scenario

### DIFF
--- a/testing/features/footer.feature
+++ b/testing/features/footer.feature
@@ -15,6 +15,7 @@ Feature: Footer component
       And a copyright notice is present
       And a company info is present
 
+    @not_mobile
     Scenario: Users can report a problem about the specific page they are on
       When I report a problem with this page
       Then I am presented with a form to report the issue about the page I am on


### PR DESCRIPTION
This PR just add the tag @not_mobile in the Scenario: Users can report a problem about the specific page they are on.
A permanent fix is going to be done soon, but in order to not block any developers builds this is the fastest solution for now.
