### PR TITLE
Allow demo-app job to run earlier

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -25,7 +25,7 @@ jobs:
       - run: npm run lint
       - run: npm test
 
-  engine:
+  engine-specs:
     runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
@@ -52,12 +52,28 @@ jobs:
           bundle config path vendor/bundle
           bundle update
           bundle install --jobs 4 --retry 3
-      - run: bundle exec rubocop --format github
-      - run: bundle exec haml-lint
       - run: bundle exec rake spec
 
+  engine-lint:
+    needs: engine-specs
+    runs-on: ubuntu-20.04
+    defaults:
+      run:
+        working-directory: engine
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '2.7.4'
+          working-directory: engine
+      - run: |
+          bundle config path vendor/bundle
+          bundle update
+          bundle install --jobs 4 --retry 3
+      - run: bundle exec rubocop --format github
+      - run: bundle exec haml-lint
+
   demo-app:
-    needs: engine
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Extracted from https://github.com/citizensadvice/design-system/pull/1841

This is to a) allow us to run the demo app job earlier as it will be doing more work b) avoid running lint checks for every single version of ruby/rails. We only care about rspec tests for different versions. We'll need to add this job to the required checks after merging this.