### PR TITLE
Add ADRs for recent testing decisions

### DIFF
--- a/.adr-dir
+++ b/.adr-dir
@@ -1,0 +1,1 @@
+contributing/adr

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,3 +3,4 @@
 - [Setup](./contributing/setup.md)
 - [Testing](./contributing/testing.md)
 - [Release process](./contributing/release-process.md)
+- [Architecture Decision Records](./contributing/adr/)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,6 @@
 # Contributing
 
+- [Architecture overview](./contributing/architecture.md)
 - [Setup](./contributing/setup.md)
 - [Testing](./contributing/testing.md)
 - [Release process](./contributing/release-process.md)

--- a/contributing/adr/0001-record-architecture-decisions.md
+++ b/contributing/adr/0001-record-architecture-decisions.md
@@ -1,0 +1,19 @@
+# 1. Record architecture decisions
+
+Date: 2022-03-22
+
+## Status
+
+Accepted
+
+## Context
+
+We need to record the architectural decisions made on this project.
+
+## Decision
+
+We will use Architecture Decision Records (ADRs), as [described by Michael Nygard](http://thinkrelevance.com/blog/2011/11/15/documenting-architecture-decisions). As we manage our work through GitHub projects storing our ADRs alongside the code makes most sense.
+
+## Consequences
+
+See Michael Nygard's article, linked above. For a lightweight ADR toolset, see Nat Pryce's [adr-tools](https://github.com/npryce/adr-tools).

--- a/contributing/adr/0002-run-automated-tests-against-demo-app.md
+++ b/contributing/adr/0002-run-automated-tests-against-demo-app.md
@@ -1,0 +1,25 @@
+# 2. Run automated tests against demo app
+
+Date: 2022-03-22
+
+## Status
+
+Accepted
+
+## Context
+
+We currently run all our automated tests against the Storybook documentation site. This is not a good reflection of how components are typically used. We are also in the process of creating a new documentation site which will replace Storybook. We have a demo Rails application that is already used for some tests that could be used for all out automation tests.
+
+## Decision
+
+We will run all our automated tests against the demo Rails app rather than Storybook.
+
+## Consequences
+
+Migration has the following benefits:
+
+- Allows us to decouple tests from Storybook
+- Tests will be run against an environment that more closely resembles our production application
+- Defines clearer boundaries between parts of the Design System. Tests run against a dedicated demo app rather than against a documentation site.
+
+As a consequence we will need to either migrate tests as is over to the demo app (Backstop tests) or explore alternatives in the process (automation and accessibility tests).

--- a/contributing/adr/0003-use-cypress-for-automated-tests.md
+++ b/contributing/adr/0003-use-cypress-for-automated-tests.md
@@ -1,0 +1,27 @@
+# 3. Use Cypress for automated tests
+
+Date: 2022-03-22
+
+## Status
+
+Accepted
+
+## Context
+
+Given the decision in "2. Run automated tests against demo app" we want to explore alternative option for running our automated tests against the demo Rails app.
+
+Our current feature tests are complex to maintain and duplicate a lot of what our rspec and visual regression tests cover.
+
+The Design System is maintained largely by front-end developers so exploring alternate tools that better match the skill sets of the people maintaining components is good for long term maintainability.
+
+## Decision
+
+- We will use Cypress to handle our automated tests. We will only migrate tests that include real user interaction and not migrate any tests that are better covered by lower level unit tests or visual regression tests.
+- We will use Cypress Testing Library to allow us to test components using matchers that best reflect how users will interact with components.
+- We will use cypress-axe to replace our current pa11y smoke tests.
+
+## Consequences
+
+Future tests will need to be written using Cypress and developers will need to learn a new tool. We have validated that all maintainers are comfortable writing Cypress tests.
+
+Pa11y will be removed as it is covered by cypress-axe and new component previews will automatically get tested for basic accessibility violations avoiding us needing to maintain a second tool to do this.

--- a/contributing/adr/README.md
+++ b/contributing/adr/README.md
@@ -1,0 +1,7 @@
+# Architecture Decision Records
+
+- [1. Record architecture decisions](0001-record-architecture-decisions.md)
+- [2. Run automated tests against demo app](0002-run-automated-tests-against-demo-app.md)
+- [3. Use Cypress for automated tests](0003-use-cypress-for-automated-tests.md)
+
+We recommend installing and using [adr-tools](https://github.com/npryce/adr-tools) to create new decision records but you can also copy a previous one as a template.

--- a/contributing/architecture.md
+++ b/contributing/architecture.md
@@ -1,0 +1,34 @@
+# Architecture overview
+
+This document outlines the key technical components that make up the Citizens Advice Design System.
+
+## NPM package
+
+The central part of the design system is the `@citizensadvice/design-system` package published at https://www.npmjs.com/package/@citizensadvice/design-system
+
+At its heart the design system is a set of CSS styles, HTML patterns, and minimal JavaScript behaviour.
+
+The `@citizensadvice/design-system` package bundles the following:
+
+- A set of SCSS files
+- A set of JavaScript modules
+- Our brand font
+- A set of custom icons (as an icon font and SVGs)
+
+This package—alongside companion HTML patterns—is the minimum requirement when using the design system.
+
+## Rails Engine
+
+We also provide a [Rails Engine](https://guides.rubyonrails.org/engines.html) which bundles up our components as a set of [view components](https://viewcomponent.org/) which is easy to integrate with Ruby on Rails.
+
+This gives us a way of distributing our component templates for use in our main internal applications so that we don't need to copy and paste HTML examples around and can call component using a clear interface.
+
+Think of the Rails Engine as the reference implementation of all our component templates. If you are using Rails then great, you can require this gem and use the provided interfaces. You can still use the design system with other frameworks but you'll need to maintain your own templates.
+
+View components can contain logic so this allows us to provide richer components like pagination where you would otherwise need to reimplement the logic behind the component each time.
+
+## Demo app
+
+The demo app is not distributed beyond this project but acts as an example of how to integrate the design system into a full Rails application.
+
+It is also used as a place to run all of our automated tests in an environment that is specifically designed for testing but still closely resembles our production applications.


### PR DESCRIPTION
We have made a number of architecturally significant decisions around how and when we test our components. We should document these decisions.

Using this as an excuse to set up a basic ADR structure using adr-tools. As we manage our work through github projects storing our ADRs alongside the code makes most sense.

I've also include an architecture overview as suggested by @marianayovcheva to hopefully make it a little clearer what the boundaries are between parts of the design system.