### PR TITLE
Remove @testing-library/react

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9441,43 +9441,6 @@
         }
       }
     },
-    "@testing-library/react": {
-      "version": "11.2.7",
-      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-11.2.7.tgz",
-      "integrity": "sha512-tzRNp7pzd5QmbtXNG/mhdcl7Awfu/Iz1RaVHY75zTdOkmHCuzMhRL83gWHSgOAcjS3CCbyfwUHMZgRJb4kAfpA==",
-      "dev": true,
-      "requires": {
-        "@babel/runtime": "^7.12.5",
-        "@testing-library/dom": "^7.28.1"
-      },
-      "dependencies": {
-        "@babel/runtime": {
-          "version": "7.14.0",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.14.0.tgz",
-          "integrity": "sha512-JELkvo/DlpNdJ7dlyw/eY7E0suy5i5GQH+Vlxaq1nsNJ+H7f4Vtv3jMeCEgRhZZQFXTjldYfQgv2qmM6M1v5wA==",
-          "dev": true,
-          "requires": {
-            "regenerator-runtime": "^0.13.4"
-          }
-        },
-        "@testing-library/dom": {
-          "version": "7.31.2",
-          "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-7.31.2.tgz",
-          "integrity": "sha512-3UqjCpey6HiTZT92vODYLPxTBWlM8ZOOjr3LX5F37/VRipW2M1kX6I/Cm4VXzteZqfGfagg8yXywpcOgQBlNsQ==",
-          "dev": true,
-          "requires": {
-            "@babel/code-frame": "^7.10.4",
-            "@babel/runtime": "^7.12.5",
-            "@types/aria-query": "^4.2.0",
-            "aria-query": "^4.2.2",
-            "chalk": "^4.1.0",
-            "dom-accessibility-api": "^0.5.6",
-            "lz-string": "^1.4.4",
-            "pretty-format": "^26.6.2"
-          }
-        }
-      }
-    },
     "@testing-library/user-event": {
       "version": "13.1.9",
       "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-13.1.9.tgz",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,6 @@
     "@storybook/html": "^6.2.9",
     "@testing-library/dom": "^8.0.0",
     "@testing-library/jest-dom": "^5.14.1",
-    "@testing-library/react": "^11.2.7",
     "@testing-library/user-event": "^13.1.9",
     "@types/jest": "^26.0.23",
     "@types/jsdom": "^16.2.11",

--- a/src/ts/greedy-nav/GreedyNav.test.ts
+++ b/src/ts/greedy-nav/GreedyNav.test.ts
@@ -4,7 +4,7 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 /* eslint-disable import/no-extraneous-dependencies */
 import '@testing-library/jest-dom';
-import { fireEvent, createEvent } from '@testing-library/react';
+import { fireEvent } from '@testing-library/dom';
 import userEvent from '@testing-library/user-event';
 import { JSDOM } from 'jsdom';
 import path from 'path';


### PR DESCRIPTION
Prompted by https://github.com/citizensadvice/design-system/pull/1292 which pointed out that we are using `@testing-library/react` even though we don't have any react components. Switches to the equivalent method from `@testing-library/dom`.

Closes #1292
