### PR TITLE
Fix/np 1504 header accessibility review

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3967,6 +3967,47 @@
         }
       }
     },
+    "@testing-library/react": {
+      "version": "11.2.3",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-11.2.3.tgz",
+      "integrity": "sha512-BirBUGPkTW28ULuCwIbYo0y2+0aavHczBT6N9r3LrsswEW3pg25l1wgoE7I8QBIy1upXWkwKpYdWY7NYYP0Bxw==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.12.5",
+        "@testing-library/dom": "^7.28.1"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.12.5",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.5.tgz",
+          "integrity": "sha512-plcc+hbExy3McchJCEQG3knOsuh3HH+Prx1P6cLIkET/0dLuQDEnrT+s27Axgc9bqfsmNUNHfscgMUdBpC9xfg==",
+          "dev": true,
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        }
+      }
+    },
+    "@testing-library/user-event": {
+      "version": "12.6.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-12.6.0.tgz",
+      "integrity": "sha512-FNEH/HLmOk5GO70I52tKjs7WvGYckeE/SrnLX/ip7z2IGbffyd5zOUM1tZ10vsTphqm+VbDFI0oaXu0wcfQsAQ==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.12.5",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.5.tgz",
+          "integrity": "sha512-plcc+hbExy3McchJCEQG3knOsuh3HH+Prx1P6cLIkET/0dLuQDEnrT+s27Axgc9bqfsmNUNHfscgMUdBpC9xfg==",
+          "dev": true,
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        }
+      }
+    },
     "@types/anymatch": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/@types/anymatch/-/anymatch-1.3.1.tgz",

--- a/package.json
+++ b/package.json
@@ -58,6 +58,8 @@
     "@storybook/html": "^6.1.12",
     "@testing-library/dom": "^7.26.0",
     "@testing-library/jest-dom": "^5.11.8",
+    "@testing-library/react": "^11.2.3",
+    "@testing-library/user-event": "^12.6.0",
     "@types/jest": "^26.0.14",
     "@types/jsdom": "^16.2.4",
     "@typescript-eslint/eslint-plugin": "^4.13.0",

--- a/src/ts/greedy-nav/GreedyNav.test.ts
+++ b/src/ts/greedy-nav/GreedyNav.test.ts
@@ -286,7 +286,7 @@ describe('Greedy Nav', () => {
     });
 
     it('toggles the menu open', () => {
-      const event = new dom.window.FocusEvent('focus');
+      const event = new dom.window.KeyboardEvent('keyup', { key: 'Tab' });
       nav.navDropdownToggle!.dispatchEvent(event);
 
       expect(nav.navDropdown!.className).toContain('show');

--- a/src/ts/greedy-nav/GreedyNav.test.ts
+++ b/src/ts/greedy-nav/GreedyNav.test.ts
@@ -1,6 +1,8 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 /* eslint-disable import/no-extraneous-dependencies */
 import '@testing-library/jest-dom';
+import { fireEvent, createEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { JSDOM } from 'jsdom';
 import path from 'path';
 
@@ -287,8 +289,7 @@ describe('Greedy Nav', () => {
     });
 
     it('toggles the menu open', () => {
-      const event = new dom.window.KeyboardEvent('keyup', { key: 'Tab' });
-      nav.navDropdownToggle!.dispatchEvent(event);
+      fireEvent.keyUp(nav.navDropdownToggle, { key: 'Tab' });
 
       expect(nav.navDropdown!.className).toContain('show');
       expect(nav.mainNavWrapper!.className).toContain('is-open');
@@ -296,17 +297,8 @@ describe('Greedy Nav', () => {
     });
 
     it('when tabbing backwards through the dropdown menu', () => {
-      const siteMenuItem = document.querySelector<HTMLElement>('nav ul li')!;
-
-      const openEvent = new dom.window.MouseEvent('focus');
-
-      nav.navDropdownToggle!.dispatchEvent(openEvent);
-
-      const event = new dom.window.FocusEvent('blur', {
-        relatedTarget: siteMenuItem,
-      });
-
-      nav.navDropdownToggle!.dispatchEvent(event);
+      fireEvent.focus(nav.navDropdownToggle);
+      fireEvent.blur(nav.navDropdownToggle);
 
       expect(nav.navDropdown!.className).not.toContain('show');
       expect(nav.mainNavWrapper!.className).not.toContain('is-open');
@@ -337,7 +329,7 @@ describe('Greedy Nav', () => {
 
     describe('openDropDown', () => {
       it('opens the dropdown menu', () => {
-        nav.openDropDown(nav.mainNavWrapper);
+        userEvent.click(nav.navDropdownToggle);
 
         expect(nav.navDropdown.classList).toContain('show');
       });
@@ -351,17 +343,17 @@ describe('Greedy Nav', () => {
 
     describe('closeDropDown', () => {
       beforeEach(() => {
-        nav.openDropDown(nav.mainNavWrapper);
+        userEvent.click(nav.navDropdownToggle);
       });
 
       it('closes the dropdown menu', () => {
-        nav.closeDropDown(nav.mainNavWrapper);
+        userEvent.click(nav.navDropdownToggle);
 
         expect(nav.navDropdown).not.toContain('show');
       });
 
       it('sets aria-hidden to true on the drop down', () => {
-        nav.closeDropDown(nav.mainNavWrapper);
+        userEvent.click(nav.navDropdownToggle);
 
         expect(nav.navDropdown).toHaveAttribute('aria-hidden', 'true');
       });

--- a/src/ts/greedy-nav/GreedyNav.test.ts
+++ b/src/ts/greedy-nav/GreedyNav.test.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 /* eslint-disable import/no-extraneous-dependencies */
+import '@testing-library/jest-dom';
 import { JSDOM } from 'jsdom';
 import path from 'path';
 
@@ -310,6 +311,60 @@ describe('Greedy Nav', () => {
       expect(nav.navDropdown!.className).not.toContain('show');
       expect(nav.mainNavWrapper!.className).not.toContain('is-open');
       expect(nav.navDropdownToggle!.innerHTML).toContain('More');
+    });
+  });
+
+  describe('menu opening and closing', () => {
+    let dom: JSDOM;
+    let document: HTMLDocument;
+    let nav: GreedyNavMenu;
+
+    beforeEach(async () => {
+      dom = await JSDOM.fromFile(
+        path.join(__dirname, './__fixtures__/menu.html'),
+        { url: 'http://www.example.com/menu.html' }
+      );
+
+      document = dom.window.document;
+
+      nav = new GreedyNavMenu(defaultConfig, document);
+      nav.init();
+    });
+
+    afterEach(() => {
+      document.body.innerHTML = '';
+    });
+
+    describe('openDropDown', () => {
+      it('opens the dropdown menu', () => {
+        nav.openDropDown(nav.mainNavWrapper);
+
+        expect(nav.navDropdown.classList).toContain('show');
+      });
+
+      it('sets aria-hidden to false on the drop down', () => {
+        nav.openDropDown(nav.mainNavWrapper);
+
+        expect(nav.navDropdown!).toHaveAttribute('aria-hidden', 'false');
+      });
+    });
+
+    describe('closeDropDown', () => {
+      beforeEach(() => {
+        nav.openDropDown(nav.mainNavWrapper);
+      });
+
+      it('closes the dropdown menu', () => {
+        nav.closeDropDown(nav.mainNavWrapper);
+
+        expect(nav.navDropdown).not.toContain('show');
+      });
+
+      it('sets aria-hidden to true on the drop down', () => {
+        nav.closeDropDown(nav.mainNavWrapper);
+
+        expect(nav.navDropdown).toHaveAttribute('aria-hidden', 'true');
+      });
     });
   });
 });

--- a/src/ts/greedy-nav/GreedyNav.ts
+++ b/src/ts/greedy-nav/GreedyNav.ts
@@ -882,8 +882,6 @@ export class GreedyNavMenu {
       this.navDropdownToggleSelector
     );
 
-    console.log('open');
-
     if (navDropdown && navDropdownToggle) {
       navDropdown.classList.add('show');
       navDropdownToggle.classList.add('is-open');

--- a/src/ts/greedy-nav/GreedyNav.ts
+++ b/src/ts/greedy-nav/GreedyNav.ts
@@ -625,15 +625,12 @@ export class GreedyNavMenu {
      * Remove when clicked outside dropdown
      */
     this.document.addEventListener('click', (event: MouseEvent) => {
-      const navDropdown = navWrapper.querySelector<HTMLElement>(
-        this.navDropdownSelector
-      );
       if (
         event.target &&
         !getClosest(<HTMLElement>event.target, `.${navDropdownClassName}`) &&
         navDropdownToggle &&
         event.target !== navDropdownToggle &&
-        navDropdown
+        navWrapper.classList.contains('is-open')
       ) {
         this.closeDropDown(navWrapper);
       }

--- a/src/ts/greedy-nav/GreedyNav.ts
+++ b/src/ts/greedy-nav/GreedyNav.ts
@@ -107,44 +107,6 @@ const parent = (element: Nullable<HTMLElement>, parentNode: Nullable<Node>) => {
 };
 
 /**
- * Toggle class on element
- * @param el
- * @param className
- */
-const toggleClass = (el: HTMLElement, className: string) => {
-  if (el.classList) {
-    el.classList.toggle(className);
-  } else {
-    const classes = el.className.split(' ');
-    const existingIndex = classes.indexOf(className);
-
-    if (existingIndex >= 0) classes.splice(existingIndex, 1);
-    else classes.push(className);
-
-    // eslint-disable-next-line no-param-reassign
-    el.className = classes.join(' ');
-  }
-};
-
-const removeClass = (el: HTMLElement, className: string) => {
-  if (el.classList) {
-    el.classList.remove(className);
-  } else {
-    // eslint-disable-next-line no-param-reassign
-    el.className = el.className.replace(new RegExp(`s?${className}s?`), '');
-  }
-};
-
-const addClass = (el: HTMLElement, className: string) => {
-  if (el.classList) {
-    el.classList.add(className);
-  } else {
-    // eslint-disable-next-line no-param-reassign
-    el.className = `${el.className} ${className}`;
-  }
-};
-
-/**
  * Show/hide toggle button
  */
 export const showToggle = (
@@ -587,91 +549,38 @@ export class GreedyNavMenu {
       },
       true
     );
-    // }
-    const {
-      navDropdownClassName,
-      navDropdownLabelActive,
-      navDropdownLabel,
-    } = this.settings;
+
+    const { navDropdownClassName } = this.settings;
 
     const navDropdownToggle = navWrapper.querySelector<HTMLElement>(
       this.navDropdownToggleSelector
     );
 
     if (navDropdownToggle) {
-      // Toggle dropdown
-      navDropdownToggle.addEventListener('mousedown', (event) => {
-        const navDropdown = navWrapper.querySelector<HTMLElement>(
-          this.navDropdownSelector
-        );
-
-        if (navDropdown) {
-          event.stopPropagation();
-          toggleClass(navDropdown, 'show');
-
-          if (event.currentTarget) {
-            toggleClass(<HTMLElement>event.currentTarget, 'is-open');
-          }
-          toggleClass(navWrapper, 'is-open');
-
-          /**
-           * Toggle aria hidden for accessibility
-           */
-          if (navWrapper.classList.contains('is-open')) {
-            navDropdown.setAttribute('aria-hidden', 'true');
-
-            updateLabel(
-              navWrapper,
-              navDropdownLabelActive,
-              this.navDropdownToggleSelector,
-              this.settings.navDropdownLabelActive
-            );
-
-            navDropdown.blur();
-          } else {
-            navDropdown.setAttribute('aria-hidden', 'false');
-
-            updateLabel(
-              navWrapper,
-              navDropdownLabel,
-              this.navDropdownToggleSelector,
-              this.settings.navDropdownLabelActive
-            );
-          }
+      navDropdownToggle.addEventListener('mouseup', (event: MouseEvent) => {
+        if (navWrapper.classList.contains('is-open')) {
+          this.closeDropDown(navWrapper);
+        } else {
+          this.openDropDown(navWrapper);
         }
       });
     }
 
     const lastItemCloseHandler = (event: FocusEvent) => {
+      console.log('closing from last item close handler');
       if (this.toggleWrapper === null) {
         return;
       }
 
-      const navDropdown = navWrapper.querySelector<HTMLElement>(
-        this.navDropdownSelector
-      );
+      if (!parent(relatedTarget(event, document), this.toggleWrapper)) {
+        this.closeDropDown(navWrapper);
 
-      if (
-        !parent(relatedTarget(event, document), this.toggleWrapper) &&
-        navDropdown &&
-        navDropdownToggle
-      ) {
-        removeClass(navDropdown, 'show');
-        removeClass(navDropdownToggle, 'is-open');
-        removeClass(navWrapper, 'is-open');
-        updateLabel(
-          navWrapper,
-          navDropdownLabel,
-          this.navDropdownToggleSelector,
-          this.settings.navDropdownLabelActive
-        );
-
-        const navDropdownLink = navWrapper.querySelector<HTMLElement>(
+        const navLastDropdownLink = navWrapper.querySelector<HTMLElement>(
           `${this.navDropdownSelector} li:last-child a`
         );
 
-        if (navDropdownLink) {
-          navDropdownLink.removeEventListener(
+        if (navLastDropdownLink) {
+          navLastDropdownLink.removeEventListener(
             blurEventName,
             lastItemCloseHandler
           );
@@ -679,38 +588,15 @@ export class GreedyNavMenu {
       }
     };
 
-    if (navDropdownToggle) {
-      navDropdownToggle.addEventListener('focus', (event: FocusEvent) => {
-        const navDropdown = navWrapper.querySelector<HTMLElement>(
-          this.navDropdownSelector
-        );
-
-        if (navDropdown) {
-          if (navWrapper.className.indexOf('is-open') === -1) {
-            addClass(navDropdown, 'show');
-            if (
-              event.currentTarget &&
-              event.currentTarget instanceof HTMLElement
-            ) {
-              addClass(event.currentTarget, 'is-open');
-            }
-            addClass(navWrapper, 'is-open');
-            updateLabel(
-              navWrapper,
-              navDropdownLabelActive,
-              this.navDropdownToggleSelector,
-              this.settings.navDropdownLabelActive
-            );
-
-            /**
-             * Toggle aria hidden for accessibility
-             */
-            navDropdown.setAttribute('aria-hidden', 'false');
-            navDropdown.blur();
-          }
+    navWrapper.addEventListener('keyup', (event) => {
+      if (event.key === 'Tab' && document.activeElement === navDropdownToggle) {
+        if (navWrapper.classList.contains('is-open')) {
+          this.closeDropDown(navWrapper);
+        } else {
+          this.openDropDown(navWrapper);
         }
-      });
-    }
+      }
+    });
 
     if (navDropdownToggle && this.toggleWrapper) {
       navDropdownToggle.addEventListener(
@@ -723,29 +609,6 @@ export class GreedyNavMenu {
                 `${this.navDropdownSelector} li:last-child a`
               )
               ?.removeEventListener(blurEventName, lastItemCloseHandler);
-
-            navWrapper
-              .querySelector<HTMLElement>(this.navDropdownSelector)
-              ?.classList.remove('show');
-
-            (<HTMLElement>e.currentTarget)?.classList.remove('is-open');
-
-            (<HTMLElement>e.currentTarget)?.classList.remove('is-open');
-            navWrapper.classList.remove('is-open');
-
-            updateLabel(
-              navWrapper,
-              this.settings.navDropdownLabel,
-              this.navDropdownToggleSelector,
-              this.settings.navDropdownLabelActive
-            );
-
-            /**
-             * Toggle aria hidden for accessibility
-             */
-            navWrapper
-              .querySelector<HTMLElement>(this.navDropdownSelector)
-              ?.setAttribute('aria-hidden', 'false');
           } else {
             // tabbing forwards
             this.document
@@ -772,15 +635,7 @@ export class GreedyNavMenu {
         event.target !== navDropdownToggle &&
         navDropdown
       ) {
-        navDropdown.classList.remove('show');
-        navDropdown.classList.remove('is-open');
-        navWrapper.classList.remove('is-open');
-        updateLabel(
-          navWrapper,
-          navDropdownLabel,
-          this.navDropdownToggleSelector,
-          this.settings.navDropdownLabelActive
-        );
+        this.closeDropDown(navWrapper);
       }
     });
 
@@ -791,17 +646,7 @@ export class GreedyNavMenu {
       const event = evt || window.event;
 
       if (event.keyCode === 27) {
-        const navDropdown = this.document.querySelector<HTMLElement>(
-          this.navDropdownSelector
-        );
-        if (navDropdown) {
-          navDropdown.classList.remove('show');
-          navDropdown.classList.remove('is-open');
-        }
-
-        if (this.mainNavWrapper) {
-          this.mainNavWrapper.classList.remove('is-open');
-        }
+        this.closeDropDown(navWrapper);
       }
     };
   }
@@ -1026,6 +871,63 @@ export class GreedyNavMenu {
     // Remove toggle
     if (this.toggleWrapper) {
       this.toggleWrapper.remove();
+    }
+  }
+
+  openDropDown(navWrapper: HTMLElement): void {
+    const { navDropdownLabelActive } = this.settings;
+
+    const navDropdown = navWrapper.querySelector<HTMLElement>(
+      this.navDropdownSelector
+    );
+
+    const navDropdownToggle = navWrapper.querySelector<HTMLElement>(
+      this.navDropdownToggleSelector
+    );
+
+    if (navDropdown && navDropdownToggle) {
+      navDropdown.classList.add('show');
+      navDropdownToggle.classList.add('is-open');
+      navWrapper.classList.add('is-open');
+
+      navDropdown.setAttribute('aria-hidden', 'false');
+      updateLabel;
+
+      updateLabel(
+        navWrapper,
+        navDropdownLabelActive,
+        this.navDropdownToggleSelector,
+        navDropdownLabelActive
+      );
+    }
+  }
+
+  closeDropDown(navWrapper: HTMLElement): void {
+    const { navDropdownLabel, navDropdownLabelActive } = this.settings;
+
+    const navDropdown = navWrapper.querySelector<HTMLElement>(
+      this.navDropdownSelector
+    );
+
+    const navDropdownToggle = navWrapper.querySelector<HTMLElement>(
+      this.navDropdownToggleSelector
+    );
+
+    if (navDropdown && navDropdownToggle) {
+      navDropdown.classList.remove('show');
+      navDropdownToggle.classList.remove('is-open');
+      navWrapper.classList.remove('is-open');
+
+      navDropdown.setAttribute('aria-hidden', 'true');
+
+      updateLabel(
+        navWrapper,
+        navDropdownLabel,
+        this.navDropdownToggleSelector,
+        navDropdownLabelActive
+      );
+
+      navDropdown.blur();
     }
   }
 }

--- a/src/ts/greedy-nav/GreedyNav.ts
+++ b/src/ts/greedy-nav/GreedyNav.ts
@@ -567,7 +567,6 @@ export class GreedyNavMenu {
     }
 
     const lastItemCloseHandler = (event: FocusEvent) => {
-      console.log('closing from last item close handler');
       if (this.toggleWrapper === null) {
         return;
       }
@@ -588,15 +587,11 @@ export class GreedyNavMenu {
       }
     };
 
+    /* Open when tabbing into the toggle */
     if (navDropdownToggle) {
       navDropdownToggle.addEventListener('keyup', (event) => {
-        if (
-          !event.shiftKey &&
-          event.key === 'Tab' &&
-          document.activeElement === navDropdownToggle
-        ) {
+        if (!event.shiftKey && event.key === 'Tab') {
           this.openDropDown(navWrapper);
-        } else {
         }
       });
     }

--- a/src/ts/greedy-nav/GreedyNav.ts
+++ b/src/ts/greedy-nav/GreedyNav.ts
@@ -588,15 +588,18 @@ export class GreedyNavMenu {
       }
     };
 
-    navWrapper.addEventListener('keyup', (event) => {
-      if (event.key === 'Tab' && document.activeElement === navDropdownToggle) {
-        if (navWrapper.classList.contains('is-open')) {
-          this.closeDropDown(navWrapper);
-        } else {
+    if (navDropdownToggle) {
+      navDropdownToggle.addEventListener('keyup', (event) => {
+        if (
+          !event.shiftKey &&
+          event.key === 'Tab' &&
+          document.activeElement === navDropdownToggle
+        ) {
           this.openDropDown(navWrapper);
+        } else {
         }
-      }
-    });
+      });
+    }
 
     if (navDropdownToggle && this.toggleWrapper) {
       navDropdownToggle.addEventListener(
@@ -609,6 +612,8 @@ export class GreedyNavMenu {
                 `${this.navDropdownSelector} li:last-child a`
               )
               ?.removeEventListener(blurEventName, lastItemCloseHandler);
+
+            this.closeDropDown(navWrapper);
           } else {
             // tabbing forwards
             this.document
@@ -882,13 +887,14 @@ export class GreedyNavMenu {
       this.navDropdownToggleSelector
     );
 
+    console.log('open');
+
     if (navDropdown && navDropdownToggle) {
       navDropdown.classList.add('show');
       navDropdownToggle.classList.add('is-open');
       navWrapper.classList.add('is-open');
 
       navDropdown.setAttribute('aria-hidden', 'false');
-      updateLabel;
 
       updateLabel(
         navWrapper,
@@ -923,8 +929,6 @@ export class GreedyNavMenu {
         this.navDropdownToggleSelector,
         navDropdownLabelActive
       );
-
-      navDropdown.blur();
     }
   }
 }


### PR DESCRIPTION
The accessibility bug was caused by the `aria-hidden` attribute remaining `true` when the more dropdown is first opened.  The code contained duplicated code for opening and closing the menu which was slightly different in different circumstances.

This PR:
 - creates `openDropDown()` and `closeDropDown()` methods
 - refactors existing code to use these methods where appropriate
 - adds test to support new methods
 - changes tab opening listener to `keyup` to simplify tab listener
