### PR TITLE
bugfix: IOS browser caps and local BS runs

### DIFF
--- a/testing/features/support/drivers/browserstack/ios.rb
+++ b/testing/features/support/drivers/browserstack/ios.rb
@@ -22,7 +22,7 @@ module Drivers
         #
         # LH - April 2021
         #
-        initial_caps = CaTesting::Drivers::V4::Browserstack::Ios.new(ios_version).capabilities
+        initial_caps = CaTesting::Drivers::V4::Browserstack::Ios.new(browserstack_os_version).capabilities
         # This can be fixed up with v2.0.1 of the gem
         initial_caps["bstack:options"]["deviceName"] = browserstack_os
         initial_caps

--- a/testing/features/support/helpers/env_variables.rb
+++ b/testing/features/support/helpers/env_variables.rb
@@ -27,7 +27,7 @@ module Helpers
     end
 
     def browserstack_build_name
-      ENV.fetch("BROWSERSTACK_BUILD_NAME")
+      ENV["BROWSERSTACK_BUILD_NAME"]
     end
 
     def grid?


### PR DESCRIPTION
- bugfix: Allow ios to use non aliased method name
- bugfix: Allow local browserstack runs