### PR TITLE
hotfix: Add in missing base url

### DIFF
--- a/testing/browserstack_ci.env
+++ b/testing/browserstack_ci.env
@@ -2,3 +2,4 @@ BROWSERSTACK=true
 HEADLESS=false
 GRID=false
 LOG_LOCATION=automation_logs.log
+TESTING_BASE_URL=https://citizensadvice.github.io/design-system


### PR DESCRIPTION
I forgot to amend the browserstack_ci env file also alongside the grid one.