### PR TITLE
fix: make nav visited links white

### DIFF
--- a/scss/6-components/_navigation.scss
+++ b/scss/6-components/_navigation.scss
@@ -10,6 +10,10 @@
   border-color: $cads-language__brand-primary;
   line-height: 1em;
 
+  &:visited {
+    color: $cads-palette__white;
+  }
+
   &:hover {
     background-color: $cads-language__link-hover-colour;
     border-color: $cads-language__link-hover-colour;


### PR DESCRIPTION
Fix to 4.0.0-alpha.1 to make visited links in the global navigation white.