### PR TITLE
Enabled targeted content tests [NP-1560]

### DIFF
--- a/testing/features/step_definitions/targeted_content_steps.rb
+++ b/testing/features/step_definitions/targeted_content_steps.rb
@@ -28,14 +28,14 @@ Then("the expand\\/collapse button will indicate it will expand") do
   expect(@component.heading).to have_expand_collapse
 
   expect(@component.heading.expand_collapse["aria-label"])
-    .to end_with(I18n.t("cads.targeted_content.descriptive_label_show"))
+    .to start_with(I18n.t("cads.targeted_content.descriptive_label_show"))
 end
 
 Then("the expand\\/collapse button will indicate it will collapse") do
   expect(@component.heading).to have_expand_collapse
 
   expect(@component.heading.expand_collapse["aria-label"])
-    .to end_with(I18n.t("cads.targeted_content.descriptive_label_hide"))
+    .to start_with(I18n.t("cads.targeted_content.descriptive_label_hide"))
 end
 
 Then("I can see additional information") do

--- a/testing/features/targeted_content.feature
+++ b/testing/features/targeted_content.feature
@@ -1,4 +1,3 @@
-@failing @NP-1560
 Feature: Targeted Content component
 
   The Targeted Content component allows content managers


### PR DESCRIPTION
https://citizensadvice.atlassian.net/browse/NP-1560

Failing scenarios were due to a `ends_with` check which needed to be `starts_with`
