### PR TITLE
fix: fix nav hover background color NP-1875

### DIFF
--- a/scss/1-settings/_colour-language.scss
+++ b/scss/1-settings/_colour-language.scss
@@ -8,7 +8,6 @@ $cads-language__link-colour: $cads-palette__heritage-blue !default;
 $cads-language__link-hover-colour: $cads-palette__heritage-blue-dark !default;
 $cads-language__link-visited-colour: $cads-palette__purple !default;
 $cads-language__link-active-colour: $cads-palette__dark-grey !default;
-$cads-language__link-hover-adviser-colour: $cads-palette__blue-adviser-dark !default;
 $cads-language__hover-background-colour: $cads-palette__blue-light !default;
 $cads-language__focus-colour: $cads-palette__yellow !default;
 $cads-language__focus-border-colour: $cads-palette__dark-grey !default;
@@ -23,6 +22,9 @@ $cads-language__secondary-button-hover-colour: $cads-language__hover-background-
 $cads-language__button-shadow-colour: $cads-palette__teal-dark !default;
 $cads-language__warning-colour: $cads-palette__red !default;
 $cads-language__success-colour: $cads-palette__green !default;
+
+// Navigation colours
+$cads-language__nav-hover-background-colour: $cads-palette__heritage-blue-dark !default;
 
 // Header colours
 $cads-header__background-colour: $cads-palette__white !default;

--- a/scss/2-tools/_interactive-elements.scss
+++ b/scss/2-tools/_interactive-elements.scss
@@ -42,7 +42,7 @@
   }
 
   &:hover {
-    background-color: $cads-language__link-hover-colour;
+    background-color: $cads-language__nav-hover-background-colour;
     border-color: $cads-language__link-hover-colour;
     color: $cads-language__brand-primary-contrast;
   }

--- a/styleguide/foundations/_colour-export.scss
+++ b/styleguide/foundations/_colour-export.scss
@@ -14,7 +14,6 @@
     link-hover-colour: $cads-language__link-hover-colour;
     link-visited-colour: $cads-language__link-visited-colour;
     link-active-colour: $cads-language__link-active-colour;
-    link-hover-adviser-colour: $cads-language__link-hover-adviser-colour;
     hover-background-colour: $cads-language__hover-background-colour;
     focus-colour: $cads-language__focus-colour;
     focus-border-colour: $cads-language__focus-border-colour;


### PR DESCRIPTION
Decouples the nav item hover color from the text color of a normal link when hovered over.  This allows correct theming of the nav in advisernet.

Removes the advisernet link hover color from the design-system which wasn't used by anything anyway.
