### PR TITLE
Test against multiple ruby versions

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -57,6 +57,41 @@ jobs:
       - run: bundle exec haml-lint
       - run: bundle exec rake spec
 
+  demo-app:
+    needs: engine
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-node@v2
+      with:
+        node-version: ${{ env.NODE_VERSION }}
+
+    # We link the @citizensadvice/design-system package
+    # from the root but we only build the lib/ directory
+    # when we publish to npm, so we need to build it first.
+    - uses: bahmutov/npm-install@v1
+    - run: npm run build
+
+    # Setup demo app
+    - uses: actions/checkout@v2
+    - uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ${{ env.RUBY_VERSION }}
+        working-directory: demo
+    - run: |
+        bundle config path vendor/bundle
+        bundle update
+        bundle install --jobs 4 --retry 3
+      working-directory: demo
+    - uses: bahmutov/npm-install@v1
+      with:
+        working-directory: demo
+
+    # Run a webpack build as a smoke test    
+    - run: ./bin/webpack
+      working-directory: demo
+
+
   # Actions can run in parallel at the job or the workflow level.
   # In order to run our build-dependent tests in parallel we need a way
   # to build the docs and then "seed" each stage with a copy.
@@ -164,30 +199,3 @@ jobs:
           name: grid-artifacts
           path: testing/artifacts
           retention-days: 3
-
-  demo-app:
-    needs: build
-    runs-on: ubuntu-20.04
-    defaults:
-      run:
-        working-directory: demo
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/download-artifact@v2
-        with:
-          name: docs-build
-      - uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: ${{ env.RUBY_VERSION }}
-          working-directory: demo
-      - run: |
-          bundle config path vendor/bundle
-          bundle update
-          bundle install --jobs 4 --retry 3
-      - uses: actions/setup-node@v2
-        with:
-          node-version: '14'
-      - uses: bahmutov/npm-install@v1
-        with:
-          working-directory: demo
-      - run: ./bin/webpack

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -73,7 +73,6 @@ jobs:
       - run: npm run build
 
       # Setup demo app
-      - uses: actions/checkout@v2
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ env.RUBY_VERSION }}

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -39,11 +39,15 @@ jobs:
     defaults:
       run:
         working-directory: engine
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby_version: ['2.7', '3.0']
     steps:
       - uses: actions/checkout@v2
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: ${{ env.RUBY_VERSION }}
+          ruby-version: ${{ matrix.ruby_version }}
           working-directory: engine
       - run: |
           bundle config path vendor/bundle

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -61,36 +61,35 @@ jobs:
     needs: engine
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-node@v2
-      with:
-        node-version: ${{ env.NODE_VERSION }}
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: ${{ env.NODE_VERSION }}
 
-    # We link the @citizensadvice/design-system package
-    # from the root but we only build the lib/ directory
-    # when we publish to npm, so we need to build it first.
-    - uses: bahmutov/npm-install@v1
-    - run: npm run build
+      # We link the @citizensadvice/design-system package
+      # from the root but we only build the lib/ directory
+      # when we publish to npm, so we need to build it first.
+      - uses: bahmutov/npm-install@v1
+      - run: npm run build
 
-    # Setup demo app
-    - uses: actions/checkout@v2
-    - uses: ruby/setup-ruby@v1
-      with:
-        ruby-version: ${{ env.RUBY_VERSION }}
+      # Setup demo app
+      - uses: actions/checkout@v2
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ env.RUBY_VERSION }}
+          working-directory: demo
+      - run: |
+          bundle config path vendor/bundle
+          bundle update
+          bundle install --jobs 4 --retry 3
         working-directory: demo
-    - run: |
-        bundle config path vendor/bundle
-        bundle update
-        bundle install --jobs 4 --retry 3
-      working-directory: demo
-    - uses: bahmutov/npm-install@v1
-      with:
+      - uses: bahmutov/npm-install@v1
+        with:
+          working-directory: demo
+
+      # Run a webpack build as a smoke test
+      - run: ./bin/webpack
         working-directory: demo
-
-    # Run a webpack build as a smoke test    
-    - run: ./bin/webpack
-      working-directory: demo
-
 
   # Actions can run in parallel at the job or the workflow level.
   # In order to run our build-dependent tests in parallel we need a way

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 
 **New**
 - 🏋 SVG Icons: Added view component SVG icons
+- Full Ruby 3 support for `citizens_advice_components`
 
 ## <sub>v5.0.0</sub>
 

--- a/engine/.rubocop.yml
+++ b/engine/.rubocop.yml
@@ -19,7 +19,7 @@ Metrics/BlockLength:
     # so we're not too worried about block length there
     - 'previews/**/*.rb'
 
-Metrics/LineLength:
+Layout/LineLength:
   Exclude:
     # Previews often include lots of test data by design
     # so we're not too worried about line length there

--- a/engine/app/components/citizens_advice_components/text_input.html.haml
+++ b/engine/app/components/citizens_advice_components/text_input.html.haml
@@ -1,2 +1,2 @@
-= render CitizensAdviceComponents::Input.new(base_input_args) do
+= render CitizensAdviceComponents::Input.new(**base_input_args) do
   %input.cads-input{ input_attributes }

--- a/engine/app/components/citizens_advice_components/text_input.rb
+++ b/engine/app/components/citizens_advice_components/text_input.rb
@@ -12,7 +12,7 @@ module CitizensAdviceComponents
       )
       args[:options]&.merge(width: @width)
       @base_input_args = args
-      super(@base_input_args)
+      super(**@base_input_args)
     end
 
     def allowed_width_values

--- a/engine/app/components/citizens_advice_components/textarea.html.haml
+++ b/engine/app/components/citizens_advice_components/textarea.html.haml
@@ -1,3 +1,3 @@
-= render CitizensAdviceComponents::Input.new(base_input_args) do
+= render CitizensAdviceComponents::Input.new(**base_input_args) do
   %textarea.cads-textarea{ input_attributes }
     = value

--- a/engine/app/components/citizens_advice_components/textarea.rb
+++ b/engine/app/components/citizens_advice_components/textarea.rb
@@ -9,7 +9,7 @@ module CitizensAdviceComponents
     def initialize(rows: DEFAULT_ROWS, **args)
       @rows = format_rows(rows)
       @base_input_args = args.merge(type: nil)
-      super(@base_input_args)
+      super(**@base_input_args)
     end
 
     def format_rows(rows)

--- a/engine/spec/components/citizens_advice_components/checkbox_single_spec.rb
+++ b/engine/spec/components/citizens_advice_components/checkbox_single_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe CitizensAdviceComponents::CheckboxSingle, type: :component do
       name: name.presence,
       error_message: error_message.presence
     ) do |c|
-      c.checkbox(checkbox)
+      c.checkbox(**checkbox)
     end
   end
 

--- a/engine/spec/components/citizens_advice_components/footer_spec.rb
+++ b/engine/spec/components/citizens_advice_components/footer_spec.rb
@@ -3,9 +3,7 @@
 RSpec.describe CitizensAdviceComponents::Footer, type: :component do
   subject(:component) do
     render_inline(described_class.new(feedback_url: feedback_url)) do |c|
-      columns.each do |column|
-        c.column(column)
-      end
+      c.columns(columns)
     end
   end
 

--- a/styleguide/components/footer/footer-docs.mdx
+++ b/styleguide/components/footer/footer-docs.mdx
@@ -73,9 +73,7 @@ These can either be passed on at a time like in the example above, or by iterati
 
 ```rb
 render CitizensAdviceComponents::Footer.new do |c|
-  my_columns.each do |column|
-    c.column(column)
-  end
+  c.columns(columns)
 end
 ```
 


### PR DESCRIPTION
A bit of a re-do of https://github.com/citizensadvice/design-system/pull/1307 but with just the Ruby version changes.

Includes a couple of Ruby 3 syntax fixes. The `**` stuff is down to https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/

> When a method call passes a Hash at the last argument, and when it passes no keywords, and when the called method accepts keywords, a warning is emitted. To continue treating the hash as keywords, add a double splat operator to avoid the warning and ensure correct behaviour in Ruby 3.

Gist seems to be—based on the context Luke gave in the original PR—that Ruby 3 requires less ambiguity.

One bit of complexity here is that branch protection required checks rely on the job name. The matrix build generates four different names that would all need to be added to the required checks list. This is a bit unwieldy!

Thankfully we can happily move the demo-app build to be dependent on the engine matrix and limit the required status checks only to this dependent build. This is conceptually more in line with the separation between the engine and the storybook build. It was a bit misleading to have the demo-app dependent on storybook before.

TODO:

- [x]  Remove old engine job from required status checks. Rely on check for dependent demo-app job.