### PR TITLE
feat: add test id to targeted content headings

### DIFF
--- a/haml/_targeted_content.html.haml
+++ b/haml/_targeted_content.html.haml
@@ -24,7 +24,8 @@
 
   heading_attributes = {
     class: %w[cads-targeted-content__title js-cads-targeted-content__title],
-    id: "h-#{id}"
+    id: "h-#{id}",
+    data: { testid: "targeted-content-title" }
   }
 
 .cads-targeted-content{ attributes }


### PR DESCRIPTION
Some of the cucumber tests (https://github.com/citizensadvice/public-website/pull/850) will rely on `h2` as a selector for the targeted content title.

This PR adds a `data-testid` attribute to the title element so the selector can be updated when the design-system is next updated in the public-website repo.