### PR TITLE
Scope stories glob

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -1,5 +1,5 @@
 module.exports = {
-  stories: ['../**/*.stories.@(js|mdx)'],
+  stories: ['../styleguide/**/*.stories.@(js|mdx)'],
   addons: [
     {
       name: '@storybook/addon-essentials',


### PR DESCRIPTION
Scope `stories` glob to be the `styleguide` directory rather than searching the whole project. 

Not hugely noticeable on master but makes a big difference in the context of https://github.com/citizensadvice/design-system/pull/594 where there are far more files.