### PR TITLE
Unpin view_component version

### DIFF
--- a/demo/Gemfile
+++ b/demo/Gemfile
@@ -9,9 +9,6 @@ gem "puma", "~> 5.5"
 gem "rails", "~> 6.1"
 gem "webpacker", "~> 5.0"
 
-# Pinned due to: https://github.com/github/view_component/issues/1315
-gem 'view_component', '2.50.0'
-
 gem "citizens_advice_components", path: "../engine"
 
 group :development do

--- a/demo/Gemfile.lock
+++ b/demo/Gemfile.lock
@@ -73,7 +73,7 @@ GEM
     builder (3.2.4)
     byebug (11.1.3)
     coderay (1.1.3)
-    concurrent-ruby (1.1.9)
+    concurrent-ruby (1.1.10)
     crass (1.0.6)
     cypress-rails (0.5.3)
       puma (>= 3.8.0)
@@ -181,7 +181,7 @@ GEM
     tilt (2.0.10)
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
-    view_component (2.50.0)
+    view_component (2.52.0)
       activesupport (>= 5.0.0, < 8.0)
       method_source (~> 1.0)
     web-console (4.2.0)
@@ -214,7 +214,6 @@ DEPENDENCIES
   spring
   spring-watcher-listen (~> 2.0.0)
   tzinfo-data
-  view_component (= 2.50.0)
   web-console (>= 3.3.0)
   webpacker (~> 5.0)
 

--- a/design-system-docs/Gemfile
+++ b/design-system-docs/Gemfile
@@ -26,7 +26,6 @@ gem "puma", "~> 5.2"
 
 # citizens advice design system view components
 gem "citizens_advice_components", path: "../engine"
-gem "view_component", "2.50.0"
 
 group :bridgetown_plugins do
   gem "bridgetown-view-component", "~> 1.0"

--- a/design-system-docs/Gemfile.lock
+++ b/design-system-docs/Gemfile.lock
@@ -302,7 +302,7 @@ GEM
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
     unicode-display_width (1.8.0)
-    view_component (2.50.0)
+    view_component (2.52.0)
       activesupport (>= 5.0.0, < 8.0)
       method_source (~> 1.0)
     webrick (1.7.0)
@@ -321,7 +321,6 @@ DEPENDENCIES
   citizens-advice-style!
   citizens_advice_components!
   puma (~> 5.2)
-  view_component (= 2.50.0)
 
 BUNDLED WITH
    2.2.31


### PR DESCRIPTION
2.52.0 is out now with a fix for the template inheritance issue so we can unpin the version again.