### PR TITLE
Tables: Account for nil cells

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+**Bugfixes**
+
+- 🧂 Tables: Account for possibly nil cells
+
 ## <sub>v5.0.0</sub>
 
 #### _Oct. 11, 2021_

--- a/engine/app/components/citizens_advice_components/table.rb
+++ b/engine/app/components/citizens_advice_components/table.rb
@@ -13,7 +13,7 @@ module CitizensAdviceComponents
 
     def rows
       @rows.reject do |row|
-        row.flatten.reject(&:empty?).blank?
+        row.flatten.reject { |item| item.to_s.empty? }.blank?
       end
     end
 

--- a/engine/spec/components/citizens_advice_components/table_spec.rb
+++ b/engine/spec/components/citizens_advice_components/table_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe CitizensAdviceComponents::Table, type: :component do
     subject(:component) do
       described_class.new(
         header: sample_header,
-        rows: sample_rows.concat([["", ""], ["", ""], ["", ""]])
+        rows: sample_rows.concat([["", ""], [nil, nil], ["", nil]])
       )
     end
 


### PR DESCRIPTION
Realised that the current table guards only work for empty string not nullish values. Updates the check to guard against both.