### PR TITLE
fix: scroll targeted content to center of viewport

### DIFF
--- a/src/js/targeted-content.js
+++ b/src/js/targeted-content.js
@@ -132,15 +132,7 @@ function initTargetedContentFor(el) {
     const elTop = el.getBoundingClientRect().top;
     // scroll back to top of targeted content if it's out of viewport
     if (elTop < 0) {
-      const FAKE_MARGIN = 16;
-      const newScrollY = window.pageYOffset + elTop - FAKE_MARGIN;
-      const supportsSmoothScroll =
-        'scrollBehavior' in document.documentElement.style;
-      if (supportsSmoothScroll) {
-        window.scrollTo({ left: 0, top: newScrollY, behavior: 'smooth' });
-      } else {
-        window.scroll(0, newScrollY);
-      }
+      el.scrollIntoView({ behavior: 'smooth', block: 'center' });
     }
   });
 }

--- a/styleguide/documentation/getting-started.stories.mdx
+++ b/styleguide/documentation/getting-started.stories.mdx
@@ -120,7 +120,9 @@ window.addEventListener('load', () => {
 
 Some components require polyfills for older browsers. Components which require polyfills note this in their documentation. The full list is:
 
-- Targeted content: [Element.prototype.closest polyfill](https://www.npmjs.com/package/element-closest)
+- Targeted content:
+  - [Element.prototype.closest polyfill](https://www.npmjs.com/package/element-closest)
+  - [Scroll behaviour (Element.prototype.scrollIntoView) polyfill](https://github.com/wessberg/scroll-behavior-polyfill)
 
 We don't include the polyfills by default in order to avoid double bundling if you have your own.
 


### PR DESCRIPTION
Fixes issue where scrolling viewport to align with top of targeted content on close resulted in an undismissed OISC warning covering the targeted content.

Just using `scrollIntoView` instead for simplicity and robustness (can't really be sure what other consumers of the design system will be rendering at the top of the viewport).