### PR TITLE
Fix/breadcrumb options

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -21,6 +21,7 @@ Style/MixinUsage:
     - 'scripts/haml.rb'
 
 Metrics/MethodLength:
+  CountAsOne: ['array', 'hash']
   Exclude:
     - 'scripts/haml.rb'
     - 'engine/previews/**/*.rb'
@@ -33,3 +34,6 @@ Metrics/BlockLength:
     - 'spec/**/*.rb'
     - 'engine/spec/**/*.rb'
     - 'demo/spec/**/*.rb'
+
+Metrics/ClassLength:
+  CountAsOne: ['array', 'hash']

--- a/demo/Gemfile
+++ b/demo/Gemfile
@@ -18,6 +18,7 @@ group :development do
   gem "spring"
   gem "spring-watcher-listen", "~> 2.0.0"
   gem "web-console", ">= 3.3.0"
+  gem "pry"
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/demo/Gemfile
+++ b/demo/Gemfile
@@ -15,10 +15,10 @@ gem "citizens_advice_components", path: "../engine"
 group :development do
   gem "byebug", platforms: %i[mri mingw x64_mingw]
   gem "listen", "~> 3.2"
+  gem "pry"
   gem "spring"
   gem "spring-watcher-listen", "~> 2.0.0"
   gem "web-console", ">= 3.3.0"
-  gem "pry"
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/demo/Gemfile.lock
+++ b/demo/Gemfile.lock
@@ -71,6 +71,7 @@ GEM
     bindex (0.8.1)
     builder (3.2.4)
     byebug (11.1.3)
+    coderay (1.1.3)
     concurrent-ruby (1.1.8)
     crass (1.0.6)
     erubi (1.10.0)
@@ -112,6 +113,9 @@ GEM
     nokogiri (1.11.6)
       mini_portile2 (~> 2.5.0)
       racc (~> 1.4)
+    pry (0.14.1)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
     puma (5.3.2)
       nio4r (~> 2.0)
     racc (1.5.2)
@@ -196,6 +200,7 @@ DEPENDENCIES
   haml-rails
   htmlbeautifier (~> 1.3)
   listen (~> 3.2)
+  pry
   puma (~> 5.3)
   rails (~> 6.1)
   spring

--- a/engine/app/components/citizens_advice_components/breadcrumbs.html.haml
+++ b/engine/app/components/citizens_advice_components/breadcrumbs.html.haml
@@ -1,10 +1,10 @@
-- haml_tag_if @full_width, ".cads-breadcrumbs-wrapper" do
+- haml_tag_if full_width?, ".cads-breadcrumbs-wrapper" do
   %nav{ class: "cads-breadcrumbs cads-breadcrumbs--#{type.to_s.dasherize}", "aria-label": "breadcrumbs" }
     %ul.cads-breadcrumbs__list
       - links.each_with_index do |link, index|
         %li.cads-breadcrumbs__crumb
           - if index == links.size - 1
-            %span.cads-breadcrumb{"aria-current": ("location" if @current_page) }
+            %span.cads-breadcrumb{"aria-current": ("location" if current_page?) }
               = link[:title]
           - else
             %a.cads-breadcrumb{ href: link[:url] }

--- a/engine/app/components/citizens_advice_components/breadcrumbs.html.haml
+++ b/engine/app/components/citizens_advice_components/breadcrumbs.html.haml
@@ -3,7 +3,7 @@
     - links.each_with_index do |link, index|
       %li.cads-breadcrumbs__crumb
         - if index == links.size - 1
-          %span.cads-breadcrumb{ aria: { current: "location" } }
+          %span.cads-breadcrumb{"aria-current": ("location" if @current_page) }
             = link[:title]
         - else
           %a.cads-breadcrumb{ href: link[:url] }

--- a/engine/app/components/citizens_advice_components/breadcrumbs.html.haml
+++ b/engine/app/components/citizens_advice_components/breadcrumbs.html.haml
@@ -1,10 +1,11 @@
-%nav{ class: "cads-breadcrumbs cads-breadcrumbs--#{type.to_s.dasherize}", "aria-label": "breadcrumbs" }
-  %ul.cads-breadcrumbs__list
-    - links.each_with_index do |link, index|
-      %li.cads-breadcrumbs__crumb
-        - if index == links.size - 1
-          %span.cads-breadcrumb{"aria-current": ("location" if @current_page) }
-            = link[:title]
-        - else
-          %a.cads-breadcrumb{ href: link[:url] }
-            = link[:title]
+- haml_tag_if @full_width, ".cads-breadcrumbs-wrapper" do
+  %nav{ class: "cads-breadcrumbs cads-breadcrumbs--#{type.to_s.dasherize}", "aria-label": "breadcrumbs" }
+    %ul.cads-breadcrumbs__list
+      - links.each_with_index do |link, index|
+        %li.cads-breadcrumbs__crumb
+          - if index == links.size - 1
+            %span.cads-breadcrumb{"aria-current": ("location" if @current_page) }
+              = link[:title]
+          - else
+            %a.cads-breadcrumb{ href: link[:url] }
+              = link[:title]

--- a/engine/app/components/citizens_advice_components/breadcrumbs.rb
+++ b/engine/app/components/citizens_advice_components/breadcrumbs.rb
@@ -19,5 +19,13 @@ module CitizensAdviceComponents
     def links
       @links.map(&:symbolize_keys)
     end
+
+    def full_width?
+      @full_width
+    end
+
+    def current_page?
+      @current_page
+    end
   end
 end

--- a/engine/app/components/citizens_advice_components/breadcrumbs.rb
+++ b/engine/app/components/citizens_advice_components/breadcrumbs.rb
@@ -9,7 +9,7 @@ module CitizensAdviceComponents
       @links = links
       @type = fetch_or_fallback(allowed_values: %i[collapse no_collapse], given_value: type, fallback: :collapse)
       @current_page = fetch_or_fallback_boolean(current_page, fallback: true)
-      @full_width = fetch_or_fallback_boolean(current_page, fallback: true)
+      @full_width = fetch_or_fallback_boolean(full_width, fallback: true)
     end
 
     def render?

--- a/engine/app/components/citizens_advice_components/breadcrumbs.rb
+++ b/engine/app/components/citizens_advice_components/breadcrumbs.rb
@@ -4,10 +4,11 @@ module CitizensAdviceComponents
   class Breadcrumbs < Base
     attr_reader :type
 
-    def initialize(links:, type: :collapse)
+    def initialize(links:, type: :collapse, current_page: true)
       super
-      @type = fetch_or_fallback(allowed_values: %i[collapse no_collapse], given_value: type, fallback: :collapse)
       @links = links
+      @type = fetch_or_fallback(allowed_values: %i[collapse no_collapse], given_value: type, fallback: :collapse)
+      @current_page = fetch_or_fallback_boolean(current_page, fallback: true)
     end
 
     def render?

--- a/engine/app/components/citizens_advice_components/breadcrumbs.rb
+++ b/engine/app/components/citizens_advice_components/breadcrumbs.rb
@@ -4,11 +4,12 @@ module CitizensAdviceComponents
   class Breadcrumbs < Base
     attr_reader :type
 
-    def initialize(links:, type: :collapse, current_page: true)
+    def initialize(links:, type: :collapse, current_page: true, full_width: true)
       super
       @links = links
       @type = fetch_or_fallback(allowed_values: %i[collapse no_collapse], given_value: type, fallback: :collapse)
       @current_page = fetch_or_fallback_boolean(current_page, fallback: true)
+      @full_width = fetch_or_fallback_boolean(current_page, fallback: true)
     end
 
     def render?

--- a/engine/app/components/citizens_advice_components/targeted_content.rb
+++ b/engine/app/components/citizens_advice_components/targeted_content.rb
@@ -35,7 +35,7 @@ module CitizensAdviceComponents
       @show_close_button
     end
 
-    def attributes # rubocop:disable Metrics/MethodLength
+    def attributes
       {
         class: [
           ("cads-targeted-content--adviser" if adviser?),

--- a/engine/previews/citizens_advice_components/breadcrumbs_preview.rb
+++ b/engine/previews/citizens_advice_components/breadcrumbs_preview.rb
@@ -92,7 +92,7 @@ module CitizensAdviceComponents
             }
           ]
         )
-      ) 
+      )
     end
 
     def not_on_current_page
@@ -114,7 +114,7 @@ module CitizensAdviceComponents
             }
           ]
         )
-      ) 
+      )
     end
   end
 end

--- a/engine/previews/citizens_advice_components/breadcrumbs_preview.rb
+++ b/engine/previews/citizens_advice_components/breadcrumbs_preview.rb
@@ -72,5 +72,49 @@ module CitizensAdviceComponents
         )
       )
     end
+
+    def not_full_width
+      render(
+        CitizensAdviceComponents::Breadcrumbs.new(
+          type: :no_collapse,
+          full_width: false,
+          links: [
+            {
+              title: "Home",
+              url: "/"
+            },
+            {
+              title: "Immigration",
+              url: "/immigration"
+            },
+            {
+              title: "Staying in the UK"
+            }
+          ]
+        )
+      ) 
+    end
+
+    def not_on_current_page
+      render(
+        CitizensAdviceComponents::Breadcrumbs.new(
+          type: :no_collapse,
+          current_page: false,
+          links: [
+            {
+              title: "Home",
+              url: "/"
+            },
+            {
+              title: "Immigration",
+              url: "/immigration"
+            },
+            {
+              title: "Staying in the UK"
+            }
+          ]
+        )
+      ) 
+    end
   end
 end

--- a/engine/spec/components/breadcrumbs_spec.rb
+++ b/engine/spec/components/breadcrumbs_spec.rb
@@ -12,6 +12,10 @@ RSpec.shared_examples "breadcrumbs" do
   it "renders the current page with an aria-current of 'location' by default" do
     expect(component.css("span").attribute("aria-current").value).to eq "location"
   end
+
+  it "renders the breadcrumbs in full width mode by default" do
+    expect(component.css(".cads-breadcrumbs-wrapper")).to be_present
+  end
 end
 
 RSpec.describe CitizensAdviceComponents::Breadcrumbs, type: :component do
@@ -19,8 +23,7 @@ RSpec.describe CitizensAdviceComponents::Breadcrumbs, type: :component do
     render_inline(
       CitizensAdviceComponents::Breadcrumbs.new(
         type: type.presence,
-        links: links.presence,
-        current_page: true
+        links: links.presence
       )
     )
   end
@@ -79,6 +82,14 @@ RSpec.describe CitizensAdviceComponents::Breadcrumbs, type: :component do
 
     it "does not add the aria-location attribute" do
       expect(component.css("span").attribute("aria-location")).to eq nil
+    end
+  end
+
+  context "when not in full width mode" do
+    let(:full_width) { false }
+
+    it "does not wrap the component in the full width wrapper" do
+      expect(component.css(".cads-breadcrumb-wrapper")).to be_empty
     end
   end
 

--- a/engine/spec/components/breadcrumbs_spec.rb
+++ b/engine/spec/components/breadcrumbs_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe CitizensAdviceComponents::Breadcrumbs, type: :component do
         url: "/immigration"
       },
       {
-        title: "Staying in the UK",
+        title: "Staying in the UK"
       }
     ]
   end

--- a/engine/spec/components/breadcrumbs_spec.rb
+++ b/engine/spec/components/breadcrumbs_spec.rb
@@ -9,7 +9,7 @@ RSpec.shared_examples "breadcrumbs" do
     expect(component.css("span").text.strip).to eq "Staying in the UK"
   end
 
-  it "renders the current page with an aria-current of 'location'" do
+  it "renders the current page with an aria-current of 'location' by default" do
     expect(component.css("span").attribute("aria-current").value).to eq "location"
   end
 end
@@ -19,7 +19,8 @@ RSpec.describe CitizensAdviceComponents::Breadcrumbs, type: :component do
     render_inline(
       CitizensAdviceComponents::Breadcrumbs.new(
         type: type.presence,
-        links: links.presence
+        links: links.presence,
+        current_page: true
       )
     )
   end
@@ -36,7 +37,7 @@ RSpec.describe CitizensAdviceComponents::Breadcrumbs, type: :component do
         url: "/immigration"
       },
       {
-        title: "Staying in the UK"
+        title: "Staying in the UK",
       }
     ]
   end
@@ -70,6 +71,14 @@ RSpec.describe CitizensAdviceComponents::Breadcrumbs, type: :component do
       it "renders collapsible version by default" do
         expect(component.css(".cads-breadcrumbs--collapse")).to be_present
       end
+    end
+  end
+
+  context "when not rendered on the current page" do
+    let(:current_page) { false }
+
+    it "does not add the aria-location attribute" do
+      expect(component.css("span").attribute("aria-location")).to eq nil
     end
   end
 

--- a/styleguide/components/breadcrumbs/breadcrumbs.stories.mdx
+++ b/styleguide/components/breadcrumbs/breadcrumbs.stories.mdx
@@ -56,6 +56,8 @@ Make sure your breadcrumb items reflect the page titles exactly for screen reade
 When breadcrumbs are displayed across the top of site content they must be wrapped in a `.cads-breadcrumb-wrapper`, this
 will correctly style and align the breadcrubs with site content. See sample pages for details.
 
+NB: If you are using the `ViewComponent` version of the breadcrumbs, they will be wrapped for you by default. You can pass `full_width: false` if you don't want those crumbs wrapped.
+
 <Preview>
   <Story
     name="Breadcrumbs (site wide)"
@@ -121,12 +123,14 @@ If you are using the `citizens_advice_components` gem, you can call the componen
 
 ### View Component Options
 
-| Property      | Description                                             |
-| ------------- | ------------------------------------------------------- |
-| `type`        | Optional, one of: `:collapse` (default), `:no_collapse` |
-| `links`       | Required, an array of hashes, each with the following:  |
-| `link[url]`   | &rarr; Required, url for the breadcrumb link            |
-| `link[title]` | &rarr; Required, title for the breadcrumb link          |
+| Property       | Description                                                                                       |
+| -------------- | ------------------------------------------------------------------------------------------------- |
+| `links`        | Required, an array of hashes, each with the following:                                            |
+| `link[url]`    | &rarr; Required, url for the breadcrumb link                                                      |
+| `link[title]`  | &rarr; Required, title for the breadcrumb link                                                    |
+| `type`         | Optional, one of: `:collapse` (default), `:no_collapse`                                           |
+| `current_page` | Optional, will render `aria-location=current` on last crumb if true. Defaults to true.            |
+| `full_width`   | Optional, will wrap breadcrumbs in the `.cads-breadcrumbs-wrapper` div if true. Defaults to true. |
 
 ### Haml template options
 


### PR DESCRIPTION
Adds some options into the `Breadcrumbs` view component:
 - `current_page` if the breadcrumbs represent the location of the current page (controls `aria-current`)
 - `full_width` if the breadcrumbs should take up the full width of the viewport (wraps in `.cads-breadcrumbs-wrapper`


Also adds `pry` into development dependencies and makes rubocop count hashes and arrays as 1 line long when assessing class and method length