### PR TITLE
Fix ignore syntax

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,11 +19,10 @@ updates:
     labels:
       - 'npm dependencies'
     target-branch: 'master'
-    ignored_updates:
-      - match:
-          # Requires webpack v5 but storybook bundles v4
-          dependency_name: 'sass-loader'
-          version_requirement: '11.x'
+    ignore:
+      # Requires webpack v5 but storybook bundles v4
+      - dependency_name: 'sass-loader'
+        versions: ['11.x']
 
   - package-ecosystem: npm
     directory: '/testing'


### PR DESCRIPTION
Turns out I used an older syntax for ignoring dependabot versions. Helpfully dependabot checks itself and flagged this in a status check.

<img width="854" alt="Screenshot 2021-05-19 at 14 34 01" src="https://user-images.githubusercontent.com/123386/118821912-9693fa80-b8af-11eb-92e7-48aee0312d36.png">
