### PR TITLE
Remove cross-domain test from the footer

### DIFF
--- a/testing/features/footer.feature
+++ b/testing/features/footer.feature
@@ -23,11 +23,6 @@ Feature: Footer component
       And a copyright notice is present
       And a company info is present
 
-    @not_mobile
-    Scenario: Users can report a problem about the specific page they are on
-      When I report a problem with this page
-      Then I am presented with a form to report the issue about the page I am on
-
   Rule: Minimal Footer
     Background:
       Given the Minimal Footer component is on the page

--- a/testing/features/step_definitions/footer_steps.rb
+++ b/testing/features/step_definitions/footer_steps.rb
@@ -8,10 +8,6 @@ Given("the Minimal Footer component is on the page") do
   @component = Footer::Minimal.new.tap(&:load)
 end
 
-When("I report a problem with this page") do
-  @component.website_feedback.click
-end
-
 Then("a report problem with this page link is present") do
   expect(@component).to have_website_feedback(text: I18n.t("cads.footer.website_feedback"))
 end
@@ -26,10 +22,4 @@ end
 
 Then("a company info is present") do
   expect(@component).to have_company_info
-end
-
-Then("I am presented with a form to report the issue about the page I am on") do
-  switch_to_newly_opened_window!(new_page: true)
-
-  expect(page.current_url).to eq("https://www.research.net/r/J8PLH2H")
 end

--- a/testing/features/support/helpers/page.rb
+++ b/testing/features/support/helpers/page.rb
@@ -19,12 +19,6 @@ module Helpers
       attach(path, "image/png")
     end
 
-    def switch_to_newly_opened_window!(new_page: false)
-      wait_for_second_window
-      page.switch_to_window(second_window)
-      wait_for_new_url if firefox? && new_page
-    end
-
     def send_tabs(count)
       count.times do
         if safari?
@@ -78,18 +72,6 @@ module Helpers
 
     def height(fallback: 800)
       ENV.fetch("BROWSER_HEIGHT", fallback)
-    end
-
-    def wait_for_second_window
-      Selenium::WebDriver::Wait.new.until { page.windows.length == 2 }
-    end
-
-    def second_window
-      page.windows.detect { |window| !window.current? }
-    end
-
-    def wait_for_new_url
-      Selenium::WebDriver::Wait.new.until { page.current_url != "about:blank" }
     end
   end
 end


### PR DESCRIPTION
We had a test for the footer link which opens up a new tab and switches to it.

It'd be nice to avoid needing to test cross domain. As it happens the test doesn't tell us much as this component is designed to accept any link, not specifically the one being tested.

Deleting this scenario also lets us remove some complex helper methods.
