### PR TITLE
chore: ignore dependabot updates for sass-loader

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,7 +23,6 @@ updates:
       - dependency-name: '@storybook/*'
       # Requires webpack v5 but storybook bundles v4
       - dependency-name: 'sass-loader'
-        versions: ['11.x']
 
   - package-ecosystem: npm
     directory: '/testing'


### PR DESCRIPTION
Sass-loader is at version 12.6.0 but we want to prevent dependabot from flagging future versions as this would impact the Storybook build.