### PR TITLE
chore: remove resize polyfill from storybook

### DIFF
--- a/.storybook/polyfill.js
+++ b/.storybook/polyfill.js
@@ -1,7 +1,1 @@
 require('url-polyfill');
-
-const ResizeObserverPolyfill = require('resize-observer-polyfill').default;
-
-if (!window.ResizeObserver) {
-  window.ResizeObserver = ResizeObserverPolyfill;
-}

--- a/package-lock.json
+++ b/package-lock.json
@@ -24277,12 +24277,6 @@
       "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=",
       "dev": true
     },
-    "resize-observer-polyfill": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",
-      "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg==",
-      "dev": true
-    },
     "resolve": {
       "version": "1.17.0",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",

--- a/package.json
+++ b/package.json
@@ -91,7 +91,6 @@
     "postcss-url": "^10.1.3",
     "prettier": "^2.1.2",
     "raw-loader": "^4.0.1",
-    "resize-observer-polyfill": "^1.5.1",
     "resolve-url-loader": "^3.1.1",
     "sane": "^4.1.0",
     "sass": "^1.32.11",


### PR DESCRIPTION
In https://github.com/citizensadvice/design-system/pull/1001, we introduced polyfill for storybook to allow older safari and IE browserstack tests to pass.

This has now introduced a typescript conflict between `resize-observer-polyfill` and `typescript` which is preventing build.

Testing removing the polyfill completely - this may cause the browserstack tests to fail.
