### PR TITLE
Success message view component [DS-36]

### DIFF
--- a/engine/app/components/citizens_advice_components/success_message.rb
+++ b/engine/app/components/citizens_advice_components/success_message.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module CitizensAdviceComponents
+  class SuccessMessage < Base
+    attr_reader :message
+
+    def initialize(message:)
+      super
+      @message = message
+    end
+
+    def call
+      content_tag(
+        :p,
+        message,
+        class: "cads-success-message",
+        "aria-live": "polite"
+      )
+    end
+
+    def render?
+      message.present?
+    end
+  end
+end

--- a/engine/previews/citizens_advice_components/success_message_preview.rb
+++ b/engine/previews/citizens_advice_components/success_message_preview.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module CitizensAdviceComponents
+  class SuccessMessagePreview < ViewComponent::Preview
+    def example
+      render CitizensAdviceComponents::SuccessMessage.new(
+        message: "Thank you for your feedback"
+      )
+    end
+  end
+end

--- a/engine/spec/components/success_message_spec.rb
+++ b/engine/spec/components/success_message_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+RSpec.describe CitizensAdviceComponents::SuccessMessage, type: :component do
+  subject(:component) do
+    render_inline(CitizensAdviceComponents::SuccessMessage.new(message: message))
+  end
+
+  let(:message) { "Thank you for your feedback" }
+
+  it "renders message" do
+    expect(component.at(".cads-success-message").text.strip).to include message
+  end
+
+  it "renders aria-live region" do
+    expect(component.at(".cads-success-message").attr("aria-live")).to eq "polite"
+  end
+
+  context "when no message present" do
+    let(:message) { nil }
+
+    it "does not render" do
+      expect(component.at(".cads-success-message")).to_not be_present
+    end
+  end
+end

--- a/engine/spec/components/success_message_spec.rb
+++ b/engine/spec/components/success_message_spec.rb
@@ -2,24 +2,25 @@
 
 RSpec.describe CitizensAdviceComponents::SuccessMessage, type: :component do
   subject(:component) do
-    render_inline(CitizensAdviceComponents::SuccessMessage.new(message: message))
+    rendered = render_inline(CitizensAdviceComponents::SuccessMessage.new(message: message))
+    rendered.at(".cads-success-message")
   end
 
   let(:message) { "Thank you for your feedback" }
 
   it "renders message" do
-    expect(component.at(".cads-success-message").text.strip).to include message
+    expect(component.text.strip).to include message
   end
 
   it "renders aria-live region" do
-    expect(component.at(".cads-success-message").attr("aria-live")).to eq "polite"
+    expect(component.attr("aria-live")).to eq "polite"
   end
 
   context "when no message present" do
     let(:message) { nil }
 
     it "does not render" do
-      expect(component.at(".cads-success-message")).to_not be_present
+      expect(component).to_not be_present
     end
   end
 end

--- a/styleguide/examples/success_message/example.html
+++ b/styleguide/examples/success_message/example.html
@@ -1,0 +1,1 @@
+<p class="cads-success-message" aria-live="polite">Thank you for your feedback</p>

--- a/styleguide/forms/success-message/_example.html.haml
+++ b/styleguide/forms/success-message/_example.html.haml
@@ -1,2 +1,0 @@
-= render partial: "@citizensadvice/design-system/haml/success_message",
-  locals: { success_message: "Thank you for your feedback" }

--- a/styleguide/forms/success-message/success-message.stories.mdx
+++ b/styleguide/forms/success-message/success-message.stories.mdx
@@ -1,20 +1,32 @@
-import { Meta, Story, Preview } from '@storybook/addon-docs/blocks';
-import { translate } from '../../story-helpers';
+import { Meta, Story, Canvas } from '@storybook/addon-docs/blocks';
+import templateExample from '../../examples/success_message/example.html';
 
 <Meta title="Forms/Success message" />
 
 # Error summary
 
-import templateExample from './_example.html.haml';
-
-<Preview>
+<Canvas>
   <Story
     name="Example"
-    parameters={{ docs: { source: { code: templateExample.raw } } }}
+    parameters={{ docs: { source: { code: templateExample } } }}
   >
-    {(_, options) => translate(templateExample, options)}
+    {() => templateExample}
   </Story>
-</Preview>
+</Canvas>
+
+## Using with Rails
+
+If you are using the `citizens_advice_components` gem, you can call the component from within a template using:
+
+```rb
+render(CitizensAdviceComponents::SuccessMessage.new(message: "Thank you for your feedback"))
+```
+
+### View Component Options
+
+| Property          | Description              |
+| ----------------- | ------------------------ |
+| `success_message` | Required. Message string |
 
 ## Haml template options
 


### PR DESCRIPTION
## Background

https://citizensadvice.atlassian.net/browse/DS-36

This is the penultimate component to be migrated before we've done all of them. Only https://github.com/citizensadvice/design-system/pull/1267 remaining.

## Changes

Fairly simple component. No template needed.

**TODO:**

- [x] View component created 
- [x] Rspec tests added 
- [x] Component previews created, matching the stories in the storybook docs
- [x] Documentation added 
- [x] Old haml example removed