### PR TITLE
Convert foundations examples to plain HTML

### DIFF
--- a/styleguide/foundations/grid/_basic-grid.html.haml
+++ b/styleguide/foundations/grid/_basic-grid.html.haml
@@ -1,5 +1,0 @@
-.cads-grid-container
-  .cads-grid-row
-    .cads-grid-col-8
-      .cads-styleguide-grid-example
-        This text is constrained to 8 columns

--- a/styleguide/foundations/grid/_multi-column-grid.html.haml
+++ b/styleguide/foundations/grid/_multi-column-grid.html.haml
@@ -1,8 +1,0 @@
-.cads-grid-container
-  .cads-grid-row
-    .cads-grid-col-8
-      .cads-styleguide-grid-example
-        8 columns
-    .cads-grid-col-4
-      .cads-styleguide-grid-example
-        4 columns

--- a/styleguide/foundations/grid/_responsive-grid.html.haml
+++ b/styleguide/foundations/grid/_responsive-grid.html.haml
@@ -1,5 +1,0 @@
-.cads-grid-container
-  .cads-grid-row
-    .cads-grid-col-md-8.cads-grid-col-lg-10
-      .cads-styleguide-grid-example
-        I vary based on breakpoint

--- a/styleguide/foundations/grid/basic-grid.html
+++ b/styleguide/foundations/grid/basic-grid.html
@@ -1,0 +1,9 @@
+<div class="cads-grid-container">
+  <div class="cads-grid-row">
+    <div class="cads-grid-col-8">
+      <div class="cads-styleguide-grid-example">
+        This text is constrained to 8 columns
+      </div>
+    </div>
+  </div>
+</div>

--- a/styleguide/foundations/grid/grid.stories.mdx
+++ b/styleguide/foundations/grid/grid.stories.mdx
@@ -1,7 +1,7 @@
 import { Meta, Story, Canvas, Source } from '@storybook/addon-docs/blocks';
-import templateBasic from './_basic-grid.html.haml';
-import templateMultiColumn from './_multi-column-grid.html.haml';
-import templateResponsive from './_responsive-grid.html.haml';
+import templateBasic from './basic-grid.html';
+import templateMultiColumn from './multi-column-grid.html';
+import templateResponsive from './responsive-grid.html';
 
 <Meta
   title="Foundations/Grid"
@@ -23,14 +23,14 @@ Grids are made up of three parts:
     name="Basic grid"
     parameters={{
       layout: 'fullscreen',
-      docs: { source: { code: templateBasic.raw } },
+      docs: { source: { code: templateBasic } },
     }}
   >
     {() => templateBasic}
   </Story>
 </Canvas>
 
-<Source dark="true" language="haml" code={templateBasic.raw} />
+<Source dark="true" language="haml" code={templateBasic} />
 
 ## Multi-column grids
 
@@ -41,14 +41,14 @@ Grids are **12** columns by default (although this can be configured by overridi
     name="Multi-column grid"
     parameters={{
       layout: 'fullscreen',
-      docs: { source: { code: templateMultiColumn.raw } },
+      docs: { source: { code: templateMultiColumn } },
     }}
   >
     {() => templateMultiColumn}
   </Story>
 </Canvas>
 
-<Source dark="true" language="haml" code={templateMultiColumn.raw} />
+<Source dark="true" language="haml" code={templateMultiColumn} />
 
 ## Responsive grids
 
@@ -61,11 +61,11 @@ The following example has a column which is 10 columns at large breakpoints, 8 a
     name="Responsive grid columns"
     parameters={{
       layout: 'fullscreen',
-      docs: { source: { code: templateResponsive.raw } },
+      docs: { source: { code: templateResponsive } },
     }}
   >
     {() => templateResponsive}
   </Story>
 </Canvas>
 
-<Source dark="true" language="haml" code={templateResponsive.raw} />
+<Source dark="true" language="haml" code={templateResponsive} />

--- a/styleguide/foundations/grid/multi-column-grid.html
+++ b/styleguide/foundations/grid/multi-column-grid.html
@@ -1,0 +1,10 @@
+<div class="cads-grid-container">
+  <div class="cads-grid-row">
+    <div class="cads-grid-col-8">
+      <div class="cads-styleguide-grid-example">8 columns</div>
+    </div>
+    <div class="cads-grid-col-4">
+      <div class="cads-styleguide-grid-example">4 columns</div>
+    </div>
+  </div>
+</div>

--- a/styleguide/foundations/grid/responsive-grid.html
+++ b/styleguide/foundations/grid/responsive-grid.html
@@ -1,0 +1,7 @@
+<div class="cads-grid-container">
+  <div class="cads-grid-row">
+    <div class="cads-grid-col-md-8 cads-grid-col-lg-10">
+      <div class="cads-styleguide-grid-example">I vary based on breakpoint</div>
+    </div>
+  </div>
+</div>

--- a/styleguide/foundations/typography/_ordered-list.html.haml
+++ b/styleguide/foundations/typography/_ordered-list.html.haml
@@ -1,7 +1,0 @@
-%ol.my-ordered-list
-  %li Lorem ipsum dolor sit amet, consectetuer adipiscing elit.
-  %li
-    Aliquam
-    %a{href: '#'}
-      auctor dapibus neque
-  %li Vestibulum auctor dapibus neque.

--- a/styleguide/foundations/typography/_plain-list.html.haml
+++ b/styleguide/foundations/typography/_plain-list.html.haml
@@ -1,7 +1,0 @@
-%ul.my-plain-list
-  %li Lorem ipsum dolor sit amet, consectetuer adipiscing elit.
-  %li
-    Aliquam
-    %a{href: '#'}
-      auctor dapibus neque
-  %li Vestibulum auctor dapibus neque.

--- a/styleguide/foundations/typography/_unordered-list.html.haml
+++ b/styleguide/foundations/typography/_unordered-list.html.haml
@@ -1,7 +1,0 @@
-%ul.my-unordered-list
-  %li Lorem ipsum dolor sit amet, consectetuer adipiscing elit.
-  %li
-    Aliquam
-    %a{href: '#'}
-      auctor dapibus neque
-  %li Vestibulum auctor dapibus neque.

--- a/styleguide/foundations/typography/ordered-list.html
+++ b/styleguide/foundations/typography/ordered-list.html
@@ -1,0 +1,8 @@
+<ol class="my-ordered-list">
+  <li>Lorem ipsum dolor sit amet, consectetuer adipiscing elit.</li>
+  <li>
+    Aliquam
+    <a href="#"> auctor dapibus neque </a>
+  </li>
+  <li>Vestibulum auctor dapibus neque.</li>
+</ol>

--- a/styleguide/foundations/typography/plain-list.html
+++ b/styleguide/foundations/typography/plain-list.html
@@ -1,0 +1,8 @@
+<ul class="my-plain-list">
+  <li>Lorem ipsum dolor sit amet, consectetuer adipiscing elit.</li>
+  <li>
+    Aliquam
+    <a href="#"> auctor dapibus neque </a>
+  </li>
+  <li>Vestibulum auctor dapibus neque.</li>
+</ul>

--- a/styleguide/foundations/typography/typography.stories.mdx
+++ b/styleguide/foundations/typography/typography.stories.mdx
@@ -1,9 +1,9 @@
 import { Meta, Preview, Story } from '@storybook/addon-docs/blocks';
+import noBulletHtml from './plain-list.html';
+import olHtml from './ordered-list.html';
+import ulHtml from './unordered-list.html';
 
-<Meta
-  title="Foundations/Typography"
-  decorators={[(Story) => `<div>${Story()}</div>`]}
-/>
+<Meta title="Foundations/Typography" />
 
 # Typography
 
@@ -202,8 +202,6 @@ export const externalLinkHTML = `
 
 Unordered lists should be used to show collections of items where their order does not have meaning, for example the criteria for claiming a particular benefit.
 
-import ulHtml from './_unordered-list.html.haml';
-
 <Preview>
   <Story
     name="Unordered List"
@@ -226,8 +224,6 @@ You can extend the following placeholder to achieve the correct unordered list s
 #### Plain
 
 In some situations, you will want the styles of an unordered list without the bullet points - for example to present a list of links on a summary page.
-
-import noBulletHtml from './_plain-list.html.haml';
 
 <Preview>
   <Story
@@ -252,8 +248,6 @@ You can extend the following placeholder to achieve the correct plain list styli
 ### Ordered lists
 
 Ordered lists should be used to show collections of items where the order does have meaning, for example the steps in a process.
-
-import olHtml from './_ordered-list.html.haml';
 
 <Preview>
   <Story

--- a/styleguide/foundations/typography/unordered-list.html
+++ b/styleguide/foundations/typography/unordered-list.html
@@ -1,0 +1,8 @@
+<ul class="my-unordered-list">
+  <li>Lorem ipsum dolor sit amet, consectetuer adipiscing elit.</li>
+  <li>
+    Aliquam
+    <a href="#"> auctor dapibus neque </a>
+  </li>
+  <li>Vestibulum auctor dapibus neque.</li>
+</ul>


### PR DESCRIPTION
One more little PR from Friday afternoon…

There's no specific haml template or component associated with these as they are foundations so you are expected to use the classes directly.

To get us one step closer to removing the haml loader from storybook lets convert the grid and typography haml templates to plain HTML.