### PR TITLE
fix: changed the section links docs to match the preview

### DIFF
--- a/styleguide/components/section-links/section-links.mdx
+++ b/styleguide/components/section-links/section-links.mdx
@@ -17,8 +17,7 @@ import { Story, Canvas } from '@storybook/addon-docs';
 If you are using the `citizens_advice_components` gem, you can call the component from within a template using:
 
 ```rb
-= render CitizensAdviceComponents::SectionLinks.new(title: "Related Content") do |c|
-    c.section_title(title: "Section title", url: "/section-title")
+= render CitizensAdviceComponents::SectionLinks.new(title: "Related Content", section_title: "Section title", section_title_url: "/section-title") do |c|
     c.section_links([
       { title: "Link 1", url: "/link-1" },
       { title: "Link 2", url: "/link-2" },
@@ -32,13 +31,13 @@ end
 
 ### View Component Options
 
-| Argument               | Description                                            |
-| ---------------------- | ------------------------------------------------------ |
-| `title`                | Required. A general title for the section links        |
-| `section_title[title]` | Required. A section title above the links              |
-| `section_title[url]`   | Optional. A link for the section title                 |
-| `section_links`        | Required, an array of hashes, each with the following: |
-| `section_link[url]`    | → Required, url for the section link                   |
-| `section_link[title]`  | → Required, title for the section link                 |
+| Argument              | Description                                            |
+| --------------------- | ------------------------------------------------------ |
+| `title`               | Required. A general title for the section links        |
+| `section_title`       | Required. A section title above the links              |
+| `section_title_url`   | Optional. A link for the section title                 |
+| `section_links`       | Required, an array of hashes, each with the following: |
+| `section_link[url]`   | → Required, url for the section link                   |
+| `section_link[title]` | → Required, title for the section link                 |
 
 The component accepts a `content` block for additional content such as adviser only links. Please note that `content` will be rendered into a nav element which accepts flow content elements.


### PR DESCRIPTION
While working on moving the section links to the public-webiste, I have realised that what I have in the docs is a bit outdated (using slot for `section_title`). Amended to match the current functionality.