### PR TITLE
Test engine against multiple Ruby + Rails versions [DS-37] [DS-38]

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -44,30 +44,6 @@ jobs:
       - run: bundle exec rubocop --format github
       - run: bundle exec haml-lint
 
-  engine:
-    runs-on: ubuntu-20.04
-    defaults:
-      run:
-        working-directory: engine
-    strategy:
-      fail-fast: false
-      matrix:
-        rails_version: ['6.1', 'main']
-        ruby_version: ['2.7', '3.0']
-    steps:
-      - uses: actions/checkout@v2
-      - uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: ${{ matrix.ruby_version }}
-          working-directory: engine
-      - run: |
-          bundle config path vendor/bundle
-          bundle update
-          bundle install --jobs 4 --retry 3
-          bundle exec rake spec
-        env:
-          RAILS_VERSION: ${{ matrix.rails_version }}
-
   # Actions can run in parallel at the job or the workflow level.
   # In order to run our build-dependent tests in parallel we need a way
   # to build the docs and then "seed" each stage with a copy.
@@ -85,7 +61,7 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
-      - run: npm run build --if-present
+      - run: npm run build
       - run: npm run docs:build
       - uses: actions/upload-artifact@v2
         with:
@@ -174,8 +150,32 @@ jobs:
           path: testing/artifacts
           retention-days: 3
 
+  engine:
+    runs-on: ubuntu-20.04
+    defaults:
+      run:
+        working-directory: engine
+    strategy:
+      fail-fast: false
+      matrix:
+        rails_version: ['6.1', 'main']
+        ruby_version: ['2.7', '3.0']
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby_version }}
+          working-directory: engine
+      - run: |
+          bundle config path vendor/bundle
+          bundle update
+          bundle install --jobs 4 --retry 3
+          bundle exec rake spec
+        env:
+          RAILS_VERSION: ${{ matrix.rails_version }}
+
   demo-app:
-    needs: build
+    needs: [build, engine]
     runs-on: ubuntu-20.04
     defaults:
       run:

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -49,11 +49,15 @@ jobs:
     defaults:
       run:
         working-directory: engine
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby_version: ['2.7', '3.0']
     steps:
       - uses: actions/checkout@v2
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: ${{ env.RUBY_VERSION }}
+          ruby-version: ${{ matrix.ruby_version }}
           working-directory: engine
       - run: |
           bundle config path vendor/bundle

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -175,16 +175,21 @@ jobs:
           RAILS_VERSION: ${{ matrix.rails_version }}
 
   demo-app:
-    needs: [build, engine]
+    needs: engine
     runs-on: ubuntu-20.04
-    defaults:
-      run:
-        working-directory: demo
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/download-artifact@v2
+      - uses: actions/setup-node@v2
         with:
-          name: docs-build
+          node-version: ${{ env.NODE_VERSION }}
+
+      # We link the @citizensadvice/design-system package
+      # from the root but we only build the lib/ directory
+      # when we publish to npm, so we need to build it first.
+      - uses: bahmutov/npm-install@v1
+      - run: npm run build
+
+      # Setup demo app
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ env.RUBY_VERSION }}
@@ -193,10 +198,11 @@ jobs:
           bundle config path vendor/bundle
           bundle update
           bundle install --jobs 4 --retry 3
-      - uses: actions/setup-node@v2
-        with:
-          node-version: '14'
+        working-directory: demo
       - uses: bahmutov/npm-install@v1
         with:
           working-directory: demo
+
+      # Run a webpack build as a smoke test
       - run: ./bin/webpack
+        working-directory: demo

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -52,6 +52,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        rails_version: ['6.1', 'main']
         ruby_version: ['2.7', '3.0']
     steps:
       - uses: actions/checkout@v2
@@ -63,7 +64,9 @@ jobs:
           bundle config path vendor/bundle
           bundle update
           bundle install --jobs 4 --retry 3
-      - run: bundle exec rake spec
+          bundle exec rake spec
+        env:
+          RAILS_VERSION: ${{ matrix.rails_version }}
 
   # Actions can run in parallel at the job or the workflow level.
   # In order to run our build-dependent tests in parallel we need a way

--- a/demo/Gemfile
+++ b/demo/Gemfile
@@ -2,12 +2,14 @@
 
 source "https://rubygems.org"
 
-ruby "2.7.3"
+rails_version = (ENV["RAILS_VERSION"] || "~> 6.1").to_s
+
+# Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
+gem "rails", rails_version == "main" ? { git: "https://github.com/rails/rails", ref: "main" } : rails_version
 
 gem "haml-rails"
 gem "htmlbeautifier", "~> 1.3"
 gem "puma", "~> 5.3"
-gem "rails", "~> 6.1"
 gem "webpacker", "~> 5.0"
 
 gem "citizens_advice_components", path: "../engine"

--- a/demo/Gemfile.lock
+++ b/demo/Gemfile.lock
@@ -213,8 +213,5 @@ DEPENDENCIES
   web-console (>= 3.3.0)
   webpacker (~> 5.0)
 
-RUBY VERSION
-   ruby 2.7.3p183
-
 BUNDLED WITH
    2.1.4

--- a/engine/Gemfile
+++ b/engine/Gemfile
@@ -4,6 +4,11 @@ source "https://rubygems.org"
 
 gemspec
 
+rails_version = (ENV["RAILS_VERSION"] || "~> 6.1").to_s
+
+# Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
+gem "rails", rails_version == "main" ? { git: "https://github.com/rails/rails", ref: "main" } : rails_version
+
 group :development, :test do
   gem "i18n-tasks"
   gem "pry", "~> 0.14.1"

--- a/engine/Gemfile.lock
+++ b/engine/Gemfile.lock
@@ -215,6 +215,7 @@ DEPENDENCIES
   citizens_advice_components!
   i18n-tasks
   pry (~> 0.14.1)
+  rails (~> 6.1)
   rspec
   rspec-rails
   rspec-snapshot (~> 0.1.2)

--- a/engine/app/components/citizens_advice_components/text_input.html.haml
+++ b/engine/app/components/citizens_advice_components/text_input.html.haml
@@ -1,2 +1,2 @@
-= render CitizensAdviceComponents::Input.new(base_input_args) do
+= render CitizensAdviceComponents::Input.new(**base_input_args) do
   %input.cads-input{ input_attributes }

--- a/engine/app/components/citizens_advice_components/text_input.rb
+++ b/engine/app/components/citizens_advice_components/text_input.rb
@@ -12,7 +12,7 @@ module CitizensAdviceComponents
       )
       args[:options]&.merge(width: @width)
       @base_input_args = args
-      super(@base_input_args)
+      super(**@base_input_args)
     end
 
     def allowed_width_values

--- a/engine/app/components/citizens_advice_components/textarea.html.haml
+++ b/engine/app/components/citizens_advice_components/textarea.html.haml
@@ -1,2 +1,2 @@
-= render CitizensAdviceComponents::Input.new(base_input_args) do
+= render CitizensAdviceComponents::Input.new(**base_input_args) do
   %textarea.cads-textarea{ input_attributes }

--- a/engine/app/components/citizens_advice_components/textarea.rb
+++ b/engine/app/components/citizens_advice_components/textarea.rb
@@ -9,7 +9,7 @@ module CitizensAdviceComponents
     def initialize(rows: DEFAULT_ROWS, **args)
       @rows = format_rows(rows)
       @base_input_args = args.merge(type: nil)
-      super(@base_input_args)
+      super(**@base_input_args)
     end
 
     def format_rows(rows)

--- a/engine/spec/components/footer_spec.rb
+++ b/engine/spec/components/footer_spec.rb
@@ -3,9 +3,7 @@
 RSpec.describe CitizensAdviceComponents::Footer, type: :component do
   subject(:component) do
     render_inline(CitizensAdviceComponents::Footer.new(feedback_url: feedback_url)) do |c|
-      columns.each do |column|
-        c.column(column)
-      end
+      c.columns(columns)
     end
   end
 


### PR DESCRIPTION
## Background

Different product teams use different versions of ruby and may upgrade to newer versions of Rails at different cadences. Let's make sure we support more than just Ruby 2.7.3 + Rails 6.1!

## Changes

### Engine changes

- Updates engine and demo gemfiles to support running against a custom version of rails or `main`
- Adds a matrix build to run against Ruby 2.7 and 3.0 + Rails 6.1 and `main`
- Fixes some Ruby 3 compatibility issues

This gives us a 4x matrix build for each ruby + rails combination. Nice!

### Workflow changes

One bit of complexity here is that branch protection required checks rely on the job name. The matrix build generates four different names that would all need to be added to the required checks list. This is a bit unweildy!

Thankfully we can happily move the `demo-app` build to be dependent on the engine matrix and limit the required status checks only to this dependent build. This is conceptually more in line with the separation between the engine and the storybook build. It was a bit misleading to have the `demo-app` dependent on storybook before.

Takes us from this:

![image](https://user-images.githubusercontent.com/123386/124485552-9b9c0300-dda4-11eb-8afe-79c67521dfff.png)

To this:

![image](https://user-images.githubusercontent.com/123386/124485578-a0f94d80-dda4-11eb-9540-d6366238b52a.png)


## Before merging

- [ ] Remove old `engine` job from required status checks. Rely on check for dependent `demo-app` job.