### PR TITLE
Feat/breadcrumb view component DS-7

### DIFF
--- a/demo/app/views/layouts/application.html.haml
+++ b/demo/app/views/layouts/application.html.haml
@@ -2,6 +2,7 @@
 %html{ lang: I18n.locale }
   %head{ profile: "http://www.w3.org/2005/10/profile" }
     %meta{ content: "text/html; charset=UTF-8", "http-equiv": "Content-Type" }
+    %meta{ name: "viewport", content:"width=device-width, initial-scale=1.0" }
     %title Demo
     = csp_meta_tag
     = stylesheet_pack_tag "application", media: "all"

--- a/demo/app/views/layouts/application.html.haml
+++ b/demo/app/views/layouts/application.html.haml
@@ -2,7 +2,7 @@
 %html{ lang: I18n.locale }
   %head{ profile: "http://www.w3.org/2005/10/profile" }
     %meta{ content: "text/html; charset=UTF-8", "http-equiv": "Content-Type" }
-    %meta{ name: "viewport", content:"width=device-width, initial-scale=1.0" }
+    %meta{ name: "viewport", content: "width=device-width, initial-scale=1.0" }
     %title Demo
     = csp_meta_tag
     = stylesheet_pack_tag "application", media: "all"

--- a/engine/app/components/citizens_advice_components/breadcrumbs.html.haml
+++ b/engine/app/components/citizens_advice_components/breadcrumbs.html.haml
@@ -1,0 +1,10 @@
+%nav{ class: "cads-breadcrumbs cads-breadcrumbs--#{@type.to_s.dasherize}", "aria-label": "breadcrumbs" }
+  %ul.cads-breadcrumbs__list
+    - @links.each_with_index do |link, index|
+      %li.cads-breadcrumbs__crumb
+        - if index == links.size - 1
+          %span.cads-breadcrumb{ aria: { current: "location" } }
+            = link[:title]
+        - else
+          %a.cads-breadcrumb{ href: link[:url] }
+            = link[:title]

--- a/engine/app/components/citizens_advice_components/breadcrumbs.html.haml
+++ b/engine/app/components/citizens_advice_components/breadcrumbs.html.haml
@@ -1,6 +1,6 @@
-%nav{ class: "cads-breadcrumbs cads-breadcrumbs--#{@type.to_s.dasherize}", "aria-label": "breadcrumbs" }
+%nav{ class: "cads-breadcrumbs cads-breadcrumbs--#{type.to_s.dasherize}", "aria-label": "breadcrumbs" }
   %ul.cads-breadcrumbs__list
-    - @links.each_with_index do |link, index|
+    - links.each_with_index do |link, index|
       %li.cads-breadcrumbs__crumb
         - if index == links.size - 1
           %span.cads-breadcrumb{ aria: { current: "location" } }

--- a/engine/app/components/citizens_advice_components/breadcrumbs.rb
+++ b/engine/app/components/citizens_advice_components/breadcrumbs.rb
@@ -1,20 +1,17 @@
 # frozen_string_literal: true
 
 module CitizensAdviceComponents
-    class Breadcrumbs < Base
-      attr_reader :type, :links
-  
-      def initialize(type: :collapse, links:)
-        super
-        @type = fetch_or_fallback(allowed_values: %i[collapse no_collapse], given_value: type, fallback: :collapse )
-        @links = links.each if links.present? do |link|
-            link.symbolize_keys!
-        end
-      end
+  class Breadcrumbs < Base
+    attr_reader :type, :links
 
-      def render?
-        links.present?
-      end
+    def initialize(links:, type: :collapse)
+      super
+      @type = fetch_or_fallback(allowed_values: %i[collapse no_collapse], given_value: type, fallback: :collapse)
+      @links = links.each if links.present?(&:symbolize_keys!)
+    end
+
+    def render?
+      links.present?
     end
   end
-  
+end

--- a/engine/app/components/citizens_advice_components/breadcrumbs.rb
+++ b/engine/app/components/citizens_advice_components/breadcrumbs.rb
@@ -2,16 +2,20 @@
 
 module CitizensAdviceComponents
   class Breadcrumbs < Base
-    attr_reader :type, :links
+    attr_reader :type
 
     def initialize(links:, type: :collapse)
       super
       @type = fetch_or_fallback(allowed_values: %i[collapse no_collapse], given_value: type, fallback: :collapse)
-      @links = links.each if links.present?(&:symbolize_keys!)
+      @links = links
     end
 
     def render?
-      links.present?
+      @links.present?
+    end
+
+    def links
+      @links.map(&:symbolize_keys)
     end
   end
 end

--- a/engine/app/components/citizens_advice_components/breadcrumbs.rb
+++ b/engine/app/components/citizens_advice_components/breadcrumbs.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module CitizensAdviceComponents
+    class Breadcrumbs < Base
+      attr_reader :type, :links
+  
+      def initialize(type:, links:)
+        super
+        @type = fetch_or_fallback(allowed_values: %i[collapse no_collapse], given_value: type, fallback: :collapse )
+        @links = links.each do |link|
+            link.symbolize_keys!
+        end
+      end
+    end
+  end
+  

--- a/engine/app/components/citizens_advice_components/breadcrumbs.rb
+++ b/engine/app/components/citizens_advice_components/breadcrumbs.rb
@@ -4,10 +4,10 @@ module CitizensAdviceComponents
     class Breadcrumbs < Base
       attr_reader :type, :links
   
-      def initialize(type:, links:)
+      def initialize(type: :collapse, links:)
         super
         @type = fetch_or_fallback(allowed_values: %i[collapse no_collapse], given_value: type, fallback: :collapse )
-        @links = links.each do |link|
+        @links = links.each if links.present? do |link|
             link.symbolize_keys!
         end
       end

--- a/engine/app/components/citizens_advice_components/breadcrumbs.rb
+++ b/engine/app/components/citizens_advice_components/breadcrumbs.rb
@@ -11,6 +11,10 @@ module CitizensAdviceComponents
             link.symbolize_keys!
         end
       end
+
+      def render?
+        links.present?
+      end
     end
   end
   

--- a/engine/previews/citizens_advice_components/breadcrumbs_preview.rb
+++ b/engine/previews/citizens_advice_components/breadcrumbs_preview.rb
@@ -45,5 +45,36 @@ module CitizensAdviceComponents
         )
       )
     end
+
+    def long
+      render(
+        CitizensAdviceComponents::Breadcrumbs.new(
+          type: :collapse,
+          links: [
+            {
+              title: 'Home',
+              url: '/'
+            },
+            {
+              title: '
+              My Grandmother Asked Me to Tell You She’s Sorry',
+              url: '/immigration'
+            },
+            {
+              title: 'The Curious Incident of the Dog in the Night-Time',
+              url: '/immigration/staying-in-the-uk'
+            },
+            {
+              title:  'Fried Green Tomatoes at the Whistle Stop Cafe',
+              url: '/'
+            },
+            {
+              title: 'Eleanor Oliphant is Completely Fine',
+              url: '/'
+            }
+          ]
+        )
+      )
+    end
   end
 end

--- a/engine/previews/citizens_advice_components/breadcrumbs_preview.rb
+++ b/engine/previews/citizens_advice_components/breadcrumbs_preview.rb
@@ -54,8 +54,7 @@ module CitizensAdviceComponents
               url: "/"
             },
             {
-              title: '
-              My Grandmother Asked Me to Tell You She’s Sorry',
+              title: "My Grandmother Asked Me to Tell You She’s Sorry",
               url: "/immigration"
             },
             {

--- a/engine/previews/citizens_advice_components/breadcrumbs_preview.rb
+++ b/engine/previews/citizens_advice_components/breadcrumbs_preview.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+module CitizensAdviceComponents
+  class BreadcrumbsPreview < ViewComponent::Preview
+    def collapsing
+      render(
+        CitizensAdviceComponents::Breadcrumbs.new(
+          type: :collapse,
+          links: [
+            {
+              title: 'Home',
+              url: '/'
+            },
+            {
+              title: 'Immigration',
+              url: '/immigration'
+            },
+            {
+              title: 'Staying in the UK',
+              url: '/immigration/staying-in-the-uk'
+            }
+          ]
+        )
+      )
+    end
+
+    def not_collapsing
+      render(
+        CitizensAdviceComponents::Breadcrumbs.new(
+          type: :no_collapse,
+          links: [
+            {
+              title: 'Home',
+              url: '/'
+            },
+            {
+              title: 'Immigration',
+              url: '/immigration'
+            },
+            {
+              title: 'Staying in the UK',
+              url: '/immigration/staying-in-the-uk'
+            }
+          ]
+        )
+      )
+    end
+  end
+end

--- a/engine/previews/citizens_advice_components/breadcrumbs_preview.rb
+++ b/engine/previews/citizens_advice_components/breadcrumbs_preview.rb
@@ -8,15 +8,15 @@ module CitizensAdviceComponents
           type: :collapse,
           links: [
             {
-              title: 'Home',
-              url: '/'
+              title: "Home",
+              url: "/"
             },
             {
-              title: 'Immigration',
-              url: '/immigration'
+              title: "Immigration",
+              url: "/immigration"
             },
             {
-              title: 'Staying in the UK'
+              title: "Staying in the UK"
             }
           ]
         )
@@ -29,15 +29,15 @@ module CitizensAdviceComponents
           type: :no_collapse,
           links: [
             {
-              title: 'Home',
-              url: '/'
+              title: "Home",
+              url: "/"
             },
             {
-              title: 'Immigration',
-              url: '/immigration'
+              title: "Immigration",
+              url: "/immigration"
             },
             {
-              title: 'Staying in the UK'
+              title: "Staying in the UK"
             }
           ]
         )
@@ -50,24 +50,24 @@ module CitizensAdviceComponents
           type: :collapse,
           links: [
             {
-              title: 'Home',
-              url: '/'
+              title: "Home",
+              url: "/"
             },
             {
               title: '
               My Grandmother Asked Me to Tell You She’s Sorry',
-              url: '/immigration'
+              url: "/immigration"
             },
             {
-              title: 'The Curious Incident of the Dog in the Night-Time',
-              url: '/immigration/staying-in-the-uk'
+              title: "The Curious Incident of the Dog in the Night-Time",
+              url: "/immigration/staying-in-the-uk"
             },
             {
-              title:  'Fried Green Tomatoes at the Whistle Stop Cafe',
-              url: '/'
+              title: "Fried Green Tomatoes at the Whistle Stop Cafe",
+              url: "/"
             },
             {
-              title: 'Eleanor Oliphant is Completely Fine'
+              title: "Eleanor Oliphant is Completely Fine"
             }
           ]
         )

--- a/engine/previews/citizens_advice_components/breadcrumbs_preview.rb
+++ b/engine/previews/citizens_advice_components/breadcrumbs_preview.rb
@@ -16,8 +16,7 @@ module CitizensAdviceComponents
               url: '/immigration'
             },
             {
-              title: 'Staying in the UK',
-              url: '/immigration/staying-in-the-uk'
+              title: 'Staying in the UK'
             }
           ]
         )
@@ -38,8 +37,7 @@ module CitizensAdviceComponents
               url: '/immigration'
             },
             {
-              title: 'Staying in the UK',
-              url: '/immigration/staying-in-the-uk'
+              title: 'Staying in the UK'
             }
           ]
         )
@@ -69,8 +67,7 @@ module CitizensAdviceComponents
               url: '/'
             },
             {
-              title: 'Eleanor Oliphant is Completely Fine',
-              url: '/'
+              title: 'Eleanor Oliphant is Completely Fine'
             }
           ]
         )

--- a/engine/spec/components/breadcrumbs_spec.rb
+++ b/engine/spec/components/breadcrumbs_spec.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+RSpec.describe CitizensAdviceComponents::Breadcrumbs, type: :component do
+  subject(:component) do
+    render_inline(
+      described_class.new(
+        type: type.presence,
+        links: links.presence
+      )
+    )
+  end
+
+  let(:type) { :collapse }
+  let(:links) { 
+    [
+      {
+        title: "Home",
+        url: "/"
+      },
+      {
+        title: "Immigration",
+        url: "/immigration"
+      },
+      {
+        title: "Staying in the UK"
+      }
+    ]
+  }
+
+  it "renders the correct number of breadcrumbs" do
+    expect(component.css("li").length).to eq 3
+  end
+
+  it "renders the current page as a span" do
+    expect(component.css("span").text.strip).to eq "Staying in the UK"
+  end
+
+  it "renders the current page with an aria-current of 'location'" do
+    expect(component.css("span").attribute("aria-current").value).to eq "location"
+  end
+
+  context "no_collapse type is provided" do
+    let(:type) { :no_collapse }
+
+    it "renders the the non-collapsible version" do
+      expect(component.css('.cads-breadcrumbs--no-collapse')).to be_present
+    end
+  end
+
+  context "no links are provided" do 
+    let(:links) { nil }
+
+    it "does not render" do
+      expect(component.css('.cads-breadcrumbs')).to_not be_present
+    end
+  end
+
+  context "no type is provided" do
+    let(:type) { nil }
+
+    context "production rails env" do
+      before do
+        allow(Rails.env).to receive(:production?).and_return(true)
+      end
+
+      it "renders collapsible version by default" do 
+        expect(component.css('.cads-breadcrumbs--collapse')).to be_present
+      end    
+    end
+  end
+end

--- a/engine/spec/components/breadcrumbs_spec.rb
+++ b/engine/spec/components/breadcrumbs_spec.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
-RSpec.shared_examples "breadcrumbs" do 
+
+RSpec.shared_examples "breadcrumbs" do
   it "renders the correct number of breadcrumbs" do
     expect(component.css("li").length).to eq 3
   end
@@ -12,7 +13,6 @@ RSpec.shared_examples "breadcrumbs" do
     expect(component.css("span").attribute("aria-current").value).to eq "location"
   end
 end
-
 
 RSpec.describe CitizensAdviceComponents::Breadcrumbs, type: :component do
   subject(:component) do
@@ -74,7 +74,7 @@ RSpec.describe CitizensAdviceComponents::Breadcrumbs, type: :component do
   end
 
   context "links are passed with the old style hash format" do
-    let(:links) do  
+    let(:links) do
       [
         {
           "title" => "Home",
@@ -89,7 +89,7 @@ RSpec.describe CitizensAdviceComponents::Breadcrumbs, type: :component do
         }
       ]
     end
-    
+
     it_behaves_like "breadcrumbs"
   end
 end

--- a/engine/spec/components/breadcrumbs_spec.rb
+++ b/engine/spec/components/breadcrumbs_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe CitizensAdviceComponents::Breadcrumbs, type: :component do
   end
 
   let(:type) { :collapse }
-  let(:links) { 
+  let(:links) do
     [
       {
         title: "Home",
@@ -25,7 +25,7 @@ RSpec.describe CitizensAdviceComponents::Breadcrumbs, type: :component do
         title: "Staying in the UK"
       }
     ]
-  }
+  end
 
   it "renders the correct number of breadcrumbs" do
     expect(component.css("li").length).to eq 3
@@ -43,15 +43,15 @@ RSpec.describe CitizensAdviceComponents::Breadcrumbs, type: :component do
     let(:type) { :no_collapse }
 
     it "renders the the non-collapsible version" do
-      expect(component.css('.cads-breadcrumbs--no-collapse')).to be_present
+      expect(component.css(".cads-breadcrumbs--no-collapse")).to be_present
     end
   end
 
-  context "no links are provided" do 
+  context "no links are provided" do
     let(:links) { nil }
 
     it "does not render" do
-      expect(component.css('.cads-breadcrumbs')).to_not be_present
+      expect(component.css(".cads-breadcrumbs")).to_not be_present
     end
   end
 
@@ -63,9 +63,9 @@ RSpec.describe CitizensAdviceComponents::Breadcrumbs, type: :component do
         allow(Rails.env).to receive(:production?).and_return(true)
       end
 
-      it "renders collapsible version by default" do 
-        expect(component.css('.cads-breadcrumbs--collapse')).to be_present
-      end    
+      it "renders collapsible version by default" do
+        expect(component.css(".cads-breadcrumbs--collapse")).to be_present
+      end
     end
   end
 end

--- a/engine/spec/components/breadcrumbs_spec.rb
+++ b/engine/spec/components/breadcrumbs_spec.rb
@@ -1,9 +1,23 @@
 # frozen_string_literal: true
+RSpec.shared_examples "breadcrumbs" do 
+  it "renders the correct number of breadcrumbs" do
+    expect(component.css("li").length).to eq 3
+  end
+
+  it "renders the current page as a span" do
+    expect(component.css("span").text.strip).to eq "Staying in the UK"
+  end
+
+  it "renders the current page with an aria-current of 'location'" do
+    expect(component.css("span").attribute("aria-current").value).to eq "location"
+  end
+end
+
 
 RSpec.describe CitizensAdviceComponents::Breadcrumbs, type: :component do
   subject(:component) do
     render_inline(
-      described_class.new(
+      CitizensAdviceComponents::Breadcrumbs.new(
         type: type.presence,
         links: links.presence
       )
@@ -27,17 +41,7 @@ RSpec.describe CitizensAdviceComponents::Breadcrumbs, type: :component do
     ]
   end
 
-  it "renders the correct number of breadcrumbs" do
-    expect(component.css("li").length).to eq 3
-  end
-
-  it "renders the current page as a span" do
-    expect(component.css("span").text.strip).to eq "Staying in the UK"
-  end
-
-  it "renders the current page with an aria-current of 'location'" do
-    expect(component.css("span").attribute("aria-current").value).to eq "location"
-  end
+  it_behaves_like "breadcrumbs"
 
   context "no_collapse type is provided" do
     let(:type) { :no_collapse }
@@ -67,5 +71,25 @@ RSpec.describe CitizensAdviceComponents::Breadcrumbs, type: :component do
         expect(component.css(".cads-breadcrumbs--collapse")).to be_present
       end
     end
+  end
+
+  context "links are passed with the old style hash format" do
+    let(:links) do  
+      [
+        {
+          "title" => "Home",
+          "url" => "/"
+        },
+        {
+          "title" => "Immigration",
+          "url" => "/immigration"
+        },
+        {
+          "title" => "Staying in the UK"
+        }
+      ]
+    end
+    
+    it_behaves_like "breadcrumbs"
   end
 end

--- a/haml/_breadcrumb.html.haml
+++ b/haml/_breadcrumb.html.haml
@@ -9,7 +9,7 @@
       %li.cads-breadcrumbs__crumb
         - if index == breadcrumbs["breadcrumb_links"].size - 1
           %span.cads-breadcrumb
-            = link["title"]
+            = link["title"]{ aria: { current: "location" } }
         - else
           %a.cads-breadcrumb{ href: link["url"] }
             = link["title"]

--- a/haml/_breadcrumb.html.haml
+++ b/haml/_breadcrumb.html.haml
@@ -8,8 +8,8 @@
     - breadcrumbs["breadcrumb_links"].each_with_index do |link, index|
       %li.cads-breadcrumbs__crumb
         - if index == breadcrumbs["breadcrumb_links"].size - 1
-          %span.cads-breadcrumb
-            = link["title"]{ aria: { current: "location" } }
+          %span.cads-breadcrumb{ aria: { current: "location" } }
+            = link["title"]
         - else
           %a.cads-breadcrumb{ href: link["url"] }
             = link["title"]

--- a/styleguide/components/breadcrumbs/breadcrumbs.stories.mdx
+++ b/styleguide/components/breadcrumbs/breadcrumbs.stories.mdx
@@ -95,7 +95,40 @@ This story shows how longer breadcrumb titles are displayed.
 
 When shown in a search result, the breadcumbs do not show the home page and do not have a horizontal rule underneath.
 
-## Haml template options
+## Using with Rails
+
+If you are using the `citizens_advice_components` gem, you can call the component from within a template using:
+
+```rb
+= render(
+  CitizensAdviceComponents::Breadcrumbs.new(
+    type: :collapse,
+    links: [
+      {
+        title: "Home",
+        url: "/"
+      },
+      {
+        title: "Immigration",
+        url: "/immigration"
+      },
+      {
+        title: "Staying in the UK"
+      }
+    ])
+)
+```
+
+### View Component Options
+
+| Property      | Description                                             |
+| ------------- | ------------------------------------------------------- |
+| `type`        | Optional, one of: `:collapse` (default), `:no_collapse` |
+| `links`       | Required, an array of hashes, each with the following:  |
+| `link[url]`   | &rarr; Required, url for the breadcrumb link            |
+| `link[title]` | &rarr; Required, title for the breadcrumb link          |
+
+### Haml template options
 
 The Haml partial takes a `breadcrumb` hash, which has the following properties:
 


### PR DESCRIPTION
Add the breadcrumbs component to the design system engine:
- new view component
- rspec
- previews
- updates `mdx` docs
- removes hard-coding and translating 'Home' link (this will be duplicated in old design system HAML in a different PR)