### PR TITLE
feat: header sign out link can be a form [NP-1604]

### DIFF
--- a/haml/_header.html.haml
+++ b/haml/_header.html.haml
@@ -29,7 +29,11 @@
 
           - if sign_in_out
             %li.cads-header__account-link
-              %a.cads-header__hyperlink{href: sign_in_out["url"], "data-testid": "account-link"}= sign_in_out["title"]
+              - if sign_in_out["form"]
+                %form{method: "POST", action: sign_in_out["url"]}
+                  %button.cads-linkbutton__regular= sign_in_out["title"]
+              - else
+                %a.cads-header__hyperlink{href: sign_in_out["url"], "data-testid": "account-link"}= sign_in_out["title"]
         .cads-header__search-form
           %form.cads-search.cads-search--icon-only{ action: search_action_url, role: "search" }
             %input.cads-search__input.cads-input{ type: "search", name: "q", "aria-label": t("cads.search.input_aria_label") }

--- a/haml/_header.html.haml
+++ b/haml/_header.html.haml
@@ -30,7 +30,7 @@
           - if sign_in_out
             %li.cads-header__account-link
               - if sign_in_out["form"]
-                %form{method: "POST", action: sign_in_out["url"]}
+                %form.cads-header__account-form{method: "POST", action: sign_in_out["url"]}
                   %button.cads-linkbutton__regular= sign_in_out["title"]
               - else
                 %a.cads-header__hyperlink{href: sign_in_out["url"], "data-testid": "account-link"}= sign_in_out["title"]

--- a/scss/4-elements/_links.scss
+++ b/scss/4-elements/_links.scss
@@ -3,7 +3,8 @@
  */
 a,
 .cads-hyperlink,
-.cads-linkbutton {
+.cads-linkbutton,
+.cads-linkbutton__regular {
   color: $cads-language__link-colour;
   text-decoration: underline;
 
@@ -41,12 +42,24 @@ a,
   @include cads-hyperlink--external-icon;
 }
 
-// Reset button styles when styled like a link link
-button.cads-linkbutton {
+// Reset button styles when styled like a link
+%cads-linkbutton-base {
   -webkit-appearance: none;
   border: none;
   background: transparent;
   padding: 0;
   box-shadow: none;
+}
+
+button.cads-linkbutton {
+  @extend %cads-linkbutton-base;
+
   font-weight: $cads-font-weight__bold;
+}
+
+button.cads-linkbutton__regular {
+  @extend %cads-linkbutton-base;
+
+  cursor: pointer;
+  font-weight: $cads-font-weight__regular;
 }

--- a/scss/6-components/_navigation_greedy-nav.scss
+++ b/scss/6-components/_navigation_greedy-nav.scss
@@ -59,6 +59,27 @@
     &.show {
       visibility: visible;
     }
+
+    .cads-header__links-item,
+    .cads-header__account-link {
+      padding-left: 0;
+      margin-left: 0;
+      border-left: none; // only on .cads-header__account-link
+    }
+
+    .cads-linkbutton__regular {
+      @include cads-nav-link;
+
+      font-weight: bold;
+      text-align: right;
+      display: block;
+      padding-right: 1rem;
+      width: 100%;
+
+      &:focus {
+        @include cads-nav-link-focus;
+      }
+    }
   }
 
   &__dropdown-toggle {

--- a/scss/6-components/_navigation_greedy-nav.scss
+++ b/scss/6-components/_navigation_greedy-nav.scss
@@ -71,8 +71,9 @@
       @include cads-nav-link;
 
       font-weight: bold;
-      text-align: right;
+      text-align: left;
       display: block;
+      padding-left: 1rem;
       padding-right: 1rem;
       width: 100%;
 
@@ -153,5 +154,9 @@
   &__header-links,
   &__header-links li:first-child {
     margin-top: $cads-spacing-2;
+  }
+
+  .cads-header__links {
+    text-align: left;
   }
 }

--- a/styleguide/components/buttons/buttons.stories.mdx
+++ b/styleguide/components/buttons/buttons.stories.mdx
@@ -15,7 +15,7 @@ Write button text in sentence case, describing the action it performs. E.g. “S
 export const buttonPrimaryHtml = `<button type="button" class="cads-button cads-button__primary">Primary button</button>`;
 export const buttonSecondaryHtml = `<button type="button" class="cads-button cads-button__secondary">Secondary button</button>`;
 export const buttonTertiaryHtml = `<button type="button" class="cads-button cads-button__tertiary">Tertiary button</button>`;
-export const buttonLinkHtml = `<button type="button" class="cads-linkbutton">Link button</button>`;
+export const buttonLinkHtml = `<button type="button" class="cads-linkbutton">Link button</button>\n<button type="button" class="cads-linkbutton__regular">Regular link button</button>`;
 
 Primary buttons should be used for the main action, such as submitting a form. Align the primary action button to the left edge of your form.
 
@@ -50,10 +50,21 @@ Tertiary buttons are used for turning something on or off instantly on a page �
   </Story>
 </Preview>
 
+Link buttons are styled to look like hyperpinks. Use these when you want a button to draw less attention, or when you would prefer to have a text styling but the action changes state such as deleting an item or logging out a user.
+
+<Preview>
+  <Story
+    name="LinkButton"
+    parameters={{ docs: { source: { code: buttonLinkHtml } } }}
+  >
+    {() => buttonLinkHtml}
+  </Story>
+</Preview>
+
 ## Using buttons with icons
 
-Icons can be placed next to the button label to clarify an action or call attention. Buttons can be used with either a left or right aligned icon.  
-The spacing between an icon and the button text should be 4px. Use the small icon (16px) within a button.  
+Icons can be placed next to the button label to clarify an action or call attention. Buttons can be used with either a left or right aligned icon.
+The spacing between an icon and the button text should be 4px. Use the small icon (16px) within a button.
 The icon must be the same color value as the text.
 
 <img src={buttonIconExample} style={{ width: '300px' }} />
@@ -77,5 +88,5 @@ In different contexts, you can use primary and secondary buttons side by side. Y
 Buttons have a clear `:focus` style when tabbing or focussing on the button
 When selecting a button, it will depress slightly to give users visual feedback that an action has taken place.
 
-Use `<input type=submit>` or `<button>` elements depending on if the button submits a form, or performs an interaction.  
+Use `<input type=submit>` or `<button>` elements depending on if the button submits a form, or performs an interaction.
 Do not use anchor tags with an empty href when you want a button `<a href=”#”>`. Read more about [why the empty href is a bad thing](https://adrianroselli.com/2016/01/links-buttons-submits-and-divs-oh-hell.html).

--- a/styleguide/components/header/header.stories.mdx
+++ b/styleguide/components/header/header.stories.mdx
@@ -37,6 +37,7 @@ The Haml partial supports the following locals:
 | `sign_in_out`              | Optional, a hash with the following:                    |
 | `sign_in_out[url]`         | &rarr; Required, url for the sign in link               |
 | `sign_in_out[title] `      | &rarr; Required, title for the sign in link             |
+| `sign_in_out[form] `       | &rarr; Optional, display the link in a form             |
 | `search_action_url`        | Required, URL for the search form                       |
 | `main_content_anchor_link` | Optional, defaults to `#cads-main-content`              |
 | `homepage_url`             | Optional, defaults to `/`                               |

--- a/styleguide/haml_locals.rb
+++ b/styleguide/haml_locals.rb
@@ -123,7 +123,7 @@
       { "title" => "AdviserNet", "url" => "?advisernet" }, { "title" => "CABlink", "url" => "?CABlink" },
       { "title" => "BMIS", "url" => "?BMIS" }, { "title" => "Cymraeg", "url" => "?lang=cy" }
     ],
-    "sign_in_out" => { "title" => "Sign out", "url" => "/sign-out/out" },
+    "sign_in_out" => { "title" => "Sign out", "url" => "/sign-out/out", "form" => true },
     "search_action_url" => "/search",
     "homepage_url" => "/"
   },


### PR DESCRIPTION
Adds support for rendering the sign out link as a form.

* Add a `cads-linkbutton__regular` class as link buttons are usually bold
* Add `form` boolean parameter to header links
* Add styles for mobile dropdown
* Fix styling so header links displayed in dropdown stretch full length of the dropdown (previously had 1rem left padding which differs from other navigation links)
* Update docs to include link button styling.

<img width="603" alt="Screenshot 2021-01-25 at 14 35 40" src="https://user-images.githubusercontent.com/45935/105720304-31408600-5f1b-11eb-842c-a79422e518b9.png">
should look the same as before

<img width="403" alt="Screenshot 2021-01-25 at 15 31 31" src="https://user-images.githubusercontent.com/45935/105726905-71efcd80-5f22-11eb-8f9d-84b61ad2d611.png">

Mobile dropdown styling

