### PR TITLE
Uninstall dotenv node module

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,6 @@
     "babel-loader": "^8.1.0",
     "chalk": "^4.1.0",
     "cssnano": "^4.1.10",
-    "dotenv": "^8.2.0",
     "eslint": "^7.23.0",
     "eslint-config-airbnb-base": "^14.2.0",
     "eslint-config-prettier": "^8.1.0",


### PR DESCRIPTION
We don't use a top-level .env file for anything and this was never called.
