### PR TITLE
Search component

### DIFF
--- a/engine/app/components/citizens_advice_components/search.html.haml
+++ b/engine/app/components/citizens_advice_components/search.html.haml
@@ -1,7 +1,7 @@
 .cads-search
-  %input.cads-search__input.cads-input{ type: "search",
-    name: param_name,
-    "aria-label": t(".input_aria_label"),
-    value: value.presence }
-  %button.cads-search__button{ type: "submit", title: t(".submit_title") }
+  = search_field_tag(param_name,
+    value.presence,
+    class: "cads-search__input cads-input",
+    "aria-label": t(".input_aria_label"))
+  %button.cads-search__button{ type: "submit", title: t(".submit_title"), "data-testid": "search-form-search-button" }
     %span.cads-search__button-label= t(".submit_label")

--- a/engine/app/components/citizens_advice_components/search.html.haml
+++ b/engine/app/components/citizens_advice_components/search.html.haml
@@ -1,0 +1,7 @@
+.cads-search
+  %input.cads-search__input.cads-input{ type: "search",
+    name: param_name,
+    "aria-label": t(".input_aria_label"),
+    value: value.presence }
+  %button.cads-search__button{ type: "submit", title: t(".submit_title") }
+    %span.cads-search__button-label= t(".submit_label")

--- a/engine/app/components/citizens_advice_components/search.rb
+++ b/engine/app/components/citizens_advice_components/search.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module CitizensAdviceComponents
+  class Search < Base
+    attr_reader :value, :param_name
+
+    def initialize(value: nil, param_name: nil)
+      super
+      @value = value
+      @param_name = param_name || :q
+    end
+  end
+end

--- a/engine/config/locales/cy.yml
+++ b/engine/config/locales/cy.yml
@@ -18,6 +18,10 @@ cy:
       next_page_label: Nesaf
       previous_page_aria_label: Ewch i'r dudalen flaenorol
       previous_page_label: Blaenorol
+    search:
+      input_aria_label: Chwiliwch trwy gynnwys y wefan
+      submit_label: Chwilio
+      submit_title: Cyflwyno ymholiad chwilio
     targeted_content:
       close_label: Cau
       descriptive_label_hide: cuddio’r adran hon

--- a/engine/config/locales/en.yml
+++ b/engine/config/locales/en.yml
@@ -18,6 +18,10 @@ en:
       next_page_label: Next
       previous_page_aria_label: Go to previous page
       previous_page_label: Previous
+    search:
+      input_aria_label: Search through site content
+      submit_label: Search
+      submit_title: Submit search query
     targeted_content:
       close_label: Close
       descriptive_label_hide: hide this section

--- a/engine/previews/citizens_advice_components/search_preview.rb
+++ b/engine/previews/citizens_advice_components/search_preview.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module CitizensAdviceComponents
+  class SearchPreview < ViewComponent::Preview
+    def example
+      render(CitizensAdviceComponents::Search.new)
+    end
+
+    def with_value
+      render(CitizensAdviceComponents::Search.new(value: "Current search term"))
+    end
+  end
+end

--- a/engine/spec/components/search_spec.rb
+++ b/engine/spec/components/search_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+RSpec.describe CitizensAdviceComponents::Search, type: :component do
+  subject(:component) do
+    render_inline(CitizensAdviceComponents::Search.new)
+  end
+
+  it "renders search input" do
+    expect(component.at(".cads-search")).to be_present
+    expect(component.at("button").text).to include "Search"
+  end
+
+  it "has no value" do
+    expect(component.at("input[type=search]").attr("value")).to be_nil
+  end
+
+  it "has default param name" do
+    expect(component.at("input[type=search]").attr("name")).to eq "q"
+  end
+
+  context "with value" do
+    subject(:component) do
+      render_inline(CitizensAdviceComponents::Search.new(value: "Example value"))
+    end
+
+    it "has a value" do
+      expect(component.at("input[type=search]").attr("value")).to eq "Example value"
+    end
+  end
+
+  context "with custom param_name" do
+    subject(:component) do
+      render_inline(CitizensAdviceComponents::Search.new(param_name: :query))
+    end
+
+    it "has custom param name" do
+      expect(component.at("input[type=search]").attr("name")).to eq "query"
+    end
+  end
+
+  context "when welsh language" do
+    before { I18n.locale = :cy }
+
+    it "has translated label" do
+      expect(component.at("button").text).to include "Chwilio"
+    end
+  end
+end

--- a/styleguide/components/search/_search-with-value.html.haml
+++ b/styleguide/components/search/_search-with-value.html.haml
@@ -1,1 +1,0 @@
-= render partial: "@citizensadvice/design-system/haml/search", locals: { search: { action_url: "/search/page", input_value: "Current search term" } }

--- a/styleguide/components/search/_search.html.haml
+++ b/styleguide/components/search/_search.html.haml
@@ -1,1 +1,0 @@
-= render partial: "@citizensadvice/design-system/haml/search", locals: { search: { action_url: "/search/page" } }

--- a/styleguide/components/search/search-docs.mdx
+++ b/styleguide/components/search/search-docs.mdx
@@ -12,6 +12,25 @@ import { Story, Preview } from '@storybook/addon-docs/blocks';
   <Story id="components-search--search-with-value" />
 </Preview>
 
+## Using with Rails
+
+If you are using the `citizens_advice_components` gem you call the component from within a template using:
+
+```rb
+= render(CitizensAdviceComponents::Search.new(value: "Current search term"))
+```
+
+Unlike the legacy haml partial the component will only render the input and button, not the surrounding from to give you more control over how the field is used.
+
+### Component arguments
+
+The component accepts the following arguments:
+
+| Argument     | Description                                         |
+| ------------ | --------------------------------------------------- |
+| `value`      | Optional, current value                             |
+| `param_name` | Optional. Pagination param name, defaults to `page` |
+
 ## Haml template options
 
 The Haml partial takes a `search` hash with the following properties:

--- a/styleguide/components/search/search-docs.mdx
+++ b/styleguide/components/search/search-docs.mdx
@@ -17,10 +17,11 @@ import { Story, Preview } from '@storybook/addon-docs/blocks';
 If you are using the `citizens_advice_components` gem you call the component from within a template using:
 
 ```rb
-= render(CitizensAdviceComponents::Search.new(value: "Current search term"))
+= form_tag("/search", method: "get", role: "search") do
+  = render(CitizensAdviceComponents::Search.new(value: "Current search term"))
 ```
 
-Unlike the legacy haml partial the component will only render the input and button, not the surrounding from to give you more control over how the field is used.
+**Note:** Unlike the legacy haml partial you'll have to render your own form when using this component. The component will only render the input and button to give you more control over how the field is used.
 
 ### Component arguments
 

--- a/styleguide/components/search/search.stories.js
+++ b/styleguide/components/search/search.stories.js
@@ -1,7 +1,6 @@
-import { translate } from '../../story-helpers';
 import docs from './search-docs.mdx';
-import templateDefault from './_search.html.haml';
-import templateWithValue from './_search-with-value.html.haml';
+import templateDefault from '../../examples/search/example.html';
+import templateWithValue from '../../examples/search/with_value.html';
 
 export default {
   title: 'Components/Search',
@@ -9,13 +8,12 @@ export default {
   decorators: [(Story) => `<div style="max-width: 800px">${Story()}</div>`],
 };
 
-export const Search = (_, options) => translate(templateDefault, options);
-templateDefault.parameters = {
-  docs: { source: { code: templateDefault.toString() } },
+export const Search = () => templateDefault;
+Search.parameters = {
+  docs: { source: { code: templateDefault } },
 };
 
-export const SearchWithValue = (_, options) =>
-  translate(templateWithValue, options);
+export const SearchWithValue = () => templateWithValue;
 SearchWithValue.parameters = {
-  docs: { source: { code: templateWithValue.toString() } },
+  docs: { source: { code: templateWithValue } },
 };

--- a/styleguide/examples/search/example.html
+++ b/styleguide/examples/search/example.html
@@ -1,0 +1,6 @@
+<div class="cads-search">
+  <input aria-label="Search through site content" class="cads-search__input cads-input" name="q" type="search">
+  <button class="cads-search__button" title="Submit search query" type="submit">
+    <span class="cads-search__button-label">Search</span>
+  </button>
+</div>

--- a/styleguide/examples/search/with_value.html
+++ b/styleguide/examples/search/with_value.html
@@ -1,0 +1,6 @@
+<div class="cads-search">
+  <input aria-label="Search through site content" class="cads-search__input cads-input" name="q" type="search" value="Current search term">
+  <button class="cads-search__button" title="Submit search query" type="submit">
+    <span class="cads-search__button-label">Search</span>
+  </button>
+</div>

--- a/testing/features/components/header.feature
+++ b/testing/features/components/header.feature
@@ -14,11 +14,11 @@ Feature: Header component
 
   Rule: A Standard Header (Screen size agnostic)
     Scenario: English Header has a search option
-      Then I am able to search in English
+      Then I am able to search
 
     Scenario: Welsh Header has a search option
       Given the language is Welsh
-      Then I am able to search in Welsh
+      Then I am able to search
 
   Rule: A Standard Header (Large Screen)
     @not_mobile

--- a/testing/features/components/search.feature
+++ b/testing/features/components/search.feature
@@ -1,31 +1,13 @@
 @failing @NP-1803
 Feature: Search components
-
-  The Search component allows users to search for the desired term and consists
-  of a search field and a button
-
   Rule: Standard Search
-    Background:
+    Scenario: Search component is on the page without any term
       Given a Standard Search component is on the page
-
-    Scenario: English Search component is on the page without any term
       Then the search field is clear
-      And I am able to search in English
-
-    Scenario: Welsh Search component is on the page without any term
-      Given the language is Welsh
-      Then the search field is clear
-      And I am able to search in Welsh
+      And I am able to search
 
   Rule: Search with Value
-    Background:
+    Scenario: Search component is on the page with a pre-defined term
       Given a Search With Value component is on the page
-
-    Scenario: English Search component is on the page with a pre-defined term
       Then the search field has a pre-defined term
-      And I am able to search in English
-
-    Scenario: Welsh Search component is on the page with a pre-defined term
-      Given the language is Welsh
-      Then the search field has a pre-defined term
-      And I am able to search in Welsh
+      And I am able to search

--- a/testing/features/components/step_definitions/common_steps.rb
+++ b/testing/features/components/step_definitions/common_steps.rb
@@ -28,7 +28,7 @@ Then("a logo is present") do
   expect(@component.logo["href"]).not_to be_blank
 end
 
-Then("I am able to search in English/Welsh") do
+Then("I am able to search") do
   @component.search_for("Anything")
 
   expect(@component.search_field.value).to eq("Anything")


### PR DESCRIPTION
Adds component version of the search field.

The main change here is to treat this like the other form inputs. Rather than including the whole form element I've limited this to the field itself.

**TODO:**

- [x] Add component and template
- [x] Rspec tests
- [x] Previews
- [x] Update documentation
- [x] Remove welsh language from functional tests