### PR TITLE
test: disable contact details tests pending docs update

### DIFF
--- a/testing/features/contact_details.feature
+++ b/testing/features/contact_details.feature
@@ -1,3 +1,4 @@
+@future_release @4.0.0+
 Feature: Contact Details component
 
   The Contact Details component provides users with full contact information


### PR DESCRIPTION
The docs will need to be updated for this test to work with the current setup. This tag can be removed in 4.0.0+