### PR TITLE
feature: Disable Mobile testing for Design-System [NP-1591]

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,8 +8,12 @@ configurationTypes = [
   ['Windows_7_78', 'firefox'],
   ['OSX_Mojave_84', 'chrome'],
   ['OSX_Mojave_12', 'safari'],
-  ['iPhone11_13', 'ios'],
-  ['iPhone8_12', 'ios'],
+// These have been disabled (25/1/21) and will not be permissible
+// until two extra pieces of work have been done and BS licenses
+// switched over to new format
+// ETA - 2nd/3rd week February 2021 - LH
+//   ['iPhone11_13', 'ios'],
+//   ['iPhone8_12', 'ios'],
 ]
 
 cron_schedule = isRelease ? '0 2 * * *' : ''


### PR DESCRIPTION
Temporary measure for 3-4 weeks whilst we ...

- Sign our new BS contract
- Migrate all users over to new "potting" system
- Work out how to get manual runs working again
- Fix up VAULT access for Dual Access API keys

Then we can re-enable the testing on iPhones
