### PR TITLE
feat: add js class to footer feedback link [NP-1463]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+**New**
+
+- 📋 Footer Feedback: add a class to allow selection of footer feedback link
 **Docs**
 
 - 📇 Contact Details: documentation updated (NP-1028)

--- a/haml/_footer.html.haml
+++ b/haml/_footer.html.haml
@@ -9,7 +9,7 @@
       .cads-grid-row
         .cads-grid-col
           %p.cads-footer__feedback
-            %a.cads-footer__hyperlink{ href: feedback_url, class: "js-cads-footer-feedback", target: "_blank", rel: "noopener" }= t("cads.footer.website_feedback")
+            %a.cads-footer__hyperlink.js-cads-footer-feedback{ href: feedback_url, target: "_blank", rel: "noopener" }= t("cads.footer.website_feedback")
             %span.cads-footer__feedback-icon.cads-icon_external-link
     %nav{"aria-label": t("cads.footer.navigation_title") }
       .cads-grid-row

--- a/haml/_footer.html.haml
+++ b/haml/_footer.html.haml
@@ -9,7 +9,7 @@
       .cads-grid-row
         .cads-grid-col
           %p.cads-footer__feedback
-            %a.cads-footer__hyperlink{ href: feedback_url, target: "_blank", rel: "noopener" }= t("cads.footer.website_feedback")
+            %a.cads-footer__hyperlink{ href: feedback_url, class: 'js-cads-footer-feedback', target: "_blank", rel: "noopener" }= t("cads.footer.website_feedback")
             %span.cads-footer__feedback-icon.cads-icon_external-link
     %nav{"aria-label": t("cads.footer.navigation_title") }
       .cads-grid-row

--- a/haml/_footer.html.haml
+++ b/haml/_footer.html.haml
@@ -9,7 +9,7 @@
       .cads-grid-row
         .cads-grid-col
           %p.cads-footer__feedback
-            %a.cads-footer__hyperlink{ href: feedback_url, class: 'js-cads-footer-feedback', target: "_blank", rel: "noopener" }= t("cads.footer.website_feedback")
+            %a.cads-footer__hyperlink{ href: feedback_url, class: "js-cads-footer-feedback", target: "_blank", rel: "noopener" }= t("cads.footer.website_feedback")
             %span.cads-footer__feedback-icon.cads-icon_external-link
     %nav{"aria-label": t("cads.footer.navigation_title") }
       .cads-grid-row


### PR DESCRIPTION
Add js-cads-footer-feedback class to the footer feedback link so that it can be selected without relying on classes used for styling.

This will be used in public-website to augment the link with the browsers userAgent.