### PR TITLE
test: read backstopjs version from visual-regression folder

### DIFF
--- a/bin/docker/visual_regression
+++ b/bin/docker/visual_regression
@@ -7,6 +7,9 @@ docker-compose up -d ca-styleguide
 
 # run visual regression tests
 # Get version string from npm inside a context with npm accessible
-version_string=`docker-compose run --volume "$(pwd)/testing/visual-regression:/bs:ro" ca-styleguide npm --prefix /bs view backstopjs version`
+version_string=`docker-compose run --volume "$(pwd)/testing:/bs:ro" ca-styleguide \
+                /bin/sh -c "npm list --silent --prefix /bs --depth=0 --json \
+                | jq --raw-output '.dependencies.backstopjs.version'"`
+echo "Using BackstopJS version ${version_string}"
 # Use the version string and strip the additional \r that docker-compose output adds
 BACKSTOPJS_VERSION=${version_string//[[:cntrl:]]/} docker-compose run visual-tests

--- a/bin/docker/visual_regression
+++ b/bin/docker/visual_regression
@@ -7,6 +7,6 @@ docker-compose up -d ca-styleguide
 
 # run visual regression tests
 # Get version string from npm inside a context with npm accessible
-version_string=`docker-compose run ca-styleguide npm view backstopjs version`
+version_string=`docker-compose run --volume "$(pwd)/testing/visual-regression:/bs:ro" ca-styleguide npm --prefix /bs view backstopjs version`
 # Use the version string and strip the additional \r that docker-compose output adds
 BACKSTOPJS_VERSION=${version_string//[[:cntrl:]]/} docker-compose run visual-tests

--- a/docker/Dockerfile.ca-styleguide
+++ b/docker/Dockerfile.ca-styleguide
@@ -6,7 +6,7 @@ ENV NODE_MAJOR_VERSION=14 \
     BUNDLE_JOBS=6 \
     BUNDLE_RETRY=3
 
-RUN apk add --no-cache build-base inotify-tools && \
+RUN apk add --no-cache build-base inotify-tools jq && \
     gem install bundler -v $BUNDLER_VERSION && \
     # These next 2 lines essentially do a fancy form of apt-get clean (In alpine)
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \


### PR DESCRIPTION
`backstopjs` is part of a sub project, so we need to read the version number from the correct package.json.