### PR TITLE
refactor: Re-enable all valid tablet tests [NP-1972]

### DIFF
--- a/testing/features/header.feature
+++ b/testing/features/header.feature
@@ -1,4 +1,3 @@
-@not_tablet
 Feature: Header component
 
   The Header component allows users to perform some quick tasks
@@ -35,7 +34,7 @@ Feature: Header component
       And a login link is present
       And a logo is present
 
-    @not_mobile
+    @not_mobile @not_tablet
     Scenario Outline: English Users can quickly navigate to various areas of the page
       Then I am able to skip to the <area> part of the page
 
@@ -45,7 +44,7 @@ Feature: Header component
         | content    |
         | footer     |
 
-    @not_mobile
+    @not_mobile @not_tablet
     Scenario Outline: Welsh Users can quickly navigate to various areas of the page
       Given the language is Welsh
       Then I am able to skip to the <area> part of the page

--- a/testing/features/header.feature
+++ b/testing/features/header.feature
@@ -59,11 +59,11 @@ Feature: Header component
   Rule: A Standard Header (Small Screen)
     @small_screen
     Scenario: English Header can be expanded to show the full search bar
-      Then I am able to expand the search bar
-      And I am able to collapse the search bar
+      Then I can expand the search bar
+      And I can collapse the search bar
 
     @small_screen
     Scenario: Welsh Header can be expanded to show the full search bar
       Given the language is Welsh
-      Then I am able to expand the search bar
-      And I am able to collapse the search bar
+      Then I can expand the search bar
+      And I can collapse the search bar

--- a/testing/features/header.feature
+++ b/testing/features/header.feature
@@ -10,10 +10,18 @@ Feature: Header component
   of the page and move straight to the Navigation/Content/Footer by using
   their "Tab" key on the keyboard
 
-  Rule: A Standard Header
-    Background:
-      Given a Standard Header component is on the page
+  Background:
+    Given a Standard Header component is on the page
 
+  Rule: A Standard Header (Screen size agnostic)
+    Scenario: English Header has a search option
+      Then I am able to search in English
+
+    Scenario: Welsh Header has a search option
+      Given the language is Welsh
+      Then I am able to search in Welsh
+
+  Rule: A Standard Header (Large Screen)
     @not_mobile
     Scenario: English Header has some quick links
       Then a link to change language is present
@@ -26,13 +34,6 @@ Feature: Header component
       Then a link to change language is present
       And a login link is present
       And a logo is present
-
-    Scenario: English Header has a search option
-      Then I am able to search in English
-
-    Scenario: Welsh Header has a search option
-      Given the language is Welsh
-      Then I am able to search in Welsh
 
     @not_mobile
     Scenario Outline: English Users can quickly navigate to various areas of the page
@@ -55,10 +56,7 @@ Feature: Header component
         | content    |
         | footer     |
 
-  Rule: A Standard Header (Mobile View)
-    Background:
-      Given a Standard Header component is on the page
-
+  Rule: A Standard Header (Small Screen)
     @small_screen
     Scenario: English Header can be expanded to show the full search bar
       Then I am able to expand the search bar

--- a/testing/features/navigation.feature
+++ b/testing/features/navigation.feature
@@ -1,11 +1,11 @@
-@future_release @v4.0.5+ @not_tablet
+@future_release @v4.0.5+
 Feature: Navigation component
 
   Rule: The greedy nav displays as many navigation links as fit on the viewport.  Any that don't fit are added into an expandable dropdown.
     Background:
       Given the navigation is on the page
 
-    @not_mobile
+    @not_mobile @not_tablet
     Scenario: all links fit onto the screen
       Then the dropdown toggle is not present
 
@@ -24,7 +24,7 @@ Feature: Navigation component
       When I close the dropdown menu
       Then the dropdown menu is closed
 
-    @not_mobile
+    @not_mobile @not_tablet
     Scenario: tabbing onto the dropdown toggle opens the dropdown menu
       Given the navigation does not fit on the screen
       And the dropdown toggle is present
@@ -32,7 +32,7 @@ Feature: Navigation component
       Then the Close button is present
       And the dropdown menu is open
 
-    @failing @np-1755 @not_mobile
+    @failing @NP-1755 @not_mobile @not_tablet
     Scenario: tabbing out of the dropdown menu closes it
       Given the dropdown menu is already open
       When I tab out of the dropdown menu
@@ -45,7 +45,7 @@ Feature: Navigation component
       Then the dropdown menu is closed
       And the More button is present
 
-    @not_mobile @np-1766
+    @not_mobile @not_tablet @NP-1766
     Scenario: you can close the dropdown menu by clicking outside of it
       Given the dropdown menu is already open
       When I click outside of the menu

--- a/testing/features/notice_banner.feature
+++ b/testing/features/notice_banner.feature
@@ -1,4 +1,3 @@
-@not_tablet
 Feature: Notice Banner
 
   The notification banner informs the user about something they need to know

--- a/testing/features/pagination.feature
+++ b/testing/features/pagination.feature
@@ -3,18 +3,18 @@ Feature: Pagination
   The pagination helps users navigate through multiple pages.
   Typically used for pages of search results.
 
-  Rule: Example
+  Rule: Example Pagination
     Background:
       Given an Example Pagination component is on the page
 
-    Scenario: All of the pagination elements are present on the page
-      Then current page displayed
+    Scenario: All of the pagination buttons are present on the page
+      Then current page is displayed
       And there are numerical buttons to skip to the 2 previous pages
       And there are numerical buttons to skip to the 2 next pages
       And there are buttons to skip to the first and last page
       And there are buttons to skip to the next and previous page
 
-  Rule: Paging Info
+  Rule: Paging Info Pagination
     Background:
       Given a Paging Info Pagination component is on the page
 

--- a/testing/features/search.feature
+++ b/testing/features/search.feature
@@ -1,4 +1,4 @@
-@failing @NP-1803 @not_tablet
+@failing @NP-1803
 Feature: Search components
 
   The Search component allows users to search for the desired term and consists

--- a/testing/features/step_definitions/common_steps.rb
+++ b/testing/features/step_definitions/common_steps.rb
@@ -32,7 +32,7 @@ Then("I am able to search in English/Welsh") do
   expect(@component.search_button["title"]).to eq(I18n.t("cads.search.submit_title"))
 end
 
-Then("I am able to expand the search bar") do
+Then("I can expand the search bar") do
   expect(@component.open_search_pane["title"]).to eq(I18n.t("cads.header.open_search"))
 
   @component.open_search_pane.click
@@ -40,7 +40,7 @@ Then("I am able to expand the search bar") do
   expect(@component).to have_search_field
 end
 
-Then("I am able to collapse the search bar") do
+Then("I can collapse the search bar") do
   expect(@component.open_search_pane["title"]).to eq(I18n.t("cads.header.close_search"))
 
   @component.open_search_pane.click

--- a/testing/features/step_definitions/pagination.rb
+++ b/testing/features/step_definitions/pagination.rb
@@ -8,7 +8,7 @@ Given("a Paging Info Pagination component is on the page") do
   @component = Pagination::PagingInfo.new.tap(&:load)
 end
 
-Then("current page displayed") do
+Then("current page is displayed") do
   expect(@component).to have_current_page
 end
 

--- a/testing/features/support/components/header/standard.rb
+++ b/testing/features/support/components/header/standard.rb
@@ -15,7 +15,7 @@ module Header
     element :open_search_pane, "[data-testid='expand-button']"
 
     def search_for(search_term)
-      open_search_pane(wait: 1).click if device?
+      open_search_pane(wait: 1).click if iphone?
       search_field.send_keys(search_term)
     end
 

--- a/testing/features/targeted_content.feature
+++ b/testing/features/targeted_content.feature
@@ -1,4 +1,3 @@
-@not_tablet
 Feature: Targeted Content component
 
   The Targeted Content component allows content managers


### PR DESCRIPTION
When we first enabled tablet we only enabled about 25% of tests.
This PR enables a further 50-60% the remainder all are not valid for tablet.