### PR TITLE
Adjust dependabot rules

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,16 +12,16 @@ updates:
   - package-ecosystem: npm
     directory: '/'
     schedule:
-      interval: daily
+      interval: weekly
       timezone: Europe/London
     open-pull-requests-limit: 10
     labels:
       - 'npm dependencies'
     target-branch: 'master'
   - package-ecosystem: npm
-    directory: '/testing/visual-regression'
+    directory: '/testing'
     schedule:
-      interval: daily
+      interval: weekly
       timezone: Europe/London
     open-pull-requests-limit: 10
     labels:


### PR DESCRIPTION
- Makes npm schedule weekly to match with ruby dependencies
- Fixes an issue with the testing rule, package.json is at root of testing/ directory, not testing/visual-regression
