### PR TITLE
No need to run build as a prerequisite  to eslint or jest tasks

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -73,13 +73,13 @@ namespace :npm do
   end
 
   desc "Run jest tests in node"
-  task jest: :build do
+  task :jest do
     puts "Running jest tests"
     system("npm run jest") || raise
   end
 
   desc "Run linting jobs in node"
-  task lint: :build do
+  task :lint do
     puts "Running Node lint"
     system("npm run lint") || raise
   end


### PR DESCRIPTION
Small build improvement I spotted whilst doing this experiment: https://github.com/citizensadvice/design-system/pull/757

Remove `build` dependency from `npm:lint` and `npm:jest` step. It shouldn't be needed and results in us doing unnecessary builds.