### PR TITLE
WIP Fix/header button translation [NP-1884]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+**Bugfixes**
+- 👤 Header: open/close search button title is now translated correctly
+
 ## <sub>v4.0.4-alpha.1</sub>
 
 #### _Mar. 12, 2021_

--- a/haml/_header.html.haml
+++ b/haml/_header.html.haml
@@ -3,6 +3,13 @@
   sign_in_out ||= {}
   main_content_anchor_link ||= "#cads-main-content"
   homepage_url ||= "/"
+  button_attr = {
+    class: %w[cads-header__search-reveal js-cads-search-reveal cads-icon_search],
+    title: t("cads.header.open_search"),
+    "data-testid": "expand-button",
+    "aria-expanded": "false",
+    data: { descriptive_label_show: t("cads.header.open_search"), descriptive_label_hide: t("cads.header.close_search") }
+  }
 
 %header.cads-header
   .cads-grid-container
@@ -16,7 +23,7 @@
           = t("cads.header.skip_to_footer")
       .cads-grid-col-md-2.cads-header__logo-row
         %a.cads-logo{ href: homepage_url, title: t("cads.shared.logo_title") }
-        %button.cads-header__search-reveal.js-cads-search-reveal.cads-icon_search{ title: t("cads.header.search_mobile"), "data-testid": "expand-button", "aria-expanded": "false" }
+        %button{ button_attr }
       .cads-grid-col-md-10.cads-header__search-row
         %ul.cads-header__links.js-cads-copy-into-nav
           - links&.each do |link|

--- a/haml/_header.html.haml
+++ b/haml/_header.html.haml
@@ -6,9 +6,8 @@
   button_attr = {
     class: %w[cads-header__search-reveal js-cads-search-reveal cads-icon_search],
     title: t("cads.header.open_search"),
-    "data-testid": "expand-button",
     "aria-expanded": "false",
-    data: { descriptive_label_show: t("cads.header.open_search"), descriptive_label_hide: t("cads.header.close_search") }
+    data: { testid: "expand-button", descriptive_label_show: t("cads.header.open_search"), descriptive_label_hide: t("cads.header.close_search") }
   }
 
 %header.cads-header

--- a/locales/cy.yml
+++ b/locales/cy.yml
@@ -13,8 +13,8 @@ cy:
     form:
       optional: dewisol
     header:
-      open_search: Ymchwiliad agored
       close_search: Close search in Welsh
+      open_search: Ymchwiliad agored
       skip_to_content: Neidio i’r cynnwys
       skip_to_footer: Neidio i’r troedyn
       skip_to_navigation: Neidio i’r llywio

--- a/locales/cy.yml
+++ b/locales/cy.yml
@@ -13,7 +13,8 @@ cy:
     form:
       optional: dewisol
     header:
-      search_mobile: Ymchwiliad agored
+      open_search: Ymchwiliad agored
+      close_search: Close search in Welsh
       skip_to_content: Neidio i’r cynnwys
       skip_to_footer: Neidio i’r troedyn
       skip_to_navigation: Neidio i’r llywio

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -13,7 +13,8 @@ en:
     form:
       optional: optional
     header:
-      search_mobile: Open search
+      open_search: Open search
+      close_search: Close search
       skip_to_content: Skip to content
       skip_to_footer: Skip to footer
       skip_to_navigation: Skip to navigation

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -13,8 +13,8 @@ en:
     form:
       optional: optional
     header:
-      open_search: Open search
       close_search: Close search
+      open_search: Open search
       skip_to_content: Skip to content
       skip_to_footer: Skip to footer
       skip_to_navigation: Skip to navigation

--- a/src/js/header.js
+++ b/src/js/header.js
@@ -15,13 +15,17 @@ const initHeader = () => {
         controlButton.classList.remove(CLASS_NAMES.iconClose);
         controlButton.classList.add(CLASS_NAMES.iconSearch);
         controlButton.setAttribute('aria-expanded', 'false');
-        controlButton.title = 'Open search';
+        controlButton.title = controlButton.getAttribute(
+          'data-descriptive-label-show'
+        );
       } else {
         header.classList.add(CLASS_NAMES.showSearch);
         controlButton.classList.remove(CLASS_NAMES.iconSearch);
         controlButton.classList.add(CLASS_NAMES.iconClose);
         controlButton.setAttribute('aria-expanded', 'true');
-        controlButton.title = 'Close search';
+        controlButton.title = controlButton.getAttribute(
+          'data-descriptive-label-hide'
+        );
       }
     });
   }

--- a/src/js/header.test.js
+++ b/src/js/header.test.js
@@ -15,9 +15,12 @@ const minimalHeaderHtml = `<header class='cads-header' data-testid="header">
       <div class='cads-grid-col-md-5 cads-header__logo-row'>
         <a class='cads-logo' href='root_path'
           title='Citizens Advice homepage'></a>
-        <button aria-expanded='false'
-          class='cads-header__search-reveal js-cads-search-reveal cads-icon_search'
-          title='Open search'></button>
+        <button aria-expanded="false" 
+          class="cads-header__search-reveal js-cads-search-reveal cads-icon_search" 
+          data-descriptive-label-hide="Close search" 
+          data-descriptive-label-show="Open search" 
+          data-testid="expand-button" 
+          title="Open search"></button>
       </div>
       <div class='cads-grid-col-md-7 cads-header__search-row'>
         ${searchFormHtml}

--- a/testing/features/header.feature
+++ b/testing/features/header.feature
@@ -60,12 +60,12 @@ Feature: Header component
     Background:
       Given a Standard Header component is on the page
 
-    @small_screen @failing @NP-1885
+    @small_screen @future_release @v4.0.4
     Scenario: English Header has be expanded to show the full search bar
       Then I am able to expand the search bar
       And I am able to collapse the search bar
 
-    @small_screen @failing @NP-1885
+    @small_screen @future_release @v4.0.4
     Scenario: Welsh Header has be expanded to show the full search bar
       Given the language is Welsh
       Then I am able to expand the search bar

--- a/testing/features/header.feature
+++ b/testing/features/header.feature
@@ -60,12 +60,12 @@ Feature: Header component
     Background:
       Given a Standard Header component is on the page
 
-    @small_screen @failing @NP-1480
+    @small_screen @failing @NP-1885
     Scenario: English Header has be expanded to show the full search bar
       Then I am able to expand the search bar
       And I am able to collapse the search bar
 
-    @small_screen @failing @NP-1480
+    @small_screen @failing @NP-1885
     Scenario: Welsh Header has be expanded to show the full search bar
       Given the language is Welsh
       Then I am able to expand the search bar

--- a/testing/features/step_definitions/common_steps.rb
+++ b/testing/features/step_definitions/common_steps.rb
@@ -33,7 +33,7 @@ Then("I am able to search in English/Welsh") do
 end
 
 Then("I am able to expand the search bar") do
-  expect(@component.open_search_pane["title"]).to eq(I18n.t("cads.header.search_mobile"))
+  expect(@component.open_search_pane["title"]).to eq(I18n.t("cads.header.open_search"))
 
   @component.open_search_pane.click
 
@@ -41,7 +41,7 @@ Then("I am able to expand the search bar") do
 end
 
 Then("I am able to collapse the search bar") do
-  expect(@component.open_search_pane["title"]).to eq(I18n.t("cads.header.search_mobile"))
+  expect(@component.open_search_pane["title"]).to eq(I18n.t("cads.header.close_search"))
 
   @component.open_search_pane.click
 


### PR DESCRIPTION
Fixes a bug in the mobile header where the title of the search expand / collapse button was not translated in the javascript by:
 - creating translations for open and close states
 - storing these in `data-` attributes on the button
 - updating the js to use these attributes when updating the button title

Waiting for the Welsh translation of 'close search' but ready for review.
