### PR TITLE
Revert "Experimental/accessible capy selectors"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,4 @@ group :test do
   gem "selenium-webdriver", "4.0.0.alpha6"
   gem "site_prism", "~> 3.7"
   gem "webdrivers"
-  gem "capybara_accessible_selectors", github: "citizensadvice/capybara_accessible_selectors"
 end
-

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,13 +7,6 @@ GIT
       faraday (~> 1.0)
 
 GIT
-  remote: https://github.com/citizensadvice/capybara_accessible_selectors.git
-  revision: 288aa63d36b7632dabe5b6b7560aec3548f76e63
-  specs:
-    capybara_accessible_selectors (0.4.2)
-      capybara (~> 3)
-
-GIT
   remote: https://github.com/citizensadvice/citizens-advice-style-ruby.git
   revision: 8786246af8134b7efa1e800b56236186c6f68f7a
   tag: v4.1.0
@@ -103,13 +96,9 @@ GEM
       mime-types-data (~> 3.2015)
     mime-types-data (3.2021.0901)
     mini_mime (1.1.1)
-    mini_portile2 (2.6.1)
     minitest (5.14.4)
     multi_test (0.1.2)
     multipart-post (2.1.1)
-    nokogiri (1.12.5)
-      mini_portile2 (~> 2.6.1)
-      racc (~> 1.4)
     nokogiri (1.12.5-x86_64-darwin)
       racc (~> 1.4)
     nokogiri (1.12.5-x86_64-linux)
@@ -180,14 +169,12 @@ GEM
     zeitwerk (2.4.2)
 
 PLATFORMS
-  ruby
   x86_64-darwin-19
   x86_64-linux
 
 DEPENDENCIES
   activesupport
   ca_testing!
-  capybara_accessible_selectors!
   citizens-advice-style!
   cucumber (~> 7.0)
   dotenv

--- a/testing/features/components/step_definitions/targeted_content_steps.rb
+++ b/testing/features/components/step_definitions/targeted_content_steps.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-DISCLOSURE_TITLE = "If you are a citizen of a country outside the EU, EEA or Switzerland"
-SUMMARY_TEXT = "You should apply to the EU Settlement Scheme if both"
-
 Given("a default targeted content component is on the page") do
   @component = TargetedContent::Default.new.tap(&:load)
 end
@@ -20,11 +17,11 @@ Given("a fallback targeted content component is on the page") do
 end
 
 When("I expand/collapse the targeted content") do
-  toggle_disclosure DISCLOSURE_TITLE
+  @component.heading.expand_collapse.click
 end
 
 When("I close the targeted content") do
-  toggle_disclosure DISCLOSURE_TITLE
+  @component.additional_information.close.click
 end
 
 When("I jump to the targeted content") do
@@ -32,29 +29,34 @@ When("I jump to the targeted content") do
 end
 
 Then("a targeted content title is present") do
-  expect(@component).to have_disclosure_button DISCLOSURE_TITLE
+  expect(@component).to have_heading
 end
 
 Then("the toggle button indicates it will expand") do
+  expect(@component.heading).to have_expand_collapse
+
   expect(@component.heading.expand_collapse["aria-label"])
     .to start_with("show this section")
 end
 
 Then("the toggle button indicates it will collapse") do
+  expect(@component.heading).to have_expand_collapse
+
   expect(@component.heading.expand_collapse["aria-label"])
     .to start_with("hide this section")
 end
 
 Then("I can see additional information") do
-  expect(@component).to have_text SUMMARY_TEXT
+  expect(@component).to have_additional_information
 end
 
 Then("I can no longer see additional information") do
-  expect(@component).not_to have_text SUMMARY_TEXT
+  expect(@component).not_to have_additional_information
 end
 
 Then("I can see a close button") do
-  expect(@component).to have_button "Close"
+  expect(@component.additional_information.close.text)
+    .to eq("Close")
 end
 
 Then("an Adviser label is present in the expandable pane") do
@@ -62,6 +64,7 @@ Then("an Adviser label is present in the expandable pane") do
 end
 
 Then("I cannot close or collapse the content") do
-  expect(@component.heading).not_to have_disclosure_button DISCLOSURE_TITLE
-  expect(@component).not_to have_button "Close"
+  expect(@component.heading).not_to have_expand_collapse
+
+  expect(@component.additional_information).not_to have_close
 end

--- a/testing/features/support/components/targeted_content/default.rb
+++ b/testing/features/support/components/targeted_content/default.rb
@@ -7,5 +7,9 @@ module TargetedContent
     section :heading, "h2[id*='targeted-content']" do
       element :expand_collapse, "button"
     end
+
+    section :additional_information, "[id$='content']" do
+      element :close, "button"
+    end
   end
 end

--- a/testing/features/support/env.rb
+++ b/testing/features/support/env.rb
@@ -2,7 +2,6 @@
 
 require "dotenv"
 Dotenv.load(".env")
-require "capybara_accessible_selectors"
 
 require_relative "all"
 require_relative "helpers/all"


### PR DESCRIPTION
Been seeing a failure in Safari browserstack tests which seems down to the recent `capybara_accessible_selectors` change. Not 100% sure why so suggesting we revert for now unless there's something I'm missing.

Reverts citizensadvice/design-system#1544