### PR TITLE
Locale lint using i18n-tasks

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -9,3 +9,7 @@ testing/visual-regression/backstop_data/
 testing/wcag/
 testing/cucumber.yml
 vendor/
+
+# Ignore locale files from prettier
+# formatted by i18n-tasks
+/locales/

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,5 @@
+require: rubocop-rake
+
 inherit_gem:
   citizens-advice-style:
     - default.yml

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -104,6 +104,28 @@ For more advanced details see the [BackstopJS Github's page](https://github.com/
 npm run wcag-test
 ```
 
+## Working with locale files
+
+English and Welsh locale files can be found under `locales/`.
+
+We use the [i18n-tasks](https://github.com/glebm/i18n-tasks) gem to help manage locale entries.
+
+You can run the following rake task to peform a health check on locale files.
+
+```
+bundle exec rake ruby:i18n_tasks
+```
+
+To auto-format locale files you can run the following:
+
+```
+bundle exec i18n-tasks normalize
+```
+
+_Note_: We disable prettier for locale files as it conflicts with `i18n-tasks normalize`.
+
+Run `bundle exec i18n-tasks --help` or [view the usage documentation](https://github.com/glebm/i18n-tasks#usage) for a full list of available tasks.
+
 ## Release process
 
 Releasing a new npm package version is a three step process.

--- a/Gemfile
+++ b/Gemfile
@@ -13,9 +13,11 @@ group :test do
   gem "dotenv"
   gem "faraday", "~> 1.1"
   gem "haml_lint"
+  gem "i18n-tasks", "~> 0.9.32"
   gem "rake"
   gem "retriable", "~> 3.1"
   gem "rspec"
+  gem "rubocop-rake", require: false
   gem "selenium-webdriver", "4.0.0.alpha6"
   gem "site_prism", "~> 3.7"
   gem "webdrivers"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -99,8 +99,19 @@ GEM
       rainbow
       rubocop (>= 0.50.0)
       sysexits (~> 1.1)
+    highline (2.0.3)
     i18n (1.8.5)
       concurrent-ruby (~> 1.0)
+    i18n-tasks (0.9.32)
+      activesupport (>= 4.0.2)
+      ast (>= 2.1.0)
+      erubi
+      highline (>= 2.0.0)
+      i18n
+      parser (>= 2.2.3.0)
+      rails-i18n
+      rainbow (>= 2.2.2, < 4.0)
+      terminal-table (>= 1.5.1)
     loofah (2.8.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
@@ -168,6 +179,8 @@ GEM
       unicode-display_width (>= 1.4.0, < 2.0)
     rubocop-ast (0.8.0)
       parser (>= 2.7.1.5)
+    rubocop-rake (0.5.1)
+      rubocop
     ruby-progressbar (1.10.1)
     ruby2_keywords (0.0.2)
     rubyzip (2.3.0)
@@ -184,6 +197,8 @@ GEM
       ffi (~> 1.1)
     sysexits (1.2.0)
     temple (0.8.2)
+    terminal-table (2.0.0)
+      unicode-display_width (~> 1.1, >= 1.1.1)
     thor (1.0.1)
     thread_safe (0.3.6)
     tilt (2.0.10)
@@ -211,10 +226,12 @@ DEPENDENCIES
   faraday (~> 1.1)
   haml (~> 5.2)
   haml_lint
+  i18n-tasks (~> 0.9.32)
   rails-i18n (~> 6.0)
   rake
   retriable (~> 3.1)
   rspec
+  rubocop-rake
   selenium-webdriver (= 4.0.0.alpha6)
   site_prism (~> 3.7)
   webdrivers

--- a/Rakefile
+++ b/Rakefile
@@ -27,32 +27,25 @@ namespace :design_system do
     ) || raise
   end
 
+  desc "Creating report folders"
   task :report_folders do
     puts "Creating folder structure for this test run"
-    [
-      "testing/#{base_cucumber_path}/html_pages",
-      "testing/#{base_cucumber_path}/logs",
-      "testing/#{base_cucumber_path}/reports",
-      "testing/#{base_cucumber_path}/screenshots"
-    ].each { |dir| FileUtils.mkdir_p(dir) }
+    dirs = %w[html_pages logs reports screenshots]
+    dirs.each do |dir|
+      FileUtils.mkdir_p("testing/#{base_cucumber_path}/#{dir}")
+    end
   end
 end
 
 desc "Run all checks in the local context"
 task :check do
-  collect_task_errors([
-    "ruby:lint",
-    "npm:test"
-  ])
+  collect_task_errors(%w[ruby:lint npm:test])
 end
 
 namespace :ruby do
   desc "Lint ruby files"
   task :lint do
-    collect_task_errors([
-      "ruby:rubocop",
-      "ruby:haml_lint"
-    ])
+    collect_task_errors(%w[ruby:rubocop ruby:haml_lint ruby:i18n_tasks])
   end
 
   desc "Rubocop Linting"
@@ -66,15 +59,18 @@ namespace :ruby do
     puts "Running haml-lint"
     system("bundle exec haml-lint haml styleguide") || raise
   end
+
+  desc "i18n-tasks health"
+  task :i18n_tasks do
+    puts "Checking locale files have matching keys"
+    system("bundle exec i18n-tasks health") || raise
+  end
 end
 
 namespace :npm do
   desc "Run node test"
   task :test do
-    collect_task_errors([
-      "npm:lint",
-      "npm:jest"
-    ])
+    collect_task_errors(%w[npm:lint npm:jest])
   end
 
   desc "Run jest tests in node"

--- a/Rakefile
+++ b/Rakefile
@@ -62,7 +62,6 @@ namespace :ruby do
 
   desc "i18n-tasks health"
   task :i18n_tasks do
-    puts "Checking locale files have matching keys"
     system("bundle exec i18n-tasks health") || raise
   end
 end

--- a/i18n-tasks.yml
+++ b/i18n-tasks.yml
@@ -1,0 +1,11 @@
+# i18n-tasks finds and manages missing and unused translations: https://github.com/glebm/i18n-tasks
+base_locale: en
+data:
+  read:
+    - locales/%{locale}.yml
+  write:
+    - locales/%{locale}.yml
+search:
+  paths:
+    - haml/
+  only: ['*.html.haml']

--- a/locales/cy.yml
+++ b/locales/cy.yml
@@ -1,39 +1,36 @@
+---
 cy:
   cads:
-    example:
-      name: Cyngor ar Bopeth
-      body: Dyma enghraifft o destun wedi'i gyfieithu
     breadcrumbs:
       home: Hafan
     callout:
+      adviser: Cynghorydd
       example: Enghraifft
       important: Pwysig
-      adviser: Cynghorydd
+    footer:
+      navigation_title: Llywio Troedyn
+      website_feedback: A oes unrhyw beth o'i le ar y dudalen hon? Gadewch i ni wybod
     form:
       optional: dewisol
     header:
       search_mobile: Ymchwiliad agored
       skip_to_content: Neidio i’r cynnwys
-      skip_to_navigation: Neidio i’r llywio
       skip_to_footer: Neidio i’r troedyn
-    footer:
-      navigation_title: Llywio Troedyn
-      website_feedback: A oes unrhyw beth o'i le ar y dudalen hon? Gadewch i ni wybod
+      skip_to_navigation: Neidio i’r llywio
     page_review:
       body_html: Adolygwyd y dudalen ar <strong>%{date}</strong>
     search:
       input_aria_label: Chwiliwch trwy gynnwys y wefan
-      submit_title: Cyflwyno ymholiad chwilio
       submit_label: Chwilio
-    targeted_content:
-      close_button_aria: Cau %{title}
+      submit_title: Cyflwyno ymholiad chwilio
     shared:
-      ui:
-        close: Cau
-      logo_title: Hafan Cyngor ar Bopeth
       copyright: Hawlfraint © 2020 Cyngor ar Bopeth. Cedwir pob hawl.
-      legal_summary: >
-        Cyngor ar Bopeth yn enw gweithredol ar Gymdeithas Genedlaethol Cyngor ar Bopeth.
-        Rhif elusen gofrestredig 279057. Rhif TAW 726 0202 76. Cwmni cyfyngedig drwy warant.
-        Rhif cofrestredig 0143694 Lloegr. Swyddfa gofrestredig:
-        Cyngor ar Bopeth, 3ydd Llawr Gogledd, 200 Aldersgate, Llundain, EC1A 4HD
+      legal_summary: 'Cyngor ar Bopeth yn enw gweithredol ar Gymdeithas Genedlaethol
+        Cyngor ar Bopeth. Rhif elusen gofrestredig 279057. Rhif TAW 726 0202 76. Cwmni
+        cyfyngedig drwy warant. Rhif cofrestredig 0143694 Lloegr. Swyddfa gofrestredig:
+        Cyngor ar Bopeth, 3ydd Llawr Gogledd, 200 Aldersgate, Llundain, EC1A 4HD'
+      logo_title: Hafan Cyngor ar Bopeth
+    targeted_content:
+      close_label: Cau
+      descriptive_label_hide: hide this section
+      descriptive_label_show: show this section

--- a/locales/cy.yml
+++ b/locales/cy.yml
@@ -32,5 +32,5 @@ cy:
       logo_title: Hafan Cyngor ar Bopeth
     targeted_content:
       close_label: Cau
-      descriptive_label_hide: hide this section
-      descriptive_label_show: show this section
+      descriptive_label_hide: cuddio’r adran hon
+      descriptive_label_show: dangos yr adran hon

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -1,42 +1,37 @@
+---
 en:
   cads:
-    example:
-      name: 'Citizens Advice'
-      body: 'This is some body text'
     breadcrumbs:
       home: Home
     callout:
+      adviser: Adviser
       example: Example
       important: Important
-      adviser: Adviser
+    footer:
+      navigation_title: Footer Navigation
+      website_feedback: Is there anything wrong with this page? Let us know
     form:
       optional: optional
     header:
       search_mobile: Open search
       skip_to_content: Skip to content
-      skip_to_navigation: Skip to navigation
       skip_to_footer: Skip to footer
-    footer:
-      navigation_title: Footer Navigation
-      website_feedback: Is there anything wrong with this page? Let us know
+      skip_to_navigation: Skip to navigation
     page_review:
       body_html: Page last reviewed on <strong>%{date}</strong>
     search:
       input_aria_label: Search through site content
-      submit_title: Submit search query
       submit_label: Search
-    targeted_content:
-      descriptive_label_show: show this section
-      descriptive_label_hide: hide this section
-      close_label: Close
+      submit_title: Submit search query
     shared:
-      ui:
-        close: Close
-      logo_title: Citizens Advice homepage
       copyright: Copyright ©2020 Citizens Advice. All rights reserved.
-      legal_summary: >
-        Citizens Advice is an operating name of the National Association of
-        Citizens Advice Bureaux. Registered charity number 279057. VAT number
-        726 0202 76. Company limited by guarantee. Registered number 01436945
-        England. Registered office: Citizens Advice, 3rd Floor North, 200
-        Aldersgate, London, EC1A 4HD
+      legal_summary: 'Citizens Advice is an operating name of the National Association
+        of Citizens Advice Bureaux. Registered charity number 279057. VAT number 726
+        0202 76. Company limited by guarantee. Registered number 01436945 England.
+        Registered office: Citizens Advice, 3rd Floor North, 200 Aldersgate, London,
+        EC1A 4HD'
+      logo_title: Citizens Advice homepage
+    targeted_content:
+      close_label: Close
+      descriptive_label_hide: hide this section
+      descriptive_label_show: show this section


### PR DESCRIPTION
Re-do of https://github.com/citizensadvice/design-system/pull/665 but using [i18n-tasks](https://github.com/glebm/i18n-tasks)

- Adds rubocop-rake
- Add and configure i18n-tasks
- Runs `i18n-tasks normalise` to sort keys, excludes from prettier check as this formatting conflicts
- Adds missing keys to `targeted_content`, fixing content errors
- Removes unused keys flagged by `i18n-tasks unused`
- Runs `i18n-tasks health` in CI to guard against future issues
