### PR TITLE
Footer: Simplify how year is calculated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 **Bugfixes**
 
 - Fix deprecation warning with newer versions of view_component
+- 🥾 Footer: Use simpler `Time.current.year` rather than `Time.zone.today.year` for footer year. Allows component to be more portable and usable outside of a Rails context.
 
 ## <sub>v5.2.0</sub>
 

--- a/engine/app/components/citizens_advice_components/footer.rb
+++ b/engine/app/components/citizens_advice_components/footer.rb
@@ -13,7 +13,7 @@ module CitizensAdviceComponents
     end
 
     def current_year
-      Time.zone.today.year
+      Time.current.year
     end
 
     def columns_to_show


### PR DESCRIPTION
Extracted from https://github.com/citizensadvice/design-system/pull/1874

Use simpler `Time.current.year` rather than `Time.zone.today.year` for footer year. Allows component to be more portable and usable outside of a Rails context.