### PR TITLE
Rubocop actions reporter

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -41,7 +41,9 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
-      - run: bundle exec rake ruby:lint
+      - run: bundle exec rubocop --format github
+      - run: bundle exec haml-lint
+      - run: bundle exec i18n-tasks health
 
   engine:
     runs-on: ubuntu-20.04

--- a/Rakefile
+++ b/Rakefile
@@ -57,7 +57,7 @@ namespace :ruby do
   desc "Haml Linting"
   task :haml_lint do
     puts "Running haml-lint"
-    system("bundle exec haml-lint haml styleguide") || raise
+    system("bundle exec haml-lint") || raise
   end
 
   desc "i18n-tasks health"

--- a/engine/previews/citizens_advice_components/callout_preview/variable_heading_levels.html.haml
+++ b/engine/previews/citizens_advice_components/callout_preview/variable_heading_levels.html.haml
@@ -16,4 +16,4 @@
       %p Monday to Friday, 8am to 5pm
       %p Saturday, 8am to 4pm
       %p
-        %a{ href: 'http://example.com' } Link to the website
+        %a{ href: "http://example.com" } Link to the website

--- a/engine/previews/citizens_advice_components/contact_details_preview/example.html.haml
+++ b/engine/previews/citizens_advice_components/contact_details_preview/example.html.haml
@@ -5,4 +5,4 @@
   %p Monday to Friday, 8am to 5pm
   %p Saturday, 8am to 4pm
   %p
-    %a{ href: 'http://example.com' } Link to the website
+    %a{ href: "http://example.com" } Link to the website


### PR DESCRIPTION
Runs lint tasks as separate run steps in actions and uses the provided github formatter for rubocop to give us inline annotations.