### PR TITLE
fix: add missing env var

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -275,7 +275,8 @@ def define_browserstack_tests() {
       withEnv([
         "BROWSER=${it.browser}",
         "BROWSERSTACK_CONFIGURATION_OPTIONS=${it.config}",
-        'BROWSERSTACK=true'
+        'BROWSERSTACK=true',
+        "BROWSERSTACK_BUILD_NAME=Design system (Jenkins) ${env.BRANCH_NAME}_${getSha()}"
       ]) {
         withTestingNode("Browser Tests for ${it.browser} on ${it.config}", true, isMobile) {
           try {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,6 +60,7 @@ services:
       - BROWSERSTACK_USERNAME
       - BROWSERSTACK_ACCESS_KEY
       - BROWSERSTACK_CONFIGURATION_OPTIONS
+      - BROWSERSTACK_BUILD_NAME
       - DOCKER_TAG
     # Every key set in here should NOT be in the list above
     # Any key in this file that also exists in the list above will be overwritten


### PR DESCRIPTION
So I _think_ this will fix the missing `BROWSERSTACK_BUILD_NAME` key issue