### PR TITLE
Add placeholders for targeted content translations

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,13 +1,15 @@
+require: rubocop-rake
+
 inherit_gem:
   citizens-advice-style:
     - default.yml
-
-Style/ClassAndModuleChildren:
-  Exclude:
-    # Monkey patch for Firefox driver, should eventually be removed
-    - 'testing/features/support/core_ext/capybara/selenium/driver/firefox_driver.rb'
 
 AllCops:
   Exclude:
     - 'vendor/**/*'
     - 'node_modules/**/*'
+
+Style/ClassAndModuleChildren:
+  Exclude:
+    # Monkey patch for Firefox driver, should eventually be removed
+    - 'testing/features/support/core_ext/capybara/selenium/driver/firefox_driver.rb'

--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,7 @@ group :test do
   gem "rake"
   gem "retriable", "~> 3.1"
   gem "rspec"
+  gem "rubocop-rake", require: false
   gem "selenium-webdriver", "4.0.0.alpha6"
   gem "site_prism", "~> 3.7"
   gem "webdrivers"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -168,6 +168,8 @@ GEM
       unicode-display_width (>= 1.4.0, < 2.0)
     rubocop-ast (0.8.0)
       parser (>= 2.7.1.5)
+    rubocop-rake (0.5.1)
+      rubocop
     ruby-progressbar (1.10.1)
     ruby2_keywords (0.0.2)
     rubyzip (2.3.0)
@@ -215,6 +217,7 @@ DEPENDENCIES
   rake
   retriable (~> 3.1)
   rspec
+  rubocop-rake
   selenium-webdriver (= 4.0.0.alpha6)
   site_prism (~> 3.7)
   webdrivers

--- a/Rakefile
+++ b/Rakefile
@@ -27,32 +27,25 @@ namespace :design_system do
     ) || raise
   end
 
+  desc "Creating report folders"
   task :report_folders do
     puts "Creating folder structure for this test run"
-    [
-      "testing/#{base_cucumber_path}/html_pages",
-      "testing/#{base_cucumber_path}/logs",
-      "testing/#{base_cucumber_path}/reports",
-      "testing/#{base_cucumber_path}/screenshots"
-    ].each { |dir| FileUtils.mkdir_p(dir) }
+    dirs = %w[html_pages logs reports screenshots]
+    dirs.each do |dir|
+      FileUtils.mkdir_p("testing/#{base_cucumber_path}/#{dir}}")
+    end
   end
 end
 
 desc "Run all checks in the local context"
 task :check do
-  collect_task_errors([
-    "ruby:lint",
-    "npm:test"
-  ])
+  collect_task_errors(%w[ruby:lint npm:test])
 end
 
 namespace :ruby do
   desc "Lint ruby files"
   task :lint do
-    collect_task_errors([
-      "ruby:rubocop",
-      "ruby:haml_lint"
-    ])
+    collect_task_errors(%w[ruby:rubocop ruby:haml_lint])
   end
 
   desc "Rubocop Linting"
@@ -71,10 +64,7 @@ end
 namespace :npm do
   desc "Run node test"
   task :test do
-    collect_task_errors([
-      "npm:lint",
-      "npm:jest"
-    ])
+    collect_task_errors(%w[npm:lint npm:jest])
   end
 
   desc "Run jest tests in node"

--- a/Rakefile
+++ b/Rakefile
@@ -46,7 +46,7 @@ namespace :design_system do
     puts "Creating folder structure for this test run"
     dirs = %w[html_pages logs reports screenshots]
     dirs.each do |dir|
-      FileUtils.mkdir_p("testing/#{base_cucumber_path}/#{dir}}")
+      FileUtils.mkdir_p("testing/#{base_cucumber_path}/#{dir}")
     end
   end
 end
@@ -78,8 +78,8 @@ namespace :ruby do
   task :locale_lint do
     puts "Checking locale files have matching keys"
     compare_yaml_hash(
-      YAML.load_file("locales/en.yml")["en"]["cads"],
-      YAML.load_file("locales/cy.yml")["cy"]["cads"]
+      YAML.load_file("locales/en.yml")["en"],
+      YAML.load_file("locales/cy.yml")["cy"]
     )
   end
 end

--- a/locales/cy.yml
+++ b/locales/cy.yml
@@ -27,6 +27,8 @@ cy:
       submit_label: Chwilio
     targeted_content:
       close_button_aria: Cau %{title}
+      descriptive_label_show: show this section
+      descriptive_label_hide: hide this section
     shared:
       ui:
         close: Cau

--- a/locales/cy.yml
+++ b/locales/cy.yml
@@ -28,7 +28,6 @@ cy:
     targeted_content:
       descriptive_label_show: show this section
       descriptive_label_hide: hide this section
-      close_label: Cau
     shared:
       ui:
         close: Cau

--- a/locales/cy.yml
+++ b/locales/cy.yml
@@ -28,6 +28,7 @@ cy:
     targeted_content:
       descriptive_label_show: show this section
       descriptive_label_hide: hide this section
+      close_label: Cau
     shared:
       ui:
         close: Cau

--- a/locales/cy.yml
+++ b/locales/cy.yml
@@ -26,9 +26,9 @@ cy:
       submit_title: Cyflwyno ymholiad chwilio
       submit_label: Chwilio
     targeted_content:
-      close_button_aria: Cau %{title}
       descriptive_label_show: show this section
       descriptive_label_hide: hide this section
+      close_label: Cau
     shared:
       ui:
         close: Cau


### PR DESCRIPTION
Add placeholders for targeted content translations. By default Rails injects translation missing markup, which when used in attributes results in the following:

<img width="763" alt="Screenshot 2020-12-16 at 13 34 27" src="https://user-images.githubusercontent.com/123386/102373148-cb75eb80-3fb7-11eb-8069-f840bcb398b5.png">

Adding placeholders to cy.yml for now, have requested translations but imagine they will come in the new year so suggest merging this as is.