### PR TITLE
[Experimental] Convert callout to view component

### DIFF
--- a/engine/app/components/citizens_advice_components/asset_hyperlink_component.rb
+++ b/engine/app/components/citizens_advice_components/asset_hyperlink_component.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module CitizensAdviceComponents
-  class AssetHyperlinkComponent < ViewComponent::Base
+  class AssetHyperlinkComponent < BaseComponent
     attr_reader :href, :description, :size
 
     def initialize(href:, description:, size:)

--- a/engine/app/components/citizens_advice_components/base_component.rb
+++ b/engine/app/components/citizens_advice_components/base_component.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module CitizensAdviceComponents
+  class BaseComponent < ViewComponent::Base
+    include CitizensAdviceComponents::FetchOrFallbackHelper
+  end
+end

--- a/engine/app/components/citizens_advice_components/callout_component.html.haml
+++ b/engine/app/components/citizens_advice_components/callout_component.html.haml
@@ -1,0 +1,4 @@
+= tag.section(class: "cads-callout cads-callout--#{type}", "aria-label": title) do
+  - if show_badge?
+    .cads-badge{ class: "cads-badge--#{type}" }= t(".#{type}")
+  = content

--- a/engine/app/components/citizens_advice_components/callout_component.rb
+++ b/engine/app/components/citizens_advice_components/callout_component.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module CitizensAdviceComponents
+  class CalloutComponent < ViewComponent::Base
+    attr_reader :type, :title
+
+    def initialize(type: nil, title: nil)
+      super
+      @type = type&.to_sym || :standard
+      @title = title
+    end
+
+    def show_badge?
+      type != :standard
+    end
+
+    def render?
+      content.present?
+    end
+  end
+end

--- a/engine/app/components/citizens_advice_components/callout_component.rb
+++ b/engine/app/components/citizens_advice_components/callout_component.rb
@@ -1,12 +1,16 @@
 # frozen_string_literal: true
 
 module CitizensAdviceComponents
-  class CalloutComponent < ViewComponent::Base
+  class CalloutComponent < BaseComponent
     attr_reader :type, :title
 
     def initialize(type: nil, title: nil)
       super
-      @type = type&.to_sym || :standard
+      @type = fetch_or_fallback(
+        allowed_values: %i[standard example important adviser],
+        given_value: type,
+        fallback: :standard
+      )
       @title = title
     end
 

--- a/engine/app/components/citizens_advice_components/pagination_component.rb
+++ b/engine/app/components/citizens_advice_components/pagination_component.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module CitizensAdviceComponents
-  class PaginationComponent < ViewComponent::Base
+  class PaginationComponent < BaseComponent
     def initialize(current_params:, num_pages:, current_page:, param_name: nil)
       super
       @current_params = current_params

--- a/engine/app/lib/citizens_advice_components/fetch_or_fallback_helper.rb
+++ b/engine/app/lib/citizens_advice_components/fetch_or_fallback_helper.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+# FetchOrFallbackHelper
+# Minimal version of https://github.com/primer/view_components/blob/main/app/lib/primer/fetch_or_fallback_helper.rb
+# A little helper to enable graceful fallbacks
+#
+# Use this helper to quietly ensure a value is
+# one that you expect:
+#
+# allowed_values    - allowed options for *value*
+# given_value       - input being coerced
+# fallback          - returned if *given_value* is not included in *allowed_values*
+#
+# fetch_or_fallback([1,2,3], 5, 2) => 2
+# fetch_or_fallback([1,2,3], 1, 2) => 1
+# fetch_or_fallback([1,2,3], nil, 2) => 2
+module CitizensAdviceComponents
+  module FetchOrFallbackHelper
+    InvalidValueError = Class.new(StandardError)
+
+    def fetch_or_fallback(allowed_values:, given_value:, fallback: nil) # rubocop:disable Metrics/MethodLength
+      if allowed_values.include?(given_value)
+        given_value
+      else
+        unless Rails.env.production?
+          raise InvalidValueError, <<~MSG
+            fetch_or_fallback was called with an invalid value.
+
+            Expected one of: #{allowed_values.inspect}
+            Got: #{given_value.inspect}
+
+            This will not raise in production, but will instead fallback to: #{fallback.inspect}
+          MSG
+        end
+
+        fallback
+      end
+    end
+  end
+end

--- a/engine/config/locales/cy.yml
+++ b/engine/config/locales/cy.yml
@@ -1,5 +1,9 @@
 cy:
   citizens_advice_components:
+    callout_component:
+      adviser: Cynghorydd
+      example: Enghraifft
+      important: Pwysig
     pagination_component:
       aria_label: Llywio tudalen
       first_page_label: Cyntaf

--- a/engine/config/locales/en.yml
+++ b/engine/config/locales/en.yml
@@ -1,5 +1,9 @@
 en:
   citizens_advice_components:
+    callout_component:
+      adviser: Adviser
+      example: Example
+      important: Important
     pagination_component:
       aria_label: Pagination navigation
       first_page_label: First

--- a/engine/previews/citizens_advice_components/callout_component_preview.rb
+++ b/engine/previews/citizens_advice_components/callout_component_preview.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module CitizensAdviceComponents
+  class CalloutComponentPreview < ViewComponent::Preview
+    def standard; end
+
+    def example; end
+
+    def important; end
+
+    def adviser; end
+
+    def nested; end
+  end
+end

--- a/engine/previews/citizens_advice_components/callout_component_preview/adviser.html.haml
+++ b/engine/previews/citizens_advice_components/callout_component_preview/adviser.html.haml
@@ -1,0 +1,3 @@
+= render(CitizensAdviceComponents::CalloutComponent.new(type: :adviser)) do
+  %h2 Callout title
+  %p Some example text

--- a/engine/previews/citizens_advice_components/callout_component_preview/example.html.haml
+++ b/engine/previews/citizens_advice_components/callout_component_preview/example.html.haml
@@ -1,0 +1,3 @@
+= render(CitizensAdviceComponents::CalloutComponent.new(type: :example)) do
+  %h2 Callout title
+  %p Some example text

--- a/engine/previews/citizens_advice_components/callout_component_preview/important.html.haml
+++ b/engine/previews/citizens_advice_components/callout_component_preview/important.html.haml
@@ -1,0 +1,3 @@
+= render(CitizensAdviceComponents::CalloutComponent.new(type: :important)) do
+  %h2 Callout title
+  %p Some example text

--- a/engine/previews/citizens_advice_components/callout_component_preview/nested.html.haml
+++ b/engine/previews/citizens_advice_components/callout_component_preview/nested.html.haml
@@ -1,0 +1,9 @@
+- lorem = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque a urna nisl. Aenean euismod purus a magna vulputate, eget volutpat neque volutpat. Donec dapibus scelerisque diam eu scelerisque. Vestibulum laoreet magna sagittis felis pellentesque semper. Nullam porta, arcu rhoncus euismod porttitor, risus augue bibendum ipsum, eget tincidunt mi lectus eget eros. Donec nisl ipsum, facilisis vitae tortor maximus, venenatis mattis purus. Quisque fringilla gravida arcu, ut bibendum nibh malesuada at. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus."
+
+= render(CitizensAdviceComponents::CalloutComponent.new(type: :standard)) do
+  %h3 This a nested callout title
+  %p= lorem
+
+  = render(CitizensAdviceComponents::CalloutComponent.new(type: :adviser)) do
+    %h4 This a callout title
+    %p= lorem

--- a/engine/previews/citizens_advice_components/callout_component_preview/standard.html.haml
+++ b/engine/previews/citizens_advice_components/callout_component_preview/standard.html.haml
@@ -1,3 +1,3 @@
-= render(CitizensAdviceComponents::CalloutComponent.new) do
+= render(CitizensAdviceComponents::CalloutComponent.new(type: :standard)) do
   %h2 Callout title
   %p Some example text

--- a/engine/previews/citizens_advice_components/callout_component_preview/standard.html.haml
+++ b/engine/previews/citizens_advice_components/callout_component_preview/standard.html.haml
@@ -1,0 +1,3 @@
+= render(CitizensAdviceComponents::CalloutComponent.new) do
+  %h2 Callout title
+  %p Some example text

--- a/engine/spec/components/base_component_spec.rb
+++ b/engine/spec/components/base_component_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+RSpec.describe CitizensAdviceComponents::BaseComponent, type: :component do
+  describe "#fetch_or_fallback" do
+    let(:subject) { described_class.new }
+    let(:allowed_values) { [1, 2, 3] }
+
+    it "returns value when in allowed_values" do
+      result = subject.fetch_or_fallback(
+        allowed_values: allowed_values,
+        given_value: 3,
+        fallback: 2
+      )
+      expect(result).to eq 3
+    end
+
+    context "production rails env" do
+      before do
+        allow(Rails.env).to receive(:production?).and_return(true)
+      end
+
+      it "returns fallback when not in allowed_values" do
+        [0, nil, "1", "one", false, true].each do |given_value|
+          result = subject.fetch_or_fallback(
+            allowed_values: [1, 2, 3],
+            given_value: given_value,
+            fallback: 2
+          )
+          expect(result).to eq 2
+        end
+      end
+    end
+
+    context "non-production rails env" do
+      before do
+        allow(Rails.env).to receive(:production?).and_return(false)
+      end
+
+      it "raises error in non-production environments" do
+        expect do
+          subject.fetch_or_fallback(
+            allowed_values: [1, 2, 3],
+            given_value: 4,
+            fallback: 2
+          )
+        end.to raise_error(CitizensAdviceComponents::FetchOrFallbackHelper::InvalidValueError)
+      end
+    end
+  end
+end

--- a/engine/spec/components/callout_component_spec.rb
+++ b/engine/spec/components/callout_component_spec.rb
@@ -21,15 +21,33 @@ RSpec.describe CitizensAdviceComponents::CalloutComponent, type: :component do
     expect(component.text).to include "Example content"
   end
 
-  context "when type is omitted" do
+  context "when missing type" do
     let(:type) { nil }
 
-    it "renders a standard callout" do
-      expect(component.at(".cads-callout").attr("class")).to include "cads-callout--standard"
+    context "non-production rails env" do
+      before do
+        allow(Rails.env).to receive(:production?).and_return(false)
+      end
+
+      it "raises an error with available options" do
+        expect do
+          CitizensAdviceComponents::CalloutComponent.new
+        end.to raise_error(CitizensAdviceComponents::FetchOrFallbackHelper::InvalidValueError)
+      end
     end
 
-    it "has no label" do
-      expect(component.at(".cads-badge")).to be_nil
+    context "production rails env" do
+      before do
+        allow(Rails.env).to receive(:production?).and_return(true)
+      end
+
+      it "renders a standard callout" do
+        expect(component.at(".cads-callout").attr("class")).to include "cads-callout--standard"
+      end
+
+      it "has no label" do
+        expect(component.at(".cads-badge")).to be_nil
+      end
     end
   end
 
@@ -100,7 +118,7 @@ RSpec.describe CitizensAdviceComponents::CalloutComponent, type: :component do
 
   context "when no content present" do
     subject(:component) do
-      render_inline(CitizensAdviceComponents::CalloutComponent.new)
+      render_inline(CitizensAdviceComponents::CalloutComponent.new(type: :standard))
     end
 
     it "does not render" do

--- a/engine/spec/components/callout_component_spec.rb
+++ b/engine/spec/components/callout_component_spec.rb
@@ -1,0 +1,110 @@
+# frozen_string_literal: true
+
+RSpec.describe CitizensAdviceComponents::CalloutComponent, type: :component do
+  before { I18n.locale = :en }
+
+  subject(:component) do
+    render_inline(
+      CitizensAdviceComponents::CalloutComponent.new(
+        type: type.presence,
+        title: title.presence
+      )
+    ) do
+      "Example content"
+    end
+  end
+
+  let(:type) { :standard }
+  let(:title) { nil }
+
+  it "renders content block" do
+    expect(component.text).to include "Example content"
+  end
+
+  context "when type is omitted" do
+    let(:type) { nil }
+
+    it "renders a standard callout" do
+      expect(component.at(".cads-callout").attr("class")).to include "cads-callout--standard"
+    end
+
+    it "has no label" do
+      expect(component.at(".cads-badge")).to be_nil
+    end
+  end
+
+  context "when type is example" do
+    let(:type) { :example }
+
+    it "renders an example callout" do
+      expect(component.at(".cads-callout").attr("class")).to include "cads-callout--example"
+    end
+
+    it "has the correct label" do
+      expect(component.at(".cads-badge").text).to eq "Example"
+    end
+
+    context "when welsh language" do
+      before { I18n.locale = :cy }
+      it "has translated label" do
+        expect(component.at(".cads-badge").text).to eq "Enghraifft"
+      end
+    end
+  end
+
+  context "when type is important" do
+    let(:type) { :important }
+
+    it "renders an important callout" do
+      expect(component.at(".cads-callout").attr("class")).to include "cads-callout--important"
+    end
+
+    it "has the correct label" do
+      expect(component.at(".cads-badge").text).to eq "Important"
+    end
+
+    context "when welsh language" do
+      before { I18n.locale = :cy }
+      it "has translated label" do
+        expect(component.at(".cads-badge").text).to eq "Pwysig"
+      end
+    end
+  end
+
+  context "when type is adviser" do
+    let(:type) { :adviser }
+
+    it "renders an adviser callout" do
+      expect(component.at(".cads-callout").attr("class")).to include "cads-callout--adviser"
+    end
+
+    it "has the correct label" do
+      expect(component.at(".cads-badge").text).to eq "Adviser"
+    end
+
+    context "when welsh language" do
+      before { I18n.locale = :cy }
+      it "has translated label" do
+        expect(component.at(".cads-badge").text).to eq "Cynghorydd"
+      end
+    end
+  end
+
+  context "when title is provided" do
+    let(:title) { "Descriptive title" }
+
+    it "Includes descriptive aria-label" do
+      expect(component.at("section").attr("aria-label")).to eq "Descriptive title"
+    end
+  end
+
+  context "when no content present" do
+    subject(:component) do
+      render_inline(CitizensAdviceComponents::CalloutComponent.new)
+    end
+
+    it "does not render" do
+      expect(component.at("section")).to be_nil
+    end
+  end
+end

--- a/engine/spec/components/pagination_component_spec.rb
+++ b/engine/spec/components/pagination_component_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "rails_helper"
-
 RSpec.describe CitizensAdviceComponents::PaginationComponent, type: :component do
   before { I18n.locale = :en }
 

--- a/styleguide/examples/callout/adviser.html
+++ b/styleguide/examples/callout/adviser.html
@@ -1,0 +1,5 @@
+<section class="cads-callout cads-callout--adviser">
+  <div class="cads-badge cads-badge--adviser">Adviser</div>
+  <h2>Callout title</h2>
+  <p>Some example text</p>
+</section>

--- a/styleguide/examples/callout/example.html
+++ b/styleguide/examples/callout/example.html
@@ -1,0 +1,5 @@
+<section class="cads-callout cads-callout--example">
+  <div class="cads-badge cads-badge--example">Example</div>
+  <h2>Callout title</h2>
+  <p>Some example text</p>
+</section>

--- a/styleguide/examples/callout/important.html
+++ b/styleguide/examples/callout/important.html
@@ -1,0 +1,5 @@
+<section class="cads-callout cads-callout--important">
+  <div class="cads-badge cads-badge--important">Important</div>
+  <h2>Callout title</h2>
+  <p>Some example text</p>
+</section>

--- a/styleguide/examples/callout/nested.html
+++ b/styleguide/examples/callout/nested.html
@@ -1,0 +1,9 @@
+<section class="cads-callout cads-callout--standard">
+  <h3>This a nested callout title</h3>
+  <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque a urna nisl. Aenean euismod purus a magna vulputate, eget volutpat neque volutpat. Donec dapibus scelerisque diam eu scelerisque. Vestibulum laoreet magna sagittis felis pellentesque semper. Nullam porta, arcu rhoncus euismod porttitor, risus augue bibendum ipsum, eget tincidunt mi lectus eget eros. Donec nisl ipsum, facilisis vitae tortor maximus, venenatis mattis purus. Quisque fringilla gravida arcu, ut bibendum nibh malesuada at. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.</p>
+  <section class="cads-callout cads-callout--adviser">
+    <div class="cads-badge cads-badge--adviser">Adviser</div>
+    <h4>This a callout title</h4>
+    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque a urna nisl. Aenean euismod purus a magna vulputate, eget volutpat neque volutpat. Donec dapibus scelerisque diam eu scelerisque. Vestibulum laoreet magna sagittis felis pellentesque semper. Nullam porta, arcu rhoncus euismod porttitor, risus augue bibendum ipsum, eget tincidunt mi lectus eget eros. Donec nisl ipsum, facilisis vitae tortor maximus, venenatis mattis purus. Quisque fringilla gravida arcu, ut bibendum nibh malesuada at. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.</p>
+  </section>
+</section>

--- a/styleguide/examples/callout/standard.html
+++ b/styleguide/examples/callout/standard.html
@@ -1,0 +1,4 @@
+<section class="cads-callout cads-callout--standard">
+  <h2>Callout title</h2>
+  <p>Some example text</p>
+</section>


### PR DESCRIPTION
As we are updating the callout component in https://github.com/citizensadvice/design-system/pull/1104 I thought it worth having a quick stab at converting this to a view component. Considering this experimental as it's probably one case where we want to thrash out the API for this component a bit more.

- Add component definition and template, use block for content
- Add rspec scenarios; include new title and render check.
- Generate example files

## Design questions

- How do we want to validate the allowed types? We can use active model validations, but these can cause runtime errors. Maybe something like https://github.com/primer/view_components/blob/main/app/lib/primer/fetch_or_fallback_helper.rb to provide a default value if an invalid type is passed
- Should `cads-badge` be its own component? Technically the only valid modifier for this is `adviser`
