### PR TITLE
fix: Changed the error summary docs to be consistent with public-website

### DIFF
--- a/engine/previews/citizens_advice_components/error_summary_preview.rb
+++ b/engine/previews/citizens_advice_components/error_summary_preview.rb
@@ -4,14 +4,10 @@ module CitizensAdviceComponents
   class ErrorSummaryPreview < ViewComponent::Preview
     def example
       render CitizensAdviceComponents::ErrorSummary.new do |c|
-        c.error(
-          href: "#your-name-input",
-          message: "Enter your full name"
-        )
-        c.error(
-          href: "#your-email-input",
-          message: "Enter an email address in the correct format, like name@example.com"
-        )
+        c.errors([
+          { href: "#your-name-input", message: "Enter your full name" },
+          { href: "#your-email-input", message: "Enter an email address in the correct format, like name@example.com" }
+        ])
       end
     end
   end

--- a/styleguide/forms/error-summary/error-summary-docs.mdx
+++ b/styleguide/forms/error-summary/error-summary-docs.mdx
@@ -52,21 +52,18 @@ If you are using the `citizens_advice_components` gem, you can call the componen
 ```rb
 = render(
   CitizensAdviceComponents::ErrorSummary.new do |c|
-    c.error(
-        href: "#your-name-input",
-        message: "Enter your full name"
-    )
-    c.error(
-        href: "#your-email-input",
-        message: "Enter an email address in the correct format, like name@example.com"
-    )
+    c.errors([
+       { href: "#your-name-input", message: "Enter your full name" },
+       { href: "#your-email-input", message: "Enter an email address in the correct format, like name@example.com" },
+    ])
   end
 )
 ```
 
 ### View Component Options
 
-| Property         | Description             |
-| ---------------- | ----------------------- |
-| `error[href]`    | Required, error href    |
-| `error[message]` | Required, error message |
+| Property         | Description                                                           |
+| ---------------- | --------------------------------------------------------------------- |
+| `errors`         | Required, array of error messages and links, each with the following: |
+| `error[href]`    | &rarr; Required, error href                                           |
+| `error[message]` | &rarr; Required, error message                                        |


### PR DESCRIPTION
Using plural `c.errors` array in the docs and preview file to be consistent with the public-website markup (see [PR2155](https://github.com/citizensadvice/public-website/pull/2155))