### PR TITLE
Footer: Use :title instead of :label in links

### DIFF
--- a/engine/app/components/citizens_advice_components/footer.html.haml
+++ b/engine/app/components/citizens_advice_components/footer.html.haml
@@ -15,7 +15,7 @@
             %ul.cads-footer__links
               - column.links.each do |link|
                 %li.cads-footer__link
-                  = link_to link[:label], link[:url], class: "cads-footer__hyperlink"
+                  = link_to link[:title], link[:url], class: "cads-footer__hyperlink"
                   - if link[:icon].present?
                     = tag.span(class: "cads-footer__icon cads-icon_#{link[:icon]}")
     .cads-footer__company-info

--- a/engine/previews/citizens_advice_components/footer_preview.rb
+++ b/engine/previews/citizens_advice_components/footer_preview.rb
@@ -9,51 +9,51 @@ module CitizensAdviceComponents
         c.column(
           title: "Advice",
           links: [
-            { url: "/benefits/", label: "Benefits" },
-            { url: "/work/", label: "Work" },
-            { url: "/debt-and-money/", label: "Debt and Money" },
-            { url: "/consumer/", label: "Consumer" },
-            { url: "/family/", label: "Family" },
-            { url: "/housing/", label: "Housing" },
-            { url: "/law-and-courts/", label: "Law and courts" },
-            { url: "/immigration/", label: "Immigration" },
-            { url: "/health/", label: "Health" }
+            { url: "/benefits/", title: "Benefits" },
+            { url: "/work/", title: "Work" },
+            { url: "/debt-and-money/", title: "Debt and Money" },
+            { url: "/consumer/", title: "Consumer" },
+            { url: "/family/", title: "Family" },
+            { url: "/housing/", title: "Housing" },
+            { url: "/law-and-courts/", title: "Law and courts" },
+            { url: "/immigration/", title: "Immigration" },
+            { url: "/health/", title: "Health" }
           ]
         )
         c.column(
           title: "Resources and tools",
           links: [
-            { url: "/about-us/how-citizens-advice-works/products-and-services/adviser-resources/", label: "Advisor resources" },
-            { url: "/about-us/how-we-provide-advice/our-prevention-work/education/", label: "Education resources" },
-            { url: "/resources-and-tools/about-this-site/accessibility/", label: "Accessibility" },
-            { url: "/resources-and-tools/about-this-site/accessibility/", label: "Site search" },
-            { url: "/resources-and-tools/search-navigation-tools/a-to-z-of-advice/", label: "A-Z of advice" }
+            { url: "/about-us/how-citizens-advice-works/products-and-services/adviser-resources/", title: "Advisor resources" },
+            { url: "/about-us/how-we-provide-advice/our-prevention-work/education/", title: "Education resources" },
+            { url: "/resources-and-tools/about-this-site/accessibility/", title: "Accessibility" },
+            { url: "/resources-and-tools/about-this-site/accessibility/", title: "Site search" },
+            { url: "/resources-and-tools/search-navigation-tools/a-to-z-of-advice/", title: "A-Z of advice" }
           ]
         )
         c.column(
           title: "More from us",
           links: [
-            { url: "/about-us/", label: "About us" },
-            { url: "/about-us/how-citizens-advice-works/who-we-are-and-what-we-do/annual-reports/", label: "Annual reports" },
-            { url: "/about-us/contact-us/contact-us/contact-us/", label: "Contact us" },
-            { url: "/about-us/contact-us/contact-us/make-a-complaint-about-us/", label: "Complaints" },
-            { url: "/about-us/how-citizens-advice-works/media/", label: "Media" },
-            { url: "/about-us/policy/", label: "Policy research" },
-            { url: "/about-us/support-us/", label: "Support us" },
-            { url: "/about-us/support-us/volunteering/", label: "Volunteering" },
-            { url: "/about-us/how-citizens-advice-works/job-and-voluntary-opportunities/", label: "Jobs" }
+            { url: "/about-us/", title: "About us" },
+            { url: "/about-us/how-citizens-advice-works/who-we-are-and-what-we-do/annual-reports/", title: "Annual reports" },
+            { url: "/about-us/contact-us/contact-us/contact-us/", title: "Contact us" },
+            { url: "/about-us/contact-us/contact-us/make-a-complaint-about-us/", title: "Complaints" },
+            { url: "/about-us/how-citizens-advice-works/media/", title: "Media" },
+            { url: "/about-us/policy/", title: "Policy research" },
+            { url: "/about-us/support-us/", title: "Support us" },
+            { url: "/about-us/support-us/volunteering/", title: "Volunteering" },
+            { url: "/about-us/how-citizens-advice-works/job-and-voluntary-opportunities/", title: "Jobs" }
           ]
         )
         c.column(
           title: "About Citizens Advice",
           links: [
-            { url: "/about-us/how-we-provide-advice/", label: "How we provide advice" },
-            { url: "/about-us/difference-we-make/", label: "The difference we make" },
-            { url: "/about-us/support-us/", label: "Support us" },
-            { url: "/about-us/how-citizens-advice-works/", label: "How Citizens Advice works" },
-            { url: "/resources-and-tools/about-this-site/disclaimer-and-copyright/", label: "Disclaimer and Copyright" },
-            { url: "/about-us/citizens-advice-privacy-policy/", label: "Privacy and cookies" },
-            { url: "http://example.com", label: "External link", icon: "external-link" }
+            { url: "/about-us/how-we-provide-advice/", title: "How we provide advice" },
+            { url: "/about-us/difference-we-make/", title: "The difference we make" },
+            { url: "/about-us/support-us/", title: "Support us" },
+            { url: "/about-us/how-citizens-advice-works/", title: "How Citizens Advice works" },
+            { url: "/resources-and-tools/about-this-site/disclaimer-and-copyright/", title: "Disclaimer and Copyright" },
+            { url: "/about-us/citizens-advice-privacy-policy/", title: "Privacy and cookies" },
+            { url: "http://example.com", title: "External link", icon: "external-link" }
           ]
         )
       end

--- a/engine/spec/components/footer_spec.rb
+++ b/engine/spec/components/footer_spec.rb
@@ -80,9 +80,9 @@ RSpec.describe CitizensAdviceComponents::Footer, type: :component do
       {
         title: "Example column #{index + 1}",
         links: [
-          { url: "#", label: "Link 1" },
-          { url: "#", label: "Link 2" },
-          { url: "#", label: "Link 3" }
+          { url: "#", title: "Link 1" },
+          { url: "#", title: "Link 2" },
+          { url: "#", title: "Link 3" }
         ]
       }
     end

--- a/styleguide/components/footer/footer-docs.mdx
+++ b/styleguide/components/footer/footer-docs.mdx
@@ -25,33 +25,33 @@ render CitizensAdviceComponents::Footer.new(
   c.column(
     title: "Advice",
     links: [
-      { url: "#", label: "Link 1" },
-      { url: "#", label: "Link 2" },
-      { url: "#", label: "Link 3" }
+      { url: "#", title: "Link 1" },
+      { url: "#", title: "Link 2" },
+      { url: "#", title: "Link 3" }
     ]
   )
   c.column(
     title: "Resources and tools",
     links: [
-      { url: "#", label: "Link 1" },
-      { url: "#", label: "Link 2" },
-      { url: "#", label: "Link 3" }
+      { url: "#", title: "Link 1" },
+      { url: "#", title: "Link 2" },
+      { url: "#", title: "Link 3" }
     ]
   )
   c.column(
     title: "More from us",
     links: [
-      { url: "#", label: "Link 1" },
-      { url: "#", label: "Link 2" },
-      { url: "#", label: "Link 3" }
+      { url: "#", title: "Link 1" },
+      { url: "#", title: "Link 2" },
+      { url: "#", title: "Link 3" }
     ]
   )
   c.column(
     title: "About Citizens Advice",
     links: [
-      { url: "#", label: "Link 1" },
-      { url: "#", label: "Link 2" },
-      { url: "#", label: "Link 3" }
+      { url: "#", title: "Link 1" },
+      { url: "#", title: "Link 2" },
+      { url: "#", title: "Link 3" }
     ]
   )
 end
@@ -93,12 +93,12 @@ Each slot accepts the following named arguments:
 
 The Haml partial the following locals:
 
-| Property        | Description                                                |
-| --------------- | ---------------------------------------------------------- |
-| `root_path`     | Required, root path for the logo home link                 |
-| `feedback_url`  | If present, a link to this feedback form will be displayed |
-| `links`         | Main content for the footer (see links above)              |
-| `links[url]`    | &rarr; Required, url for the link                          |
-| `links[label] ` | &rarr; Required, title for the link                        |
-| `links[icon] `  | &rarr; Optional, display an icon next to the link          |
-| `homepage_url`  | Optional, defaults to `/`                                  |
+| Property         | Description                                                |
+| ---------------- | ---------------------------------------------------------- |
+| `root_path`      | Required, root path for the logo home link                 |
+| `feedback_url`   | If present, a link to this feedback form will be displayed |
+| `links`          | Main content for the footer (see links above)              |
+| `links[:url]`    | &rarr; Required, url for the link                          |
+| `links[:title] ` | &rarr; Required, title for the link                        |
+| `links[:icon] `  | &rarr; Optional, display an icon next to the link          |
+| `homepage_url`   | Optional, defaults to `/`                                  |


### PR DESCRIPTION
Spotted whilst demoing the new components. We use `:title` for the other components that accept lists of links, like navigation and breadcrumbs. Update the new footer component to be consistent.