### PR TITLE
Fix: close menu on last item blur [NP-1624]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+**Bugfixes**
+- 🌎 Navigation: tabbing off last item in the dropdown closes the dropdown
+
 ## <sub>v4.0.2-alpha.0</sub>
 
 #### _Jan. 25, 2021_

--- a/src/ts/greedy-nav/GreedyNav.test.ts
+++ b/src/ts/greedy-nav/GreedyNav.test.ts
@@ -277,7 +277,7 @@ describe('Greedy Nav', () => {
       nav = new GreedyNavMenu(defaultConfig, document);
       nav.init();
 
-      // Change the viewport to 500px.
+      // Change the viewport to 300px.
       global.innerWidth = 300;
 
       // Trigger the window resize event.

--- a/src/ts/greedy-nav/GreedyNav.ts
+++ b/src/ts/greedy-nav/GreedyNav.ts
@@ -603,19 +603,18 @@ export class GreedyNavMenu {
       navDropdownToggle.addEventListener(
         blurEventName,
         (e: FocusEvent): void => {
-          let lastItem: Nullable<HTMLElement> = null;
+          let lastItem: Nullable<HTMLElement> | undefined = null;
           const headerLinksInNav: Nullable<HTMLElement> = document.querySelector(
             `${this.navDropdownSelector} .js-cads-copy-into-nav`
           );
 
           if (headerLinksInNav?.offsetParent !== null) {
-            console.log('header links visible in nav', headerLinksInNav);
-            lastItem = headerLinksInNav!.querySelector(
+            lastItem = headerLinksInNav?.querySelector(
               '.js-cads-close-on-blur'
             );
           } else {
-            lastItem = document.querySelector(
-              `${this.navDropdownSelector} li:nth-last-child(2) a`
+            lastItem = this.navDropdown?.querySelector(
+              `li:nth-last-child(2) a`
             );
           }
 

--- a/src/ts/greedy-nav/GreedyNav.ts
+++ b/src/ts/greedy-nav/GreedyNav.ts
@@ -479,6 +479,14 @@ export class GreedyNavMenu {
 
     const headerLinks = document.querySelector('.js-cads-copy-into-nav');
     if (headerLinks) {
+      // prepare items that can close the more dropdown on blur
+      const closeNavOnBlur = headerLinks.lastElementChild?.querySelectorAll(
+        'a, button'
+      );
+      closeNavOnBlur?.forEach((el) =>
+        el.classList.add('js-cads-close-on-blur')
+      );
+
       const headerLinksClone = headerLinks.cloneNode(true);
       const headerLinksContainer = document.createElement('li');
       headerLinksContainer.className = 'cads-greedy-nav__header-links';
@@ -595,22 +603,30 @@ export class GreedyNavMenu {
       navDropdownToggle.addEventListener(
         blurEventName,
         (e: FocusEvent): void => {
+          let lastItem: Nullable<HTMLElement> = null;
+          const headerLinksInNav: Nullable<HTMLElement> = document.querySelector(
+            `${this.navDropdownSelector} .js-cads-copy-into-nav`
+          );
+
+          if (headerLinksInNav?.offsetParent !== null) {
+            console.log('header links visible in nav', headerLinksInNav);
+            lastItem = headerLinksInNav!.querySelector(
+              '.js-cads-close-on-blur'
+            );
+          } else {
+            lastItem = document.querySelector(
+              `${this.navDropdownSelector} li:nth-last-child(2) a`
+            );
+          }
+
           if (!parent(relatedTarget(e, this.document), this.toggleWrapper)) {
             // tabbing backwards
-            this.document
-              .querySelector<HTMLElement>(
-                `${this.navDropdownSelector} li:last-child a`
-              )
-              ?.removeEventListener(blurEventName, lastItemCloseHandler);
+            lastItem?.removeEventListener(blurEventName, lastItemCloseHandler);
 
             this.closeDropDown(navWrapper);
           } else {
             // tabbing forwards
-            this.document
-              .querySelector<HTMLElement>(
-                `${this.navDropdownSelector} li:last-child a`
-              )
-              ?.addEventListener(blurEventName, lastItemCloseHandler);
+            lastItem?.addEventListener(blurEventName, lastItemCloseHandler);
           }
         }
       );

--- a/src/ts/greedy-nav/__fixtures__/menu.html
+++ b/src/ts/greedy-nav/__fixtures__/menu.html
@@ -59,6 +59,40 @@
               More from us
             </a>
           </li>
+          <li class="cads-greedy-nav__header-links">
+            <ul class="cads-header__links js-cads-copy-into-nav">
+              <li class="cads-header__links-item">
+                <span class="cads-header__text"> Public site </span>
+              </li>
+              <li class="cads-header__links-item">
+                <a class="cads-header__hyperlink" href="?advisernet"
+                  >AdviserNet</a
+                >
+              </li>
+              <li class="cads-header__links-item">
+                <a class="cads-header__hyperlink" href="?CABlink">CABlink</a>
+              </li>
+              <li class="cads-header__links-item">
+                <a class="cads-header__hyperlink" href="?BMIS">BMIS</a>
+              </li>
+              <li class="cads-header__links-item">
+                <a class="cads-header__hyperlink" href="?lang=cy">Cymraeg</a>
+              </li>
+              <li class="cads-header__account-link">
+                <form
+                  action="/sign-out/out"
+                  class="cads-header__account-form"
+                  method="POST"
+                >
+                  <button
+                    class="cads-linkbutton__regular js-cads-close-on-blur"
+                  >
+                    Sign out
+                  </button>
+                </form>
+              </li>
+            </ul>
+          </li>
         </ul>
       </nav>
     </div>


### PR DESCRIPTION
Restores the close on blur functionality for the last item in the greedy nav dropdown. 

 - updates header link copying to include a `js-cads` class later used to identify the last item in the copied header links (handles both `a` and `button` elements for Sign out
 - calculates the last item in the dropdown based on whether the copied links are visible or not 
 - update test fixtures to include the copied links