### PR TITLE
Fix: tab helper NP-1765

### DIFF
--- a/testing/features/support/components/header/standard.rb
+++ b/testing/features/support/components/header/standard.rb
@@ -20,8 +20,7 @@ module Header
     end
 
     def tab_to(desired_area)
-      tab_count = tab_quantity_for_skip_link(desired_area)
-      send_tabs(tab_count)
+      send_tabs(tab_quantity_for_skip_link(desired_area))
     end
   end
 end

--- a/testing/features/support/components/header/standard.rb
+++ b/testing/features/support/components/header/standard.rb
@@ -20,28 +20,8 @@ module Header
     end
 
     def tab_to(desired_area)
-      tab_quantity_for_skip_link(desired_area).times do
-        # This next line is a hack until capybara cut a new version containing
-        # https://github.com/teamcapybara/capybara/pull/2422
-        # ETA Early December based on previous releases
-        #
-        # LH - Nov 2020
-        fake_active_element = page.find("body")
-        if safari?
-          fake_active_element.send_keys(%i[alt tab])
-          # This next line is ANOTHER hack that is needed because Safari is crap
-          # and broken. The modifier key here (OPTION, but called :alt), is not
-          # "un-depressed" after being used in the alt+tab call. This means that
-          # subsequent calls do things like alt+click which downloads a link!
-          #
-          # See: https://bugs.webkit.org/show_bug.cgi?id=219948
-          # LH - Dec 2020
-          fake_active_element.send_keys(:alt)
-        else
-          fake_active_element.send_keys(:tab)
-        end
-        sleep 0.1
-      end
+      tab_count = tab_quantity_for_skip_link(desired_area)
+      send_tabs(tab_count)
     end
   end
 end

--- a/testing/features/support/components/navigation/standard.rb
+++ b/testing/features/support/components/navigation/standard.rb
@@ -2,8 +2,8 @@
 
 module Navigation
   class Standard < ::Base
-    include Helpers::Page 
-    
+    include Helpers::Page
+
     set_url "/iframe.html?id=components-navigation--default-story&viewMode=story"
 
     element :navigation, ".js-cads-greedy-nav"

--- a/testing/features/support/components/navigation/standard.rb
+++ b/testing/features/support/components/navigation/standard.rb
@@ -2,6 +2,8 @@
 
 module Navigation
   class Standard < ::Base
+    include Helpers::Page 
+    
     set_url "/iframe.html?id=components-navigation--default-story&viewMode=story"
 
     element :navigation, ".js-cads-greedy-nav"
@@ -10,15 +12,11 @@ module Navigation
     element :last_link, "a", text: "More from us"
 
     def tab_into_dropdown
-      5.times do
-        send_keys(:tab)
-      end
+      send_tabs(5)
     end
 
     def tab_through_dropdown
-      10.times do
-        send_keys(:tab)
-      end
+      send_tabs(10)
     end
 
     def click_outside_navigation

--- a/testing/features/support/helpers/page.rb
+++ b/testing/features/support/helpers/page.rb
@@ -31,6 +31,23 @@ module Helpers
       wait_for_new_url if firefox? && new_page
     end
 
+    def send_tabs(count) 
+      count.times do
+        if safari?
+          send_keys(%i[alt tab])
+          # In Safari the modifier key (OPTION, but called :alt), is not
+          # released after being used in the alt+tab call. This means that
+          # subsequent calls do things like alt+click which downloads a link.
+          #
+          # See: https://bugs.webkit.org/show_bug.cgi?id=219948
+          send_keys(:alt)
+        else
+          send_keys(:tab)
+        end
+        sleep 0.1
+      end
+    end
+
     def tab_quantity_for_skip_link(desired_area)
       case desired_area
       when :navigation; then 1

--- a/testing/features/support/helpers/page.rb
+++ b/testing/features/support/helpers/page.rb
@@ -31,7 +31,7 @@ module Helpers
       wait_for_new_url if firefox? && new_page
     end
 
-    def send_tabs(count) 
+    def send_tabs(count)
       count.times do
         if safari?
           send_keys(%i[alt tab])

--- a/testing/features/support/helpers/page.rb
+++ b/testing/features/support/helpers/page.rb
@@ -40,6 +40,7 @@ module Helpers
           # subsequent calls do things like alt+click which downloads a link.
           #
           # See: https://bugs.webkit.org/show_bug.cgi?id=219948
+          # LH - Dec 2020
           send_keys(:alt)
         else
           send_keys(:tab)


### PR DESCRIPTION
Refactors a method inside the header support file into a helper file, to allow a common way of sending tabs that caters for safari weirdness.  Will unblock one of the failing feature tests for navigation.