### PR TITLE
fix: add correct focus styles to tertiary dark

### DIFF
--- a/scss/4-elements/_buttons.scss
+++ b/scss/4-elements/_buttons.scss
@@ -139,7 +139,6 @@ $button-shadow-size: 4px;
   }
 
   &:focus {
-    outline: none;
     color: $cads-language__focus-text-colour;
     border-color: $cads-language__focus-border-colour;
     background-color: $cads-language__focus-colour;

--- a/scss/4-elements/_buttons.scss
+++ b/scss/4-elements/_buttons.scss
@@ -137,4 +137,12 @@ $button-shadow-size: 4px;
     color: $cads-language__tertiary-button-dark-hover-colour;
     border-color: $cads-language__tertiary-button-dark-hover-border-colour;
   }
+
+  &:focus {
+    outline: none;
+    color: $cads-language__focus-text-colour;
+    border-color: $cads-language__focus-border-colour;
+    background-color: $cads-language__focus-colour;
+    box-shadow: 0 $button-shadow-size 0 0 $cads-language__focus-border-colour;
+  }
 }


### PR DESCRIPTION
Add specific focus styles to tertiary--dark button.

![image](https://user-images.githubusercontent.com/2331893/119363424-b3607180-bca5-11eb-885c-6062d98dac00.png)
