### PR TITLE
Support dynamic copyright year in footer component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+**New**
+
+- 🥾 Footer: Supports dynamic copyright year
+
+
 ## <sub>v4.3.0-alpha.0</sub>
 
 #### _Aug. 31, 2021_

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -99,6 +99,8 @@ GEM
     minitest (5.14.4)
     multi_test (0.1.2)
     multipart-post (2.1.1)
+    nokogiri (1.12.5-x86_64-darwin)
+      racc (~> 1.4)
     nokogiri (1.12.5-x86_64-linux)
       racc (~> 1.4)
     parallel (1.21.0)
@@ -167,6 +169,7 @@ GEM
     zeitwerk (2.4.2)
 
 PLATFORMS
+  x86_64-darwin-19
   x86_64-linux
 
 DEPENDENCIES

--- a/engine/app/components/citizens_advice_components/footer.html.haml
+++ b/engine/app/components/citizens_advice_components/footer.html.haml
@@ -22,5 +22,5 @@
       .cads-footer__logo
         %a.cads-logo{ href: homepage_url, title: t(".logo_title") }
       .cads-footer__meta
-        %p.cads-footer__meta-text{ "data-testid": "copyright" }= t(".copyright")
+        %p.cads-footer__meta-text{ "data-testid": "copyright" }= t(".copyright", year: current_year)
         %p.cads-footer__meta-text{ "data-testid": "legal-summary" }= t(".legal_summary")

--- a/engine/app/components/citizens_advice_components/footer.rb
+++ b/engine/app/components/citizens_advice_components/footer.rb
@@ -12,6 +12,10 @@ module CitizensAdviceComponents
       @feedback_url = feedback_url
     end
 
+    def current_year
+      Time.zone.today.year
+    end
+
     def columns_to_show
       columns.take(4)
     end

--- a/engine/config/locales/cy.yml
+++ b/engine/config/locales/cy.yml
@@ -6,7 +6,7 @@ cy:
       example: Enghraifft
       important: Pwysig
     footer:
-      copyright: Hawlfraint ©2021 Cyngor ar Bopeth. Cedwir pob hawl.
+      copyright: Hawlfraint ©%{year} Cyngor ar Bopeth. Cedwir pob hawl.
       legal_summary: 'Cyngor ar Bopeth yn enw gweithredol ar Gymdeithas Genedlaethol Cyngor ar Bopeth. Rhif elusen gofrestredig 279057. Rhif TAW 726 0202 76. Cwmni cyfyngedig drwy warant. Rhif cofrestredig 0143694 Lloegr. Swyddfa gofrestredig: Cyngor ar Bopeth, 3ydd Llawr Gogledd, 200 Aldersgate, Llundain, EC1A 4HD'
       logo_title: Hafan Cyngor ar Bopeth
       navigation_title: Llywio Troedyn

--- a/engine/config/locales/en.yml
+++ b/engine/config/locales/en.yml
@@ -6,7 +6,7 @@ en:
       example: Example
       important: Important
     footer:
-      copyright: Copyright ©2021 Citizens Advice. All rights reserved.
+      copyright: Copyright ©%{year} Citizens Advice. All rights reserved.
       legal_summary: 'Citizens Advice is an operating name of the National Association of Citizens Advice Bureaux. Registered charity number 279057. VAT number 726 0202 76. Company limited by guarantee. Registered number 01436945 England. Registered office: Citizens Advice, 3rd Floor North, 200 Aldersgate, London, EC1A 4HD'
       logo_title: Citizens Advice homepage
       navigation_title: Footer Navigation

--- a/engine/spec/components/citizens_advice_components/footer_spec.rb
+++ b/engine/spec/components/citizens_advice_components/footer_spec.rb
@@ -12,6 +12,10 @@ RSpec.describe CitizensAdviceComponents::Footer, type: :component do
   let(:columns) { generate_columns(4) }
   let(:feedback_url) { "https://www.research.net/r/J8PLH2H" }
 
+  before do
+    travel_to Time.zone.local(2049)
+  end
+
   describe "feedback URL" do
     let(:subject) { component.at("a[href='#{feedback_url}']") }
 
@@ -57,12 +61,12 @@ RSpec.describe CitizensAdviceComponents::Footer, type: :component do
   describe "copyright notice" do
     let(:subject) { component.at("[data-testid='copyright']").text }
 
-    it { is_expected.to include "Copyright" }
+    it { is_expected.to start_with "Copyright ©2049 Citizens Advice" }
 
     context "when welsh language" do
       before { I18n.locale = :cy }
 
-      it { is_expected.to include "Hawlfraint" }
+      it { is_expected.to start_with "Hawlfraint ©2049 Cyngor ar Bopeth" }
     end
   end
 

--- a/engine/spec/rails_helper.rb
+++ b/engine/spec/rails_helper.rb
@@ -27,6 +27,7 @@ module TestHelpers
 end
 
 RSpec.configure do |config|
+  config.include ActiveSupport::Testing::TimeHelpers
   config.include ViewComponent::TestHelpers, type: :component
   config.include TestHelpers
 


### PR DESCRIPTION
Support dynamic copyright year in footer component. Uses `ActiveSupport::Testing::TimeHelpers` to move to a specific year when testing.

Fixes #1405
