### PR TITLE
Feature/np 1589 heading levels targeted content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 **Bugfixes**
 
 - 🔗 Link Buttons: fixed a visual bug with focus styling
+
+**New**
+
+- 🎯 Targeted content: you can now specifiy the heading level of the title element
 ## <sub>v4.0.2-alpha.1</sub>
 
 #### _Jan. 27, 2021_

--- a/haml/_targeted_content.html.haml
+++ b/haml/_targeted_content.html.haml
@@ -5,8 +5,8 @@
   title = targeted_content["title"].squish
   body = targeted_content["body"]
   # Allow control over heading level, default to h2
-  heading_level = targeted_content.fetch("heading_level", 2)
-  heading_tag = "h#{heading_level}"
+  heading_level = targeted_content.fetch("heading_level", 2).to_i
+  heading_tag = "h#{heading_level.clamp(1, 6)}"
   # Allow disabling toggleable behaviour (mostly for tests)
   is_toggleable = targeted_content.fetch("is_toggleable", true)
 

--- a/haml/_targeted_content.html.haml
+++ b/haml/_targeted_content.html.haml
@@ -23,7 +23,7 @@
   }
 
   heading_attributes = {
-    class: ["cads-targeted-content__title", "js-cads-targeted-content__title"],
+    class: %w[cads-targeted-content__title js-cads-targeted-content__title],
     id: "h-#{id}"
   }
 

--- a/haml/_targeted_content.html.haml
+++ b/haml/_targeted_content.html.haml
@@ -4,6 +4,7 @@
   id = targeted_content["id"]
   title = targeted_content["title"].squish
   body = targeted_content["body"]
+  heading_level = targeted_content.fetch("heading_level", 2)
   # Allow disabling toggleable behaviour (mostly for tests)
   is_toggleable = targeted_content.fetch("is_toggleable", true)
 
@@ -19,8 +20,10 @@
     }
   }
 
+
+
 .cads-targeted-content{ attributes }
-  %h2.cads-targeted-content__title.js-cads-targeted-content__title{ id: "h-#{id}" }
+  .cads-targeted-content__title.js-cads-targeted-content__title{ id: "h-#{id}", role: "heading", aria: { level: heading_level } }
     .cads-targeted-content__title-text
       - if type != "public"
         .cads-targeted-content__badge

--- a/haml/_targeted_content.html.haml
+++ b/haml/_targeted_content.html.haml
@@ -4,7 +4,9 @@
   id = targeted_content["id"]
   title = targeted_content["title"].squish
   body = targeted_content["body"]
+  # Allow control over heading level, default to h2
   heading_level = targeted_content.fetch("heading_level", 2)
+  heading_tag = "h#{heading_level}"
   # Allow disabling toggleable behaviour (mostly for tests)
   is_toggleable = targeted_content.fetch("is_toggleable", true)
 
@@ -20,10 +22,13 @@
     }
   }
 
-
+  heading_attributes = {
+    class: ["cads-targeted-content__title", "js-cads-targeted-content__title"],
+    id: "h-#{id}"
+  }
 
 .cads-targeted-content{ attributes }
-  .cads-targeted-content__title.js-cads-targeted-content__title{ id: "h-#{id}", role: "heading", aria: { level: heading_level } }
+  - haml_tag(heading_tag, heading_attributes) do
     .cads-targeted-content__title-text
       - if type != "public"
         .cads-targeted-content__badge

--- a/styleguide/components/targeted-content/_default.html.haml
+++ b/styleguide/components/targeted-content/_default.html.haml
@@ -5,6 +5,6 @@
     %li you have family in the UK from the EU, EEA or Switzerland
   %p You need to apply to the scheme even if you have a permanent residence card as it will not be valid after 31 December 2020.
 
-- targeted_content = { "id" => "targeted-content-123", "title" => "If you are a citizen of a country outside the EU, EEA or Switzerland", "body" => body }
+- targeted_content = { "id" => "targeted-content-123", "title" => "If you are a citizen of a country outside the EU, EEA or Switzerland", "body" => body, "heading_level" => 2 }
 
 = render partial: "@citizensadvice/design-system/haml/targeted_content", locals: { targeted_content: targeted_content }

--- a/styleguide/components/targeted-content/targeted-content-docs.mdx
+++ b/styleguide/components/targeted-content/targeted-content-docs.mdx
@@ -51,12 +51,13 @@ If JavaScript either fails or is disabled in the users browser the fallback is t
 
 The Haml partial takes a `targeted_content` hash with the following properties:
 
-| properties | Description                                                  |
-| ---------- | ------------------------------------------------------------ |
-| `id`       | Required, unique ID                                          |
-| `title`    | Required, title string                                       |
-| `body`     | Required, body HTML                                          |
-| `type`     | Optional, one of `public` or `adviser`. Defaults to `public` |
+| properties      | Description                                                    |
+| --------------- | -------------------------------------------------------------- |
+| `id`            | Required, unique ID                                            |
+| `title`         | Required, title string                                         |
+| `body`          | Required, body HTML                                            |
+| `type`          | Optional, one of `public` or `adviser`. Defaults to `public`   |
+| `heading_level` | Optional, sets the heading level of the title. Defaults to `2` |
 
 ## JavaScript behaviour
 


### PR DESCRIPTION
Allows clients of design-system to specify the heading level of the title element in targeted content components.  Defaults to a heading level of 2 if none provided.  Coerces to a integer and clamps between 1 and 6.