### PR TITLE
Page review component

### DIFF
--- a/demo/Gemfile.lock
+++ b/demo/Gemfile.lock
@@ -4,6 +4,7 @@ PATH
     citizens_advice_components (0.1.0)
       haml-rails (>= 2.0.0, < 3.0)
       rails (>= 6.0.0, < 7.0)
+      rails-i18n (>= 6.0.0, < 7.0)
       view_component (>= 2.0.0, < 3.0)
 
 GEM
@@ -144,6 +145,9 @@ GEM
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.3.0)
       loofah (~> 2.3)
+    rails-i18n (6.0.0)
+      i18n (>= 0.7, < 2)
+      railties (>= 6.0.0, < 7)
     railties (6.1.3.2)
       actionpack (= 6.1.3.2)
       activesupport (= 6.1.3.2)
@@ -174,7 +178,7 @@ GEM
     tilt (2.0.10)
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
-    view_component (2.32.0)
+    view_component (2.34.0)
       activesupport (>= 5.0.0, < 7.0)
     web-console (4.1.0)
       actionview (>= 6.0.0)

--- a/engine/Gemfile.lock
+++ b/engine/Gemfile.lock
@@ -4,6 +4,7 @@ PATH
     citizens_advice_components (0.1.0)
       haml-rails (>= 2.0.0, < 3.0)
       rails (>= 6.0.0, < 7.0)
+      rails-i18n (>= 6.0.0, < 7.0)
       view_component (>= 2.0.0, < 3.0)
 
 GEM

--- a/engine/app/components/citizens_advice_components/page_review.rb
+++ b/engine/app/components/citizens_advice_components/page_review.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module CitizensAdviceComponents
+  class PageReview < Base
+    def initialize(page_review_date:, date_format: nil)
+      super
+      @date_format = date_format || "%d %B %Y"
+      @page_review_date = page_review_date
+    end
+
+    def call
+      content_tag(
+        :p,
+        t("citizens_advice_components.page_review.body_html", date: formatted_date),
+        class: "cads-page-review"
+      )
+    end
+
+    def formatted_date
+      I18n.l(@page_review_date, format: @date_format)
+    end
+
+    def render?
+      @page_review_date.present?
+    end
+  end
+end

--- a/engine/citizens_advice_components.gemspec
+++ b/engine/citizens_advice_components.gemspec
@@ -25,5 +25,6 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency     "haml-rails", [">= 2.0.0", "< 3.0"]
   spec.add_runtime_dependency     "rails", [">= 6.0.0", "< 7.0"]
+  spec.add_runtime_dependency     "rails-i18n", [">= 6.0.0", "< 7.0"]
   spec.add_runtime_dependency     "view_component", [">= 2.0.0", "< 3.0"]
 end

--- a/engine/config/locales/cy.yml
+++ b/engine/config/locales/cy.yml
@@ -7,6 +7,8 @@ cy:
       important: Pwysig
     input:
       optional: dewisol
+    page_review:
+      body_html: Adolygwyd y dudalen ar <strong>%{date}</strong>
     pagination:
       aria_label: Llywio tudalen
       first_page_aria_label: Ewch i'r dudalen gyntaf

--- a/engine/config/locales/en.yml
+++ b/engine/config/locales/en.yml
@@ -7,6 +7,8 @@ en:
       important: Important
     input:
       optional: optional
+    page_review:
+      body_html: Page last reviewed on <strong>%{date}</strong>
     pagination:
       aria_label: Pagination navigation
       first_page_aria_label: Go to first page

--- a/engine/lib/citizens_advice_components/engine.rb
+++ b/engine/lib/citizens_advice_components/engine.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "haml-rails"
+require "rails-i18n"
 require "active_support/core_ext"
 require "view_component/engine"
 

--- a/engine/previews/citizens_advice_components/page_review_preview.rb
+++ b/engine/previews/citizens_advice_components/page_review_preview.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module CitizensAdviceComponents
+  class PageReviewPreview < ViewComponent::Preview
+    def example
+      render(
+        CitizensAdviceComponents::PageReview.new(
+          page_review_date: Date.new(2020, 9, 21)
+        )
+      )
+    end
+  end
+end

--- a/engine/spec/components/page_review_spec.rb
+++ b/engine/spec/components/page_review_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+RSpec.describe CitizensAdviceComponents::PageReview, type: :component do
+  subject(:component) do
+    render_inline(
+      CitizensAdviceComponents::PageReview.new(
+        page_review_date: page_review_date.presence,
+        date_format: date_format.presence
+      )
+    )
+  end
+
+  let(:page_review_date) { Date.new(2021, 6, 12) }
+  let(:date_format) { nil }
+
+  it "renders a formatted date" do
+    expect(component.text.strip).to eq "Page last reviewed on 12 June 2021"
+  end
+
+  context "when no date" do
+    let(:page_review_date) { nil }
+
+    it "does not render" do
+      expect(component.at(".cads-page-review")).to_not be_present
+    end
+  end
+
+  context "when custom date format" do
+    let(:date_format) { :short }
+
+    it "renders date with custom format" do
+      expect(component.text.strip).to eq "Page last reviewed on Jun 12"
+    end
+  end
+
+  context "when welsh language" do
+    before { I18n.locale = :cy }
+
+    it "has translated date" do
+      expect(component.text.strip).to eq "Adolygwyd y dudalen ar 12 Mehefin 2021"
+    end
+  end
+end

--- a/styleguide/components/page-review/_example.html.haml
+++ b/styleguide/components/page-review/_example.html.haml
@@ -1,1 +1,0 @@
-= render partial: "@citizensadvice/page_review", locals: { page_review_date: '21 September 2020' }

--- a/styleguide/components/page-review/page-review.stories.mdx
+++ b/styleguide/components/page-review/page-review.stories.mdx
@@ -1,20 +1,32 @@
 import { Meta, Story, Preview, Source } from '@storybook/addon-docs/blocks';
-import { translate } from '../../story-helpers';
+import template from '../../examples/page_review/example.html';
 
 <Meta title="Components/Page review" />
 
 # Page review
 
-import template from './_example.html.haml';
-
 <Preview>
-  <Story
-    name="Example"
-    parameters={{ docs: { source: { code: template.raw } } }}
-  >
-    {(_, options) => translate(template, options)}
+  <Story name="Example" parameters={{ docs: { source: { code: template } } }}>
+    {() => template}
   </Story>
 </Preview>
+
+## Using with Rails
+
+If you are using the `citizens_advice_components` gem, you can call the component from within a template using:
+
+```rb
+= render(CitizensAdviceComponents::PageReview.new(page_review_date: Date.new(2020, 9, 21)))
+```
+
+Unlike the legacy haml partial the component accepts a date object rather than a formatted string. This allows us to define a default format. This can be customised by passing a `date_format` option.
+
+### View Component Options
+
+| Property           | Description                                                             |
+| ------------------ | ----------------------------------------------------------------------- |
+| `page_review_date` | Required, date object for last reviewed date                            |
+| `date_format`      | Optional, custom date format passed to `I18n.l`. Defaults to `%d %B %Y` |
 
 ## Haml template options
 

--- a/styleguide/components/page-review/page-review.stories.mdx
+++ b/styleguide/components/page-review/page-review.stories.mdx
@@ -19,7 +19,7 @@ If you are using the `citizens_advice_components` gem, you can call the componen
 = render(CitizensAdviceComponents::PageReview.new(page_review_date: Date.new(2020, 9, 21)))
 ```
 
-Unlike the legacy haml partial the component accepts a date object rather than a formatted string. This allows us to define a default format. This can be customised by passing a `date_format` option.
+Unlike the legacy haml partial the component accepts a date object rather than a formatted string. This allows us to define a default format. This [can be customised](https://guides.rubyonrails.org/i18n.html#adding-date-time-formats) by passing a `date_format` option which is passed to `I18n.l`.
 
 ### View Component Options
 

--- a/styleguide/examples/page_review/example.html
+++ b/styleguide/examples/page_review/example.html
@@ -1,0 +1,1 @@
+<p class="cads-page-review">Page last reviewed on <strong>21 September 2020</strong></p>

--- a/testing/features/components/page_review.feature
+++ b/testing/features/components/page_review.feature
@@ -1,17 +1,9 @@
-Feature: Page Review component
+Feature: Page review component
 
-  The Page Review component reassures the public that the content
+  The page review component reassures the reader that the content
   they are viewing is up to date
 
-  Rule: Example Page Review
-    Background:
-      Given an Example Page Review component is on the page
-
-    Scenario: English Label includes the date
-      Then the date that the page was last reviewed is present
-      And the date is bold
-
-    Scenario: Welsh Label includes the date
-      Given the language is Welsh
-      Then the date that the page was last reviewed is present
-      And the date is bold
+  Scenario: Page last reviewed date
+    Given a page review component is on the page
+    Then the date that the page was last reviewed is present
+    And the date is bold

--- a/testing/features/components/step_definitions/page_review_steps.rb
+++ b/testing/features/components/step_definitions/page_review_steps.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-Given("an Example Page Review component is on the page") do
+Given("a page review component is on the page") do
   @component = PageReview::Example.new.tap(&:load)
 end
 


### PR DESCRIPTION
In a bit of a flow for migrating these, so doing one more whilst I have the time. Migrates the page review component.

**TODO:**

- [x] Add rspec scenarios
- [x] Add component interface
- [x] Confirm approach to passing date (formatted or as date object)
- [x] Add preview
- [x] Document component API
- [x] Update functional tests to remove welsh language scenarios