### PR TITLE
Breadcrumbs render check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 **Bugfixes**
 - `TextInput` and `Textarea` components: allow consumers to specify a value (!)
+- 🥖 Breadcrumbs: Don't render when there is only one item.
 
 ## <sub>v4.2.0</sub>
 

--- a/engine/app/components/citizens_advice_components/breadcrumbs.rb
+++ b/engine/app/components/citizens_advice_components/breadcrumbs.rb
@@ -13,7 +13,7 @@ module CitizensAdviceComponents
     end
 
     def render?
-      @links.present?
+      @links.present? && @links.size > 1
     end
 
     def links

--- a/engine/spec/components/citizens_advice_components/breadcrumbs_spec.rb
+++ b/engine/spec/components/citizens_advice_components/breadcrumbs_spec.rb
@@ -63,6 +63,14 @@ RSpec.describe CitizensAdviceComponents::Breadcrumbs, type: :component do
     end
   end
 
+  context "when there is only one item" do
+    let(:links) { [{ title: "Home", url: "/" }] }
+
+    it "does not render" do
+      expect(component.css(".cads-breadcrumbs")).not_to be_present
+    end
+  end
+
   context "when no type is provided" do
     let(:type) { nil }
 


### PR DESCRIPTION
## Summary of problem

Breadcrumbs render even if there's only one item. We should probably only render if there is more than one.


## Steps to replicate

Provide a single item to the `Breadcrumbs` component, e.g. just a Home link

```rb
render CitizensAdviceComponents::Breadcrumbs.new(links: [{ title: "Home", url: "/" }])
```

## Expected behaviour

We should probably only render the breadcrumb trail if there is more than one item.

## Actual behaviour

It renders a single item. Because it's also the "last" item it renders without a link and on small screens is hidden apart from a border.

## Context

**Single item:**

![image](https://user-images.githubusercontent.com/123386/128850146-dffd56d8-dffb-4d2e-9c97-a90075fe8c48.png)

**Missing on mobile:**

![image](https://user-images.githubusercontent.com/123386/128850290-9ee1ccdd-1912-47c9-8cfc-18021f4ec061.png)

(A bit hard to tell from the screenshot but all that's left is the border)