### PR TITLE
fix: apply focus state to active pagination page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+**Bugfixes**
+
+- 🔗 Pagination links: Apply focus state to active page
+
 ## <sub>v4.0.0</sub>
 
 #### _Jan. 14, 2021_

--- a/scss/6-components/_pagination.scss
+++ b/scss/6-components/_pagination.scss
@@ -2,6 +2,13 @@
 // Pagination
 // ============================================================================
 
+@mixin cads-paging-focus() {
+  outline: none;
+  color: $cads-language__focus-text-colour;
+  border-color: $cads-language__focus-border-colour;
+  background-color: $cads-language__focus-colour;
+}
+
 /** @define paging */
 .cads-paging {
   @include cads-reset-list-style();
@@ -24,10 +31,7 @@
   margin-bottom: $cads-spacing-2;
 
   &:focus {
-    outline: none;
-    color: $cads-language__focus-text-colour;
-    border-color: $cads-language__focus-border-colour;
-    background-color: $cads-language__focus-colour;
+    @include cads-paging-focus();
   }
 
   &:hover,
@@ -42,6 +46,10 @@
     color: $cads-palette__white;
     background-color: $cads-language__primary-button-colour;
     border-color: $cads-language__primary-button-colour;
+
+    &:focus {
+      @include cads-paging-focus();
+    }
 
     &:hover {
       border-color: $cads-language__primary-button-hover-colour;


### PR DESCRIPTION
https://citizensadvice.atlassian.net/browse/NP-1490

> Missing focus state on active page on pagination when tabbing.

Turns out this was exactly what it sounds like. Active pages were missing a link focus state.

<img width="686" alt="Screenshot 2021-01-13 at 11 08 05" src="https://user-images.githubusercontent.com/123386/104444681-09066e00-5590-11eb-9eab-55975256c4ee.png">
