### PR TITLE
bugfix: Skip Links [NP-1396]

### DIFF
--- a/testing/features/header.feature
+++ b/testing/features/header.feature
@@ -22,7 +22,7 @@ Feature: Header component
     Scenario: Header has a search option
       Then I am able to search for "Anything"
 
-    @future_release @v3.1.0+ @not_mobile
+    @not_mobile
     Scenario Outline: English Users can quickly navigate to various areas of the page
       Then I am able to skip to the <area> part of the page
 
@@ -32,7 +32,7 @@ Feature: Header component
         | content    |
         | footer     |
 
-    @future_release @v3.1.0+ @not_mobile
+    @not_mobile
     Scenario Outline: Welsh Users can quickly navigate to various areas of the page
       Given the language is Welsh
       Then I am able to skip to the <area> part of the page

--- a/testing/features/support/components/header/standard.rb
+++ b/testing/features/support/components/header/standard.rb
@@ -22,7 +22,19 @@ module Header
         #
         # LH - Nov 2020
         fake_active_element = page.find("body")
-        fake_active_element.send_keys(:tab)
+        if safari?
+          fake_active_element.send_keys([:alt, :tab])
+          # This next line is ANOTHER hack that is needed because Safari is crap
+          # and broken. The modifier key here (OPTION, but called :alt), is not
+          # "un-depressed" after being used in the alt+tab call. This means that
+          # subsequent calls do things like alt+click which downloads a link!
+          #
+          # See: https://bugs.webkit.org/show_bug.cgi?id=219948
+          # LH - Dec 2020
+          fake_active_element.send_keys(:alt)
+        else
+          fake_active_element.send_keys(:tab)
+        end
         sleep 0.1
       end
     end


### PR DESCRIPTION
This is now fixed same as in public-website

We use option+tab to skip through them on safari. They are still not enabled for mobile as this concept is irrelevant there