### PR TITLE
fix: callouts as sections [NP-2017]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 **Bugfixes**
 
 - 👤 Header: The sign out button now has the visual appearance of a button
+- 🗣️ Callouts: Rendered as sections with an aria-label if `title` is provided in the hash
 
 ## <sub>v4.0.6-alpha.0</sub>
 

--- a/haml/_callout.html.haml
+++ b/haml/_callout.html.haml
@@ -1,7 +1,9 @@
 -# Default type to standard if none is provided
-- type = notice.fetch("type", "standard")
 
-.cads-callout{ class: "cads-callout--#{type}" }
+- type = notice.fetch("type", "standard")
+- title = notice.fetch("title", nil)
+
+%section.cads-callout{ class: "cads-callout--#{type}", aria: { label: title } }
   - if type != "standard"
     .cads-badge{ class: "cads-badge--#{type}" }= t("cads.callout.#{type}")
   = notice["body"]

--- a/styleguide/components/callouts/_adviser.html.haml
+++ b/styleguide/components/callouts/_adviser.html.haml
@@ -1,2 +1,2 @@
 - body = '<h3>This is the callout title</h3><p>The important callout should be used for any important snippet of text that has serious and/or legal implications if the client does not follow the advice.</p>'
-= render partial: "@citizensadvice/design-system/haml/callout", locals: { notice: { 'type' => 'adviser', 'body' => body } }
+= render partial: "@citizensadvice/design-system/haml/callout", locals: { notice: { 'type' => 'adviser', 'body' => body, 'title' => "This is the title of the callout" } }

--- a/styleguide/components/callouts/callouts-docs.mdx
+++ b/styleguide/components/callouts/callouts-docs.mdx
@@ -71,7 +71,8 @@ Note that there is code in the Content Platform app that ensure headings inside 
 
 The Haml partial takes a `notice` hash with the following properties:
 
-| Property | Description                                                          |
-| -------- | -------------------------------------------------------------------- |
-| `type`   | Optional type, one of: `standard`, `example`, `important`, `adviser` |
-| `body`   | HTML string                                                          |
+| Property | Description                                                                      |
+| -------- | -------------------------------------------------------------------------------- |
+| `type`   | Optional type, one of: `standard`, `example`, `important`, `adviser`             |
+| `body`   | HTML string                                                                      |
+| `title`  | Optional, will be rendered as the aria label for the callout section if provided |


### PR DESCRIPTION
Renders callout as `section` elements as recommended by DAC.

If a `title` attribute is provided, it is rendered as an `aria-label` attribute on the `section` element.  Note that:
 - this is already present in the `notice` hash created by the public website renderer
 - only Adviser callouts have a meaningful title so we will need to be careful when we merge this into public website, as some non-adviser callouts will generate `notice["title"]` like `example-callout-milli-9e8r93`