### PR TITLE
feat: option to remove the close button for targeted content [NP-757]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+**New**
+
+- 🎯 Targeted content: Option to remove the close button.
+
 **Chores**
 
 - 🗣️ Remove unused callout.js module

--- a/haml/_targeted_content.html.haml
+++ b/haml/_targeted_content.html.haml
@@ -9,10 +9,12 @@
   heading_tag = "h#{heading_level.clamp(1, 6)}"
   # Allow disabling toggleable behaviour (mostly for tests)
   is_toggleable = targeted_content.fetch("is_toggleable", true)
+  close_button = targeted_content.fetch("close_button", true)
 
   attributes = {
     class: [
       ("cads-targeted-content--adviser" if type == "adviser"),
+      ("cads-no-close" unless close_button),
       ("js-cads-targeted-content" if is_toggleable)
     ],
     data: {

--- a/src/js/targeted-content.js
+++ b/src/js/targeted-content.js
@@ -20,6 +20,7 @@ const CLASS_NAMES = {
   toggleable: 'cads-targeted-content--toggleable',
   open: 'cads-targeted-content--open',
   button: 'cads-targeted-content__button',
+  closeButton: 'cads-targeted-content__close-button',
   icon: 'cads-targeted-content__icon',
   iconVertLine: 'cads-targeted-content__icon-vert',
 };
@@ -103,7 +104,9 @@ function initTargetedContentFor(el) {
   const createCloseButton = () => {
     const ariaLabel = el.getAttribute('data-descriptive-label-hide');
     const closeButton = `<hr class="cads-separator" />
-        <button aria-label="${ariaLabel}" class="cads-linkbutton cads-targeted-content__close-button">
+        <button aria-label="${ariaLabel}" class="cads-linkbutton ${
+      CLASS_NAMES.closeButton
+    }">
           ${el.getAttribute('data-close-label')}
         </button>`;
 
@@ -114,7 +117,7 @@ function initTargetedContentFor(el) {
   createToggleButton();
   createCloseButton();
 
-  const toggleButtonEl = el.querySelector('button');
+  const toggleButtonEl = el.querySelector(`.${CLASS_NAMES.button}`);
   toggleButtonEl.addEventListener('click', () => {
     const currentlyExpanded =
       toggleButtonEl.getAttribute('aria-expanded') === 'true' || false;
@@ -122,7 +125,7 @@ function initTargetedContentFor(el) {
     setState(el, currentlyExpanded ? 'closed' : 'open');
   });
 
-  const closeButtonEl = contentEl.querySelector('button');
+  const closeButtonEl = contentEl.querySelector(`.${CLASS_NAMES.closeButton}`);
   closeButtonEl.addEventListener('click', () => {
     const matchEl = closeButtonEl.closest(SELECTORS.el);
     if (matchEl) {

--- a/src/js/targeted-content.js
+++ b/src/js/targeted-content.js
@@ -17,6 +17,7 @@ const SELECTORS = {
 };
 
 const CLASS_NAMES = {
+  noClose: 'cads-no-close',
   toggleable: 'cads-targeted-content--toggleable',
   open: 'cads-targeted-content--open',
   button: 'cads-targeted-content__button',
@@ -115,9 +116,9 @@ function initTargetedContentFor(el) {
 
   el.classList.add(CLASS_NAMES.toggleable);
   createToggleButton();
-  createCloseButton();
 
   const toggleButtonEl = el.querySelector(`.${CLASS_NAMES.button}`);
+
   toggleButtonEl.addEventListener('click', () => {
     const currentlyExpanded =
       toggleButtonEl.getAttribute('aria-expanded') === 'true' || false;
@@ -125,19 +126,26 @@ function initTargetedContentFor(el) {
     setState(el, currentlyExpanded ? 'closed' : 'open');
   });
 
-  const closeButtonEl = contentEl.querySelector(`.${CLASS_NAMES.closeButton}`);
-  closeButtonEl.addEventListener('click', () => {
-    const matchEl = closeButtonEl.closest(SELECTORS.el);
-    if (matchEl) {
-      setState(matchEl, 'closed');
-    }
+  if (!el.classList.contains(CLASS_NAMES.noClose)) {
+    createCloseButton();
+  }
 
-    const elTop = el.getBoundingClientRect().top;
-    // scroll back to top of targeted content if it's out of viewport
-    if (elTop < 0) {
-      el.scrollIntoView({ behavior: 'smooth', block: 'center' });
-    }
-  });
+  const closeButtonEl = contentEl.querySelector(`.${CLASS_NAMES.closeButton}`);
+
+  if (closeButtonEl) {
+    closeButtonEl.addEventListener('click', () => {
+      const matchEl = closeButtonEl.closest(SELECTORS.el);
+      if (matchEl) {
+        setState(matchEl, 'closed');
+      }
+
+      const elTop = el.getBoundingClientRect().top;
+      // scroll back to top of targeted content if it's out of viewport
+      if (elTop < 0) {
+        el.scrollIntoView({ behavior: 'smooth', block: 'center' });
+      }
+    });
+  }
 }
 
 export default function initTargetedContent() {

--- a/styleguide/components/targeted-content/targeted-content-docs.mdx
+++ b/styleguide/components/targeted-content/targeted-content-docs.mdx
@@ -51,13 +51,14 @@ If JavaScript either fails or is disabled in the users browser the fallback is t
 
 The Haml partial takes a `targeted_content` hash with the following properties:
 
-| properties      | Description                                                    |
-| --------------- | -------------------------------------------------------------- |
-| `id`            | Required, unique ID                                            |
-| `title`         | Required, title string                                         |
-| `body`          | Required, body HTML                                            |
-| `type`          | Optional, one of `public` or `adviser`. Defaults to `public`   |
-| `heading_level` | Optional, sets the heading level of the title. Defaults to `2` |
+| properties      | Description                                                              |
+| --------------- | ------------------------------------------------------------------------ |
+| `id`            | Required, unique ID                                                      |
+| `title`         | Required, title string                                                   |
+| `body`          | Required, body HTML                                                      |
+| `type`          | Optional, one of `public` or `adviser`. Defaults to `public`             |
+| `heading_level` | Optional, sets the heading level of the title. Defaults to `2`           |
+| `close_button`  | Optional, include close button at the end of content. Defaults to `true` |
 
 ## JavaScript behaviour
 


### PR DESCRIPTION
This is coded in the positive, with a default set to true so existing behaviour is maintained.

Set local `"targeted_content" => { "close_button" => false }` to omit the close button. This is useful when targeted content is as part of a UI that does not require the close button - specifically this applies to the Expandable Sidebar that is part of the public advice website.