### PR TITLE
Fix: NP-1699 scroll to top of targeted content on close

### DIFF
--- a/src/js/targeted-content.js
+++ b/src/js/targeted-content.js
@@ -136,7 +136,6 @@ function initTargetedContentFor(el) {
       const newScrollY = window.pageYOffset + elTop - FAKE_MARGIN;
       const supportsSmoothScroll =
         'scrollBehavior' in document.documentElement.style;
-      console.log(supportsSmoothScroll);
       if (supportsSmoothScroll) {
         window.scrollTo({ left: 0, top: newScrollY, behavior: 'smooth' });
       } else {

--- a/src/js/targeted-content.js
+++ b/src/js/targeted-content.js
@@ -124,10 +124,10 @@ function initTargetedContentFor(el) {
 
   const closeButtonEl = contentEl.querySelector('button');
   closeButtonEl.addEventListener('click', () => {
-    // const matchEl = closeButtonEl.closest(SELECTORS.el);
-    // if (matchEl) {
-    //   setState(matchEl, 'closed');
-    // }
+    const matchEl = closeButtonEl.closest(SELECTORS.el);
+    if (matchEl) {
+      setState(matchEl, 'closed');
+    }
 
     const elTop = el.getBoundingClientRect().top;
     // scroll back top to of targeted content if it's out of viewport

--- a/src/js/targeted-content.js
+++ b/src/js/targeted-content.js
@@ -128,6 +128,14 @@ function initTargetedContentFor(el) {
     if (matchEl) {
       setState(matchEl, 'closed');
     }
+
+    const elTop = el.getBoundingClientRect().top;
+    // scroll back top to of targeted content if it's out of viewport
+    if (elTop < 0) {
+      const FAKE_MARGIN = 16;
+      const newScrollY = window.scrollY + elTop - FAKE_MARGIN;
+      window.scrollTo({ left: 0, top: newScrollY, behavior: 'smooth' });
+    }
   });
 }
 

--- a/src/js/targeted-content.js
+++ b/src/js/targeted-content.js
@@ -124,17 +124,23 @@ function initTargetedContentFor(el) {
 
   const closeButtonEl = contentEl.querySelector('button');
   closeButtonEl.addEventListener('click', () => {
-    const matchEl = closeButtonEl.closest(SELECTORS.el);
-    if (matchEl) {
-      setState(matchEl, 'closed');
-    }
+    // const matchEl = closeButtonEl.closest(SELECTORS.el);
+    // if (matchEl) {
+    //   setState(matchEl, 'closed');
+    // }
 
     const elTop = el.getBoundingClientRect().top;
     // scroll back top to of targeted content if it's out of viewport
     if (elTop < 0) {
       const FAKE_MARGIN = 16;
-      const newScrollY = window.scrollY + elTop - FAKE_MARGIN;
-      window.scrollTo({ left: 0, top: newScrollY, behavior: 'smooth' });
+      const newScrollY = window.pageYOffset + elTop - FAKE_MARGIN;
+      const supportsSmoothScroll =
+        'scrollBehaviour' in document.documentElement.style;
+      if (supportsSmoothScroll) {
+        window.scrollTo({ left: 0, top: newScrollY, behavior: 'smooth' });
+      } else {
+        window.scroll(0, newScrollY);
+      }
     }
   });
 }

--- a/src/js/targeted-content.js
+++ b/src/js/targeted-content.js
@@ -135,7 +135,8 @@ function initTargetedContentFor(el) {
       const FAKE_MARGIN = 16;
       const newScrollY = window.pageYOffset + elTop - FAKE_MARGIN;
       const supportsSmoothScroll =
-        'scrollBehaviour' in document.documentElement.style;
+        'scrollBehavior' in document.documentElement.style;
+      console.log(supportsSmoothScroll);
       if (supportsSmoothScroll) {
         window.scrollTo({ left: 0, top: newScrollY, behavior: 'smooth' });
       } else {

--- a/src/js/targeted-content.js
+++ b/src/js/targeted-content.js
@@ -130,7 +130,7 @@ function initTargetedContentFor(el) {
     }
 
     const elTop = el.getBoundingClientRect().top;
-    // scroll back top to of targeted content if it's out of viewport
+    // scroll back to top of targeted content if it's out of viewport
     if (elTop < 0) {
       const FAKE_MARGIN = 16;
       const newScrollY = window.pageYOffset + elTop - FAKE_MARGIN;

--- a/styleguide/components/targeted-content/_anchor.html.haml
+++ b/styleguide/components/targeted-content/_anchor.html.haml
@@ -18,10 +18,10 @@
 
     %h2 Heading level 2
 
-    - 2.times do
+    - 8.times do
       %p= lorem
 
     = render partial: "@citizensadvice/design-system/haml/targeted_content", locals: { targeted_content: targeted_content }
 
-    - 3.times do
+    - 8.times do
       %p= lorem


### PR DESCRIPTION
Targeted contents do not alter the window's scroll position, which means when you close a long targeted content via the 'Close' button at the bottom, lots of content is skipped.  The epi site scrolls the user to the top of the targeted content on close, this PR replicates that behaviour.