### PR TITLE
hotfix: Fix image caching on master branch

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -298,15 +298,18 @@ def withForcedDockerUpdate(images = [], local_images = [], Closure body) {
       sh "docker pull ${it}"
       sh "docker image rm ${it}_tmp"
     }
-    // docker-compose builds a container with a name like dev_ruby_master on the release branch
-    // This name doesn't exist remotely.
-    // If this exists in the local context then it will be used. So it needs to be removed
-    local_images.each {
-      // Delete the image if it exists - it's ok if there's an error which will most likely be the tag does not exist.
-      sh "docker image rm ${it} || true"
-    }
-    withDockerSandbox(images) {
-      body{}
+    try {
+      withDockerSandbox(images) {
+        body{}
+      }
+    } finally {
+      // docker-compose builds a container with a name like dev_ruby_master on the release branch
+      // This name doesn't exist remotely.
+      // If this exists in the local context then it will be used. So it needs to be removed
+      local_images.each {
+        // Delete the image if it exists - it's ok if there's an error which will most likely be the tag does not exist.
+        sh "docker image rm ${it}"
+      }
     }
   }
 }


### PR DESCRIPTION
Ugly fix to handle the container naming issue. When design-system builds container images on the master branch, it uses a image tag like dev_ruby_master. This tag doesn't exist in the repository, so should be rebuilt using the caching of the primary image (e.g. ruby). Because it wasn't getting removed, when a big change happened, each of the parallel tests had a chance of picking up the pre-change image from the last run - or rebuilding the post change image.

This adds some steps to ensure that after every run of the tests, these local container tags get removed. The layers and their hashes still exist, so the benefits of caching are still there, they just won't be used if they are supposed to have changed.

<!--
# PR template for Design System

These steps are designed to show what to do. After doing each step, delete all the placeholder lines
1) Rename title of PR to: feature/bugfix/refactor: TITLE OF PR [NP-XXX]
2) Add initial Reasons for Change: If you feel it easier to describe the change with code blocks feel free
3) Then add a bullet point for each "thing" you've changed with a brief explanation i.e.

- Refactored code in `directory/file.js`
  - This code was previously very messy
  - Now you can call this code all over the suite
- Opted to refactor constant `otherThing`
  - This should now allow users to write less code in css files

4a) If the PR is ready for review, assign the reviewers to it once the build has passed
4b) If the PR is not ready for review, do not assign any reviewers and attach a "do not merge" label
-->
