### PR TITLE
Update more specs to use capybara matchers

### DIFF
--- a/engine/spec/components/citizens_advice_components/asset_hyperlink_spec.rb
+++ b/engine/spec/components/citizens_advice_components/asset_hyperlink_spec.rb
@@ -2,16 +2,15 @@
 
 RSpec.describe CitizensAdviceComponents::AssetHyperlink, type: :component do
   subject(:component) do
-    render_inline(
-      described_class.new(
-        href: "https://example.com",
-        description: "Test PDF",
-        size: 6_444_516
-      )
+    described_class.new(
+      href: "https://example.com",
+      description: "Test PDF",
+      size: 6_444_516
     )
   end
 
   it "renders link with text" do
-    expect(component.at("a").text.strip.strip.tr("\n", " ")).to eq "Test PDF  6.15 MB"
+    render_inline component
+    expect(rendered_component).to have_link "Test PDF 6.15 MB"
   end
 end

--- a/engine/spec/components/citizens_advice_components/badge_spec.rb
+++ b/engine/spec/components/citizens_advice_components/badge_spec.rb
@@ -1,20 +1,16 @@
 # frozen_string_literal: true
 
 RSpec.describe CitizensAdviceComponents::Badge, type: :component do
-  subject(:badge) { component.at(".cads-badge--#{type}") }
-
   let(:component) do
-    render_inline(described_class.new(type: type.presence))
+    described_class.new(type: type.presence)
   end
-  let(:type) { :adviser }
 
-  context "when missing type" do
-    let(:type) { nil }
+  let(:type) { nil }
 
-    it "does not render when type is missing" do
-      without_fetch_or_fallback_raises do
-        expect(component.at(".cads-badge")).not_to be_present
-      end
+  it "does not render when type is missing" do
+    without_fetch_or_fallback_raises do
+      render_inline component
+      expect(rendered_component.at(".cads-badge")).not_to be_present
     end
   end
 
@@ -22,14 +18,16 @@ RSpec.describe CitizensAdviceComponents::Badge, type: :component do
     let(:type) { :example }
 
     it "has the correct label" do
-      expect(badge.text).to eq "Example"
+      render_inline component
+      expect(rendered_component).to have_selector ".cads-badge--example", text: "Example"
     end
 
     context "when welsh language" do
       before { I18n.locale = :cy }
 
       it "has translated label" do
-        expect(badge.text).to eq "Enghraifft"
+        render_inline component
+        expect(rendered_component).to have_text "Enghraifft"
       end
     end
   end
@@ -38,14 +36,16 @@ RSpec.describe CitizensAdviceComponents::Badge, type: :component do
     let(:type) { :important }
 
     it "has the correct label" do
-      expect(badge.text).to eq "Important"
+      render_inline component
+      expect(rendered_component).to have_selector ".cads-badge--important", text: "Important"
     end
 
     context "when welsh language" do
       before { I18n.locale = :cy }
 
       it "has translated label" do
-        expect(badge.text).to eq "Pwysig"
+        render_inline component
+        expect(rendered_component).to have_text "Pwysig"
       end
     end
   end
@@ -54,14 +54,16 @@ RSpec.describe CitizensAdviceComponents::Badge, type: :component do
     let(:type) { :adviser }
 
     it "has the correct label" do
-      expect(badge.text).to eq "Adviser"
+      render_inline component
+      expect(rendered_component).to have_selector ".cads-badge--adviser", text: "Adviser"
     end
 
     context "when welsh language" do
       before { I18n.locale = :cy }
 
       it "has translated label" do
-        expect(badge.text).to eq "Cynghorydd"
+        render_inline component
+        expect(rendered_component).to have_text "Cynghorydd"
       end
     end
   end

--- a/engine/spec/components/citizens_advice_components/contact_details_spec.rb
+++ b/engine/spec/components/citizens_advice_components/contact_details_spec.rb
@@ -1,23 +1,21 @@
 # frozen_string_literal: true
 
 RSpec.describe CitizensAdviceComponents::ContactDetails, type: :component do
-  subject(:component) do
-    render_inline(described_class.new) do
-      "Example content"
-    end
-  end
+  context "when content is present" do
+    subject(:component) { described_class.new.with_content("Example content") }
 
-  it "renders content block" do
-    expect(component.at(".cads-contact-details").text).to include "Example content"
+    it "renders content block" do
+      render_inline component
+      expect(rendered_component).to have_selector ".cads-contact-details", text: "Example content"
+    end
   end
 
   context "when no content present" do
-    subject(:component) do
-      render_inline(described_class.new)
-    end
+    subject(:component) { described_class.new }
 
     it "does not render" do
-      expect(component.at(".cads-contact-details")).not_to be_present
+      render_inline component
+      expect(rendered_component).to have_no_selector ".cads-contact-details"
     end
   end
 end

--- a/engine/spec/components/citizens_advice_components/page_review_spec.rb
+++ b/engine/spec/components/citizens_advice_components/page_review_spec.rb
@@ -2,11 +2,9 @@
 
 RSpec.describe CitizensAdviceComponents::PageReview, type: :component do
   subject(:component) do
-    render_inline(
-      described_class.new(
-        page_review_date: page_review_date.presence,
-        date_format: date_format.presence
-      )
+    described_class.new(
+      page_review_date: page_review_date.presence,
+      date_format: date_format.presence
     )
   end
 
@@ -14,14 +12,16 @@ RSpec.describe CitizensAdviceComponents::PageReview, type: :component do
   let(:date_format) { nil }
 
   it "renders a formatted date" do
-    expect(component.text.strip).to eq "Page last reviewed on 12 June 2021"
+    render_inline component
+    expect(rendered_component).to have_text "Page last reviewed on 12 June 2021"
   end
 
   context "when no date" do
     let(:page_review_date) { nil }
 
     it "does not render" do
-      expect(component.at(".cads-page-review")).not_to be_present
+      render_inline component
+      expect(rendered_component).to have_no_selector ".cads-page-review"
     end
   end
 
@@ -29,7 +29,8 @@ RSpec.describe CitizensAdviceComponents::PageReview, type: :component do
     let(:date_format) { :short }
 
     it "renders date with custom format" do
-      expect(component.text.strip).to eq "Page last reviewed on Jun 12"
+      render_inline component
+      expect(rendered_component).to have_text "Page last reviewed on Jun 12"
     end
   end
 
@@ -37,7 +38,8 @@ RSpec.describe CitizensAdviceComponents::PageReview, type: :component do
     before { I18n.locale = :cy }
 
     it "has translated date" do
-      expect(component.text.strip).to eq "Adolygwyd y dudalen ar 12 Mehefin 2021"
+      render_inline component
+      expect(rendered_component).to have_text "Adolygwyd y dudalen ar 12 Mehefin 2021"
     end
   end
 end


### PR DESCRIPTION
Update more specs to use capybara matchers. We don't have to use these for everything, it's fine to mix and match nokogiri with capybara where it makes sense. But generally speaking it's feeling more natural to write.