### PR TITLE
chore: match against http and https for external links (tighter match…

### DIFF
--- a/scss/5-objects/_prose.scss
+++ b/scss/5-objects/_prose.scss
@@ -52,7 +52,8 @@
     @extend %cads-list-no-bullet;
   }
 
-  a[href*="//"]:not([href*="citizensadvice.org.uk"])::after
+  a[href^="https://"]:not([href*="citizensadvice.org.uk"])::after,
+  a[href^="http://"]:not([href*="citizensadvice.org.uk"])::after
   {
     @extend %cads-hyperlink--external-icon;
   }


### PR DESCRIPTION
… than previous

Match against `https://` or `http://` at start of href, rather than just `//`. This will avoid showing external link icon for urls that just contain a double slash. 