### PR TITLE
Targeted content: Support number anchors [NP-1951]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - 👤 Header: The sign out button now has the visual appearance of a button
 - 🗣️ Callouts: Rendered as sections with an aria-label if `title` is provided in the hash
+- 🎯 Targeted content: Fix error thrown when anchoring to an ID starting with a number, e.g. #41za
 
 ## <sub>v4.0.6-alpha.0</sub>
 

--- a/src/js/targeted-content.js
+++ b/src/js/targeted-content.js
@@ -48,13 +48,16 @@ function setState(el, state) {
 }
 
 function openByHash(hash) {
-  const targetEl = document.querySelector(hash);
-  if (targetEl) {
-    const matchEl = targetEl.closest(SELECTORS.el);
-    if (matchEl) {
-      setState(matchEl, 'open');
+  try {
+    const hashId = hash.replace(/^#/, '');
+    const targetEl = document.getElementById(hashId);
+    if (targetEl) {
+      const matchEl = targetEl.closest(SELECTORS.el);
+      if (matchEl) {
+        setState(matchEl, 'open');
+      }
     }
-  }
+  } catch (e) {} // eslint-disable-line no-empty
 }
 
 function initTargetedContentFor(el) {


### PR DESCRIPTION
The HTML spec states that IDs can consist of any character https://html.spec.whatwg.org/multipage/dom.html#the-id-attribute. However, `querySelector` requires selectors that start with numbers to be escaped.

Previously, if you tried to anchor to an ID starting with a number, e.g. for paragraph numbers this would throw an error.

For our use case we can normalise the hash and use `getElementById` instead.

Also wrapping the hash behaviour in a try/catch as this is an enhancement and it's fine to fail silently if this code fails.

Fixes NP-1951