### PR TITLE
fix/add font-display option to font

### DIFF
--- a/scss/3-generics/_fonts.scss
+++ b/scss/3-generics/_fonts.scss
@@ -11,6 +11,8 @@
     url('../../assets/fonts/open-sans-v26-latin-regular.woff2') format('woff2'),
     /* Chrome 26+, Opera 23+, Firefox 39+ */
       url('../../assets/fonts/open-sans-v26-latin-regular.woff') format('woff'); /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
+
+  font-display: swap;
 }
 
 /* open-sans-700 - latin */
@@ -22,6 +24,8 @@
     url('../../assets/fonts/open-sans-v26-latin-700.woff2') format('woff2'),
     /* Chrome 26+, Opera 23+, Firefox 39+ */
       url('../../assets/fonts/open-sans-v26-latin-700.woff') format('woff'); /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
+
+  font-display: swap;
 }
 
 // ============================================================================


### PR DESCRIPTION
I accidentally removed `font-display: swap` when I updated the font srcs 😬 
https://github.com/citizensadvice/design-system/pull/1531/files#diff-d91684fda3bfd2eb2c979e255ceb1812089a7304a0ec4e352e4e3b41a3b25d24L9

