### PR TITLE
fix: asset size reported in MiB not MB

### DIFF
--- a/engine/app/components/citizens_advice_components/asset_hyperlink.html.haml
+++ b/engine/app/components/citizens_advice_components/asset_hyperlink.html.haml
@@ -2,4 +2,4 @@
   = description
   %span.cads-asset-type<
     %span.cads-icon_file
-    \ #{number_to_human_size(size)}
+    \ #{number_to_human(size, precision: 2, units: { unit: 'B', thousand: 'KB', million: 'MB' })}

--- a/engine/spec/components/asset_hyperlink_spec.rb
+++ b/engine/spec/components/asset_hyperlink_spec.rb
@@ -12,6 +12,6 @@ RSpec.describe CitizensAdviceComponents::AssetHyperlink, type: :component do
   end
 
   it "renders link with text" do
-    expect(component.at("a").text.strip.strip.tr("\n", " ")).to eq "Test PDF  6.15 MB"
+    expect(component.at("a").text.strip.strip.tr("\n", " ")).to eq "Test PDF  6.4 MB"
   end
 end


### PR DESCRIPTION
Can't quite believe I spent time on this but the asset hyperlink view component reports 6,444,516 bytes as 6.15MB.  I sort of don't really care about the MiB / MB holy war but after you've downloaded the file, your OS will report it as 6.4MB rather than 6.15MB.  So I think they should match.

http://localhost:3000/immigration/applying-for-settled-status/

![image](https://user-images.githubusercontent.com/2331893/122197519-2c5f7d00-ce90-11eb-8369-22cecd3f5adb.png)

![image](https://user-images.githubusercontent.com/2331893/122197370-0508b000-ce90-11eb-8cfe-75abb4d738a8.png)
