### PR TITLE
Add the Rails csrf token to the sign in/out form if it's present

### DIFF
--- a/haml/_header.html.haml
+++ b/haml/_header.html.haml
@@ -36,6 +36,8 @@
             - if sign_in_out["form"]
               %form.cads-header__account-form{method: "POST", action: sign_in_out["url"], "data-testid": "account-link"}
                 %button.cads-linkbutton__regular= sign_in_out["title"]
+                - if respond_to? :form_authenticity_token
+                  %input{type: "hidden", name: "authenticity_token", value: form_authenticity_token}
             - else
               %a.cads-header__hyperlink{href: sign_in_out["url"], "data-testid": "account-link"}= sign_in_out["title"]
         .cads-header__search-form


### PR DESCRIPTION
This is a bit of a dirty hack and it'll cease to be an issue once the design system moves to a Rails engine, because then we can ensure there will always be a Rails context and use `button_to` instead.

The current `"form"` parameter to the header's `sign_in_out` mimics the behaviour of Rails `button_to` but doesn't add the CSRF token. This is fine while it's posting to Epi but in using the DS during my auth spike I encountered problems because Rails will not accept a form that doesn't have the CSRF token present.

This checks to see if it's in a Rails context by looking for a method called `form_authenticity_token`. If it's present, it adds it into the form as a hidden parameter, exactly like the `button_to` method does. If the DS is being used outside of a Rails context, as long as it doesn't too define a method with this name, it'll just skip over that code.

We don't really have any tests for low-level code like this, do we? If we did I'd update them here.