### PR TITLE
bugfix: Fix Breadcrumb tests for iPhone [NP=1253]

### DIFF
--- a/testing/features/breadcrumbs.feature
+++ b/testing/features/breadcrumbs.feature
@@ -10,7 +10,7 @@ Feature: Breadcrumbs component
     Scenario: Breadcrumbs only link up till the last one
       Then a series of breadcrumbs are present
       And the initial breadcrumbs are all links
-      But the final breadcrumb isn't a link
+      But the final breadcrumb isn't a link unless on mobile
 
   Rule: Site Wide Breadcrumb
     Background:

--- a/testing/features/breadcrumbs.feature
+++ b/testing/features/breadcrumbs.feature
@@ -1,4 +1,3 @@
-@not_mobile @NP-1253
 Feature: Breadcrumbs component
 
   The Breadcrumbs component allows users to see a navigable path to their

--- a/testing/features/breadcrumbs.feature
+++ b/testing/features/breadcrumbs.feature
@@ -7,10 +7,15 @@ Feature: Breadcrumbs component
     Background:
       Given a Default Breadcrumbs component is on the page
 
-    Scenario: Breadcrumbs only link up till the last one
+    @not_mobile
+    Scenario: On large devices breadcrumbs only link up till the last one
       Then a series of breadcrumbs are present
       And the initial breadcrumbs are all links
-      But the final breadcrumb isn't a link unless on mobile
+      But the final breadcrumb isn't a link
+
+    @small_screen
+    Scenario: On small devices there is only ever one breadcrumb link
+      Then the only breadcrumb is a link
 
   Rule: Site Wide Breadcrumb
     Background:

--- a/testing/features/breadcrumbs.feature
+++ b/testing/features/breadcrumbs.feature
@@ -12,6 +12,15 @@ Feature: Breadcrumbs component
       And the initial breadcrumbs are all links
       But the final breadcrumb isn't a link
 
+  Rule: Site Wide Breadcrumb
+    Background:
+      Given a Site Wide Breadcrumbs component is on the page
+
+    Scenario: Breadcrumbs only link up till the last one
+      Then a series of breadcrumbs are present
+      And the initial breadcrumbs are all links
+      But the final breadcrumb isn't a link
+
   Rule: No Collapse Breadcrumb
     Background:
       Given a No Collapse Breadcrumbs component is on the page

--- a/testing/features/step_definitions/breadcrumbs_steps.rb
+++ b/testing/features/step_definitions/breadcrumbs_steps.rb
@@ -13,7 +13,7 @@ end
 
 Then("a series of breadcrumbs are present") do
   if mobile_phone?
-    expect(@component).to have_breadcrumbs(minimum: 1) if mobile_phone?
+    expect(@component).to have_breadcrumbs(minimum: 1)
   else
     expect(@component).to have_breadcrumbs(minimum: 3)
   end

--- a/testing/features/step_definitions/breadcrumbs_steps.rb
+++ b/testing/features/step_definitions/breadcrumbs_steps.rb
@@ -1,18 +1,15 @@
 # frozen_string_literal: true
 
 Given("a Default Breadcrumbs component is on the page") do
-  @component = Breadcrumbs::Default.new
-  @component.load
+  @component = Breadcrumbs::Default.new.tap(&:load)
 end
 
 Given("a No Collapse Breadcrumbs component is on the page") do
-  @component = Breadcrumbs::NoCollapse.new
-  @component.load
+  @component = Breadcrumbs::NoCollapse.new.tap(&:load)
 end
 
 Given("a Site Wide Breadcrumbs component is on the page") do
-  @component = Breadcrumbs::SiteWide.new
-  @component.load
+  @component = Breadcrumbs::SiteWide.new.tap(&:load)
 end
 
 Then("a series of breadcrumbs are present") do

--- a/testing/features/step_definitions/breadcrumbs_steps.rb
+++ b/testing/features/step_definitions/breadcrumbs_steps.rb
@@ -24,7 +24,7 @@ Then("the initial breadcrumbs are all links") do
 end
 
 Then("the final breadcrumb isn't a link") do
-  if mobile_phone? && @default === true
+  if mobile_phone? && @default == true
     expect(@component.breadcrumbs.last).to have_link
   else
     expect(@component.breadcrumbs.last).not_to have_link

--- a/testing/features/step_definitions/breadcrumbs_steps.rb
+++ b/testing/features/step_definitions/breadcrumbs_steps.rb
@@ -3,12 +3,17 @@
 Given("a Default Breadcrumbs component is on the page") do
   @component = Breadcrumbs::Default.new
   @component.load
-  @default = true
 end
 
 Given("a No Collapse Breadcrumbs component is on the page") do
   @component = Breadcrumbs::NoCollapse.new
   @component.load
+end
+
+Given('a Site Wide Breadcrumbs component is on the page') do
+  @component = Breadcrumbs::SiteWide.new
+  @component.load
+
 end
 
 Then("a series of breadcrumbs are present") do

--- a/testing/features/step_definitions/breadcrumbs_steps.rb
+++ b/testing/features/step_definitions/breadcrumbs_steps.rb
@@ -10,10 +10,9 @@ Given("a No Collapse Breadcrumbs component is on the page") do
   @component.load
 end
 
-Given('a Site Wide Breadcrumbs component is on the page') do
+Given("a Site Wide Breadcrumbs component is on the page") do
   @component = Breadcrumbs::SiteWide.new
   @component.load
-
 end
 
 Then("a series of breadcrumbs are present") do
@@ -28,10 +27,14 @@ Then("the initial breadcrumbs are all links") do
   expect(@component.all_but_last_breadcrumb).to all have_link
 end
 
-Then("the final breadcrumb isn't a link") do
-  if mobile_phone? && @default == true
+Then("the final breadcrumb isn't a link unless on mobile") do
+  if mobile_phone?
     expect(@component.breadcrumbs.last).to have_link
   else
     expect(@component.breadcrumbs.last).not_to have_link
   end
+end
+
+Then("the final breadcrumb isn't a link") do
+  expect(@component.breadcrumbs.last).not_to have_link
 end

--- a/testing/features/step_definitions/breadcrumbs_steps.rb
+++ b/testing/features/step_definitions/breadcrumbs_steps.rb
@@ -3,6 +3,7 @@
 Given("a Default Breadcrumbs component is on the page") do
   @component = Breadcrumbs::Default.new
   @component.load
+  @default = true
 end
 
 Given("a No Collapse Breadcrumbs component is on the page") do
@@ -11,7 +12,11 @@ Given("a No Collapse Breadcrumbs component is on the page") do
 end
 
 Then("a series of breadcrumbs are present") do
-  expect(@component).to have_breadcrumbs(minimum: 3)
+  if mobile_phone?
+    expect(@component).to have_breadcrumbs(minimum: 1) if mobile_phone?
+  else
+    expect(@component).to have_breadcrumbs(minimum: 3)
+  end
 end
 
 Then("the initial breadcrumbs are all links") do
@@ -19,5 +24,9 @@ Then("the initial breadcrumbs are all links") do
 end
 
 Then("the final breadcrumb isn't a link") do
-  expect(@component.breadcrumbs.last).not_to have_link
+  if mobile_phone? && @default === true
+    expect(@component.breadcrumbs.last).to have_link
+  else
+    expect(@component.breadcrumbs.last).not_to have_link
+  end
 end

--- a/testing/features/step_definitions/breadcrumbs_steps.rb
+++ b/testing/features/step_definitions/breadcrumbs_steps.rb
@@ -16,25 +16,17 @@ Given("a Site Wide Breadcrumbs component is on the page") do
 end
 
 Then("a series of breadcrumbs are present") do
-  if mobile_phone?
-    expect(@component).to have_breadcrumbs(minimum: 1)
-  else
-    expect(@component).to have_breadcrumbs(minimum: 3)
-  end
+  expect(@component).to have_breadcrumbs(minimum: 3)
 end
 
 Then("the initial breadcrumbs are all links") do
   expect(@component.all_but_last_breadcrumb).to all have_link
 end
 
-Then("the final breadcrumb isn't a link unless on mobile") do
-  if mobile_phone?
-    expect(@component.breadcrumbs.last).to have_link
-  else
-    expect(@component.breadcrumbs.last).not_to have_link
-  end
-end
-
 Then("the final breadcrumb isn't a link") do
   expect(@component.breadcrumbs.last).not_to have_link
+end
+
+Then("the only breadcrumb is a link") do
+  expect(@component.breadcrumbs.last).to have_link
 end

--- a/testing/features/support/components/breadcrumbs/sitewide.rb
+++ b/testing/features/support/components/breadcrumbs/sitewide.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module Breadcrumbs
+  class SiteWide < Default
+    set_url "/iframe.html?id=components-breadcrumbs--breadcrumbs-site-wide&viewMode=story"
+  end
+end

--- a/testing/features/support/hooks.rb
+++ b/testing/features/support/hooks.rb
@@ -10,6 +10,7 @@ Before do |test_case|
   skip_this_scenario("This does not work on iOS12") if ios12? && test_case.source_tag_names.include?("@not_ios12")
   skip_this_scenario("This does not work on iOS11") if ios11? && test_case.source_tag_names.include?("@not_ios11")
   resize_window unless mobile_phone?
+  resize_window(320) if test_case.source_tag_names.include?("@small_screen") && !mobile_phone?
   AutomationLogger.info("Running Scenario: #{test_case.name}")
   AutomationLogger.debug("BROWSERSTACK_CONFIGURATION_OPTIONS = #{ENV['BROWSERSTACK_CONFIGURATION_OPTIONS']}")
   AutomationLogger.debug("DOCKER_TAG = #{ENV['DOCKER_TAG']}")


### PR DESCRIPTION
Some breadcrumbs scenarios were falling on the iPhone because breadcrumb behaves differently on responsive screens.
This PR fixes those problems by expecting different results for mobile_phones. 