### PR TITLE
chore: add codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # Global owners - all PRs will be assigned to these users
-@davidrapson @davidsauntson
+*       @davidrapson @davidsauntson

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Global owners - all PRs will be assigned to these users
+@davidrapson @davidsauntson


### PR DESCRIPTION
Add The Davids(TM) as global code owners.  When this is merged they should be added as reviewers to any PR with `master` as the target.
