### PR TITLE
feat: show links and search in absence of js

### DIFF
--- a/scss/6-components/_header.scss
+++ b/scss/6-components/_header.scss
@@ -126,3 +126,24 @@
     display: block;
   }
 }
+
+/* stylelint-disable no-descending-specificity */
+.no-js {
+  .cads-header__search-reveal {
+    @include cads-media-breakpoint-only(sm) {
+      display: none;
+    }
+  }
+
+  .cads-header__search-row {
+    @include cads-media-breakpoint-only(sm) {
+      display: block;
+    }
+  }
+  .cads-header__links {
+    @include cads-media-breakpoint-only(sm) {
+      display: block;
+      margin-top: $cads-spacing-2;
+    }
+  }
+}

--- a/scss/6-components/_header.scss
+++ b/scss/6-components/_header.scss
@@ -7,7 +7,7 @@
   background-color: $cads-header__background-colour;
   padding: $cads-spacing-4 0;
 
-  .cads-header__hyperlink {
+  &__hyperlink {
     color: $cads-header__link-colour;
 
     &:hover {
@@ -30,12 +30,12 @@
     }
   }
 
-  .cads-header__text {
+  &__text {
     color: $cads-language__secondary-text-colour;
     font-weight: $cads-font-weight__bold;
   }
 
-  .cads-header__search-reveal {
+  &__search-reveal {
     @include cads-button-defaults();
 
     display: none;
@@ -60,7 +60,7 @@
     }
   }
 
-  .cads-header__links {
+  &__links {
     @extend %cads-list-unordered-inline;
 
     text-align: right;
@@ -144,6 +144,12 @@
     @include cads-media-breakpoint-only(sm) {
       display: block;
       margin-top: $cads-spacing-2;
+    }
+  }
+
+  .cads-header__links-item {
+    @include cads-media-breakpoint-only(sm) {
+      margin-bottom: $cads-spacing-4;
     }
   }
 }


### PR DESCRIPTION
Shows search input and links in the header when javascript is not loaded.

![image](https://user-images.githubusercontent.com/2331893/105174622-bd693c80-5b1a-11eb-9d2d-cec1fd8dfae2.png)

Updated margins as per @minniessuyuhuang request, reduced specificity of header classes to remove conflict with no-js class