### PR TITLE
chore: rename master to main

### DIFF
--- a/contributing/release-process.md
+++ b/contributing/release-process.md
@@ -8,7 +8,7 @@ Releasing a new npm package version is a three step process.
 npm run release
 ```
 
-This prepares the release and puts it in a branch with the appropriate version name, which needs a pull request to be merged into master. Once that is merged you can then do the actual release.
+This prepares the release and puts it in a branch with the appropriate version name, which needs a pull request to be merged into main. Once that is merged you can then do the actual release.
 
 ## 2. Publish to npm
 
@@ -24,7 +24,7 @@ npm login
 
 You will only need to do this once on the machine you want to release from.
 
-After the new version branch is merged, switch to `master`, pull the latest changes and run:
+After the new version branch is merged, switch to `main`, pull the latest changes and run:
 
 ```sh
 npm publish
@@ -38,7 +38,7 @@ git push origin v{your_version_here}
 
 To publish the release tag to GitHub.
 
-A `prePublish` script will ensure you can only run npm publish from a `master` that is in a clean state. It will build the package and publish to npm.
+A `prePublish` script will ensure you can only run npm publish from a `main` that is in a clean state. It will build the package and publish to npm.
 
 ## 3. Update the release tag in GitHub
 

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -29,7 +29,7 @@ function updateVersionNumber(newVersion) {
 checkRepoStatus(PATH);
 chalk.bold(`You are preparing a new release.
 This script will create a branch based on your chosen version number and you must then create a
-pull request to master.`);
+pull request to main.`);
 prompt([
   {
     message: 'Have you updated the Changelog?',

--- a/scripts/releaseHelpers.js
+++ b/scripts/releaseHelpers.js
@@ -23,9 +23,9 @@ function checkRepoStatus(repo, testRun) {
 
     let err = false;
 
-    if (branch !== 'master') {
+    if (branch !== 'main') {
       showError(
-        `${error} You must be in the master branch to release. Currently you are in ${branch}.`
+        `${error} You must be in the main branch to release. Currently you are in ${branch}.`
       );
       err = true;
     }
@@ -51,7 +51,7 @@ function checkRepoStatus(repo, testRun) {
 
     if (err) {
       showError(
-        'Please ensure you are in the master branch and that the repo is in a clean state.',
+        'Please ensure you are in the main branch and that the repo is in a clean state.',
         !testRun
       );
     }

--- a/styleguide/documentation/getting-started.stories.mdx
+++ b/styleguide/documentation/getting-started.stories.mdx
@@ -117,7 +117,7 @@ Once installed you can call them within your application by passing the componen
 ## Changelog
 
 - Release notes for each version (starting with v2.0.0) can be seen at [https://github.com/citizensadvice/design-system/releases](https://github.com/citizensadvice/design-system/releases)
-- The full changelog can be found at [https://github.com/citizensadvice/design-system/blob/master/CHANGELOG.md](https://github.com/citizensadvice/design-system/blob/master/CHANGELOG.md)
+- The full changelog can be found at [https://github.com/citizensadvice/design-system/blob/main/CHANGELOG.md](https://github.com/citizensadvice/design-system/blob/main/CHANGELOG.md)
 
 ## Contact
 


### PR DESCRIPTION
Rename master branch to main in release script and docs.

Fixes #1406