### PR TITLE
Remove language switcher from Storybook

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -26,31 +26,3 @@ export const parameters = {
     },
   },
 };
-
-export const globalTypes = {
-  locale: {
-    name: 'Locale',
-    description: 'I18n locale',
-    defaultValue: 'en',
-    toolbar: {
-      icon: 'globe',
-      items: [
-        { value: 'en', right: '🏴󠁧󠁢󠁥󠁮󠁧󠁿', title: 'English' },
-        { value: 'cy', right: '🏴󠁧󠁢󠁷󠁬󠁳󠁿', title: 'Cymraeg' },
-      ],
-    },
-  },
-};
-
-const setLocaleFromUrl = (Story, context) => {
-  const params = new URL(document.location).searchParams;
-
-  const locale = params.get('locale');
-  if (locale) {
-    context.globals.locale = locale;
-  }
-
-  return Story();
-};
-
-export const decorators = [setLocaleFromUrl];

--- a/styleguide/story-helpers.js
+++ b/styleguide/story-helpers.js
@@ -3,4 +3,4 @@
  * @param {Object} haml the imported haml object, as produced by the loader
  * @param {*} options the mdx options hash
  */
-module.exports.translate = (haml, options) => haml[options.globals.locale];
+module.exports.translate = (haml) => haml.en;

--- a/testing/features/components/header.feature
+++ b/testing/features/components/header.feature
@@ -13,25 +13,20 @@ Feature: Header component
     Given a Standard Header component is on the page
 
   Rule: A Standard Header (Screen size agnostic)
-    Scenario: Header has a search option
+    Scenario: English Header has a search option
       Then I am able to search
 
   Rule: A Standard Header (Large Screen)
     @not_mobile
-    Scenario: Header has some quick links
+    Scenario: English Header has some quick links
       Then a link to change language is present
       And a login link is present
       And a logo is present
 
     @not_mobile @not_tablet
-    Scenario Outline: Users can quickly navigate to various areas of the page
-      Then I am able to skip to the <area> part of the page labelled "<description>"
-
-      Examples:
-        | area       | description
-        | navigation | Skip to navigation
-        | content    | Skip to content
-        | footer     | Skip to footer
+    Scenario: Users can quickly navigate to various areas of the page
+      Then I am able to tab through skip links
+        | Skip to navigation | Skip to content | Skip to footer |
 
   Rule: A Standard Header (Small Screen)
     @small_screen

--- a/testing/features/components/header.feature
+++ b/testing/features/components/header.feature
@@ -13,40 +13,18 @@ Feature: Header component
     Given a Standard Header component is on the page
 
   Rule: A Standard Header (Screen size agnostic)
-    Scenario: English Header has a search option
-      Then I am able to search
-
-    Scenario: Welsh Header has a search option
-      Given the language is Welsh
+    Scenario: Header has a search option
       Then I am able to search
 
   Rule: A Standard Header (Large Screen)
     @not_mobile
-    Scenario: English Header has some quick links
-      Then a link to change language is present
-      And a login link is present
-      And a logo is present
-
-    @not_mobile
-    Scenario: Welsh Header has some quick links
-      Given the language is Welsh
+    Scenario: Header has some quick links
       Then a link to change language is present
       And a login link is present
       And a logo is present
 
     @not_mobile @not_tablet
-    Scenario Outline: English Users can quickly navigate to various areas of the page
-      Then I am able to skip to the <area> part of the page
-
-      Examples:
-        | area       |
-        | navigation |
-        | content    |
-        | footer     |
-
-    @not_mobile @not_tablet
-    Scenario Outline: Welsh Users can quickly navigate to various areas of the page
-      Given the language is Welsh
+    Scenario Outline: Users can quickly navigate to various areas of the page
       Then I am able to skip to the <area> part of the page
 
       Examples:
@@ -57,12 +35,6 @@ Feature: Header component
 
   Rule: A Standard Header (Small Screen)
     @small_screen
-    Scenario: English Header can be expanded to show the full search bar
-      Then I can expand the search bar
-      And I can collapse the search bar
-
-    @small_screen
-    Scenario: Welsh Header can be expanded to show the full search bar
-      Given the language is Welsh
+    Scenario: Header can be expanded to show the full search bar
       Then I can expand the search bar
       And I can collapse the search bar

--- a/testing/features/components/header.feature
+++ b/testing/features/components/header.feature
@@ -25,13 +25,13 @@ Feature: Header component
 
     @not_mobile @not_tablet
     Scenario Outline: Users can quickly navigate to various areas of the page
-      Then I am able to skip to the <area> part of the page
+      Then I am able to skip to the <area> part of the page labelled "<description>"
 
       Examples:
-        | area       |
-        | navigation |
-        | content    |
-        | footer     |
+        | area       | description
+        | navigation | Skip to navigation
+        | content    | Skip to content
+        | footer     | Skip to footer
 
   Rule: A Standard Header (Small Screen)
     @small_screen

--- a/testing/features/components/step_definitions/common_steps.rb
+++ b/testing/features/components/step_definitions/common_steps.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
-When("I am able to skip to the {skip-link-area} part of the page labelled {string}") do |area, description|
-  @component.tab_to(area)
-
-  expect(@component.active_element.text).to eq(description)
+When("I am able to skip to the {skip-link-area} part of the page labelled {string}") do |table|
+  data = table.rows_hash
+  @component.tab_to(data[:area])
+  expect(@component.active_element.text).to eq(data[:description])
 end
 
 Then("a logo is present") do

--- a/testing/features/components/step_definitions/common_steps.rb
+++ b/testing/features/components/step_definitions/common_steps.rb
@@ -1,13 +1,13 @@
 # frozen_string_literal: true
 
-When("I am able to skip to the {skip-link-area} part of the page") do |area|
+When("I am able to skip to the {skip-link-area} part of the page labelled {string}" ) do |area, description|
   @component.tab_to(area)
 
-  expect(@component.active_element.text).to eq(I18n.t("cads.header.skip_to_#{area}"))
+  expect(@component.active_element.text).to eq(description)
 end
 
 Then("a logo is present") do
-  expect(@component.logo["title"]).to eq(I18n.t("cads.shared.logo_title"))
+  expect(@component.logo["title"]).to eq("Citizens Advice homepage")
 
   expect(@component.logo["href"]).not_to be_blank
 end
@@ -17,15 +17,15 @@ Then("I am able to search") do
 
   expect(@component.search_field.value).to eq("Anything")
 
-  expect(@component.search_field["aria-label"]).to eq(I18n.t("cads.search.input_aria_label"))
+  expect(@component.search_field["aria-label"]).to eq("Search through site content")
 
-  expect(@component.search_button.text).to eq(I18n.t("cads.search.submit_label"))
+  expect(@component.search_button.text).to eq("Search")
 
-  expect(@component.search_button["title"]).to eq(I18n.t("cads.search.submit_title"))
+  expect(@component.search_button["title"]).to eq("Submit search query")
 end
 
 Then("I can expand the search bar") do
-  expect(@component.open_search_pane["title"]).to eq(I18n.t("cads.header.open_search"))
+  expect(@component.open_search_pane["title"]).to eq("Open search")
 
   @component.open_search_pane.click
 
@@ -33,7 +33,7 @@ Then("I can expand the search bar") do
 end
 
 Then("I can collapse the search bar") do
-  expect(@component.open_search_pane["title"]).to eq(I18n.t("cads.header.close_search"))
+  expect(@component.open_search_pane["title"]).to eq("Close search")
 
   @component.open_search_pane.click
 

--- a/testing/features/components/step_definitions/common_steps.rb
+++ b/testing/features/components/step_definitions/common_steps.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-When("I am able to skip to the {skip-link-area} part of the page labelled {string}" ) do |area, description|
+When("I am able to skip to the {skip-link-area} part of the page labelled {string}") do |area, description|
   @component.tab_to(area)
 
   expect(@component.active_element.text).to eq(description)

--- a/testing/features/components/step_definitions/common_steps.rb
+++ b/testing/features/components/step_definitions/common_steps.rb
@@ -1,21 +1,5 @@
 # frozen_string_literal: true
 
-Given("the language is Welsh") do
-  if @component
-    @component.switch_language(:cy)
-  else
-    @form.switch_language(:cy)
-  end
-end
-
-Given("the language is English") do
-  if @component
-    @component.switch_language(:en)
-  else
-    @form.switch_language(:en)
-  end
-end
-
 When("I am able to skip to the {skip-link-area} part of the page") do |area|
   @component.tab_to(area)
 

--- a/testing/features/components/step_definitions/common_steps.rb
+++ b/testing/features/components/step_definitions/common_steps.rb
@@ -1,9 +1,10 @@
 # frozen_string_literal: true
 
-When("I am able to skip to the {skip-link-area} part of the page labelled {string}") do |table|
-  data = table.rows_hash
-  @component.tab_to(data[:area])
-  expect(@component.active_element.text).to eq(data[:description])
+When("I am able to tab through skip links") do |table|
+  table.raw.first.each do |description|
+    send_tabs(1)
+    expect(@component.active_element.text).to eq(description)
+  end
 end
 
 Then("a logo is present") do

--- a/testing/features/components/step_definitions/page_review_steps.rb
+++ b/testing/features/components/step_definitions/page_review_steps.rb
@@ -5,7 +5,7 @@ Given("a page review component is on the page") do
 end
 
 Then("the date that the page was last reviewed is present") do
-  expect(@component.reviewed_on.text).to start_with(@component.localised_reviewed_on_prefix)
+  expect(@component.reviewed_on.text).to start_with("Page last reviewed on")
 end
 
 Then("the date is bold") do

--- a/testing/features/support/all.rb
+++ b/testing/features/support/all.rb
@@ -5,7 +5,6 @@ require "capybara/dsl"
 require "capybara/cucumber"
 require "faraday"
 require "forwardable"
-require "i18n"
 require "logger"
 require "retriable"
 require "rspec"
@@ -17,5 +16,3 @@ require "webdrivers"
 # Patches need to be required last after everything else defined
 require "active_support/core_ext/object/blank"
 require "ca_testing"
-
-I18n.load_path += Dir["../locales/*.yml"]

--- a/testing/features/support/components/base.rb
+++ b/testing/features/support/components/base.rb
@@ -8,13 +8,6 @@ class Base < SitePrism::Page
     [validate_initial_state!, "Initial #{self.class} component didn't load correctly!"]
   end
 
-  def switch_language(language)
-    return if I18n.locale == language
-
-    visit(page.current_url + "&locale=#{language}")
-    I18n.locale = language
-  end
-
   def validate_initial_state!
     has_root?(wait: 5) && !text.empty?
   end

--- a/testing/features/support/components/header/standard.rb
+++ b/testing/features/support/components/header/standard.rb
@@ -18,9 +18,5 @@ module Header
       open_search_pane(wait: 1).click if iphone?
       search_field.send_keys(search_term)
     end
-
-    def tab_to(desired_area)
-      send_tabs(tab_quantity_for_skip_link(desired_area))
-    end
   end
 end

--- a/testing/features/support/components/page_review/example.rb
+++ b/testing/features/support/components/page_review/example.rb
@@ -6,9 +6,5 @@ module PageReview
 
     element :reviewed_on, ".cads-page-review"
     element :bold_date, "strong"
-
-    def localised_reviewed_on_prefix
-      I18n.t("cads.page_review.body_html").split("<strong>").first
-    end
   end
 end

--- a/testing/features/support/helpers/page.rb
+++ b/testing/features/support/helpers/page.rb
@@ -36,15 +36,6 @@ module Helpers
       end
     end
 
-    def tab_quantity_for_skip_link(desired_area)
-      case desired_area
-      when :navigation; then 1
-      when :content;    then 2
-      when :footer;     then 3
-      else raise "Invalid Input argument for tabbing!"
-      end
-    end
-
     private
 
     def image_file_path(test_case)

--- a/testing/features/support/hooks.rb
+++ b/testing/features/support/hooks.rb
@@ -7,7 +7,6 @@ end
 Before do |test_case|
   CucumberInfo.test_case = test_case
   skip_this_scenario("Scenario is not permitted to run. See logs for details") if CucumberInfo.skip_scenario?
-  I18n.locale = :en
   resize_window unless device?
   resize_window(320) if test_case.source_tag_names.include?("@small_screen") && !device?
   AutomationLogger.info("Running Scenario: #{test_case.name}")

--- a/testing/features/support/parameter_types.rb
+++ b/testing/features/support/parameter_types.rb
@@ -5,9 +5,3 @@ ParameterType(
   regexp: /(Primary|Secondary|Tertiary)/,
   transformer: ->(button) { button.downcase }
 )
-
-ParameterType(
-  name: "skip-link-area",
-  regexp: /(navigation|content|footer)/,
-  transformer: ->(area) { area.to_sym }
-)


### PR DESCRIPTION
**Background**

We're pretty much at the point now where all our welsh language specs are in rspec component tests. I think we should strip the remaining locale code out now to make the last stages of migration simpler.

**Changes**

- Remove any remaining welsh language scenarios from functional tests
- Remove reliance on `I18n` in functional tests
- Remove `switch_language` behaviour
- Remove language switcher from Storybook