### PR TITLE
fix: release script does not create tag

### DIFF
--- a/scripts/release.js
+++ b/scripts/release.js
@@ -17,7 +17,7 @@ const FULL_PACKAGE_NAME = `${ORG_NAME}/${PACKAGE_NAME}`;
 
 function updateVersionNumber(newVersion) {
   log(chalk.blue.dim(`${ok} Updating version number to ${newVersion}`));
-  execSync(`npm version ${newVersion}`);
+  execSync(`npm --no-git-tag-version version ${newVersion}`);
   log(chalk.green(`${ok} Updated version number to ${newVersion}`));
 }
 


### PR DESCRIPTION
Prevents the release script from adding a tag for the release by using [`--no-git-tag-version`](https://docs.npmjs.com/cli/v8/commands/npm-version#description), as the docs say to do this manually after publishing.  

Duplicate tags are potentially causing [issues](https://github.com/citizensadvice/public-website/pull/2384) in products that have the gem as a github dependency.