### PR TITLE
Add support for component examples

### DIFF
--- a/design-system-docs/Gemfile
+++ b/design-system-docs/Gemfile
@@ -19,12 +19,9 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 # Happy Bridgetowning!
 
 gem "bridgetown", "~> 1.0"
-
-# Puma is a Rack-compatible server
-# (you can optionally limit this to the "development" group)
+gem "htmlbeautifier"
 gem "puma", "~> 5.2"
 
-# citizens advice design system view components
 gem "citizens_advice_components", path: "../engine"
 
 group :bridgetown_plugins do

--- a/design-system-docs/Gemfile.lock
+++ b/design-system-docs/Gemfile.lock
@@ -178,6 +178,7 @@ GEM
       haml (>= 4.0, < 6)
       nokogiri (>= 1.6.0)
       ruby_parser (~> 3.5)
+    htmlbeautifier (1.4.1)
     i18n (1.10.0)
       concurrent-ruby (~> 1.0)
     io-wait (0.2.1)
@@ -323,6 +324,7 @@ DEPENDENCIES
   bridgetown-view-component (~> 1.0)
   citizens-advice-style!
   citizens_advice_components!
+  htmlbeautifier
   puma (~> 5.2)
 
 BUNDLED WITH

--- a/design-system-docs/bridgetown.config.yml
+++ b/design-system-docs/bridgetown.config.yml
@@ -20,10 +20,13 @@ permalink: pretty
 template_engine: erb
 
 collections:
-  cads_components:
+  component_docs:
     output: true
     sort_by: order
     name: Components
     permalink: /components/:slug/
+  component_examples:
+    output: true
+    permalink: /examples/:slug/
 # pagination:
 #   enabled: true

--- a/design-system-docs/frontend/javascript/index.js
+++ b/design-system-docs/frontend/javascript/index.js
@@ -1,1 +1,7 @@
 import '../styles/index.scss';
+
+import initTargetedContent from '@citizensadvice/design-system/lib/targeted-content';
+import initDisclosure from '@citizensadvice/design-system/lib/disclosure/disclosure';
+
+initTargetedContent();
+initDisclosure();

--- a/design-system-docs/frontend/styles/_code.scss
+++ b/design-system-docs/frontend/styles/_code.scss
@@ -1,0 +1,14 @@
+// ============================================================================
+// Code styles
+// ============================================================================
+
+pre code {
+  display: block;
+  background: none;
+  white-space: pre;
+  -webkit-overflow-scrolling: touch;
+  overflow-x: scroll;
+  max-width: 100%;
+  min-width: 100px;
+  padding: 20px;
+}

--- a/design-system-docs/frontend/styles/_examples.scss
+++ b/design-system-docs/frontend/styles/_examples.scss
@@ -1,0 +1,32 @@
+// ============================================================================
+// Component examples
+// ============================================================================
+
+.component-example {
+  border: 1px solid $cads-language__border-colour;
+  padding: $cads-spacing-5;
+  margin-bottom: $cads-spacing-6;
+}
+.component-example__links {
+  text-align: right;
+  margin-bottom: $cads-spacing-5;
+}
+.component-example__iframe {
+  display: block;
+  width: 100%;
+  max-width: 100%;
+  border: 0;
+  min-width: 230px;
+  min-height: 60px;
+  overflow: auto;
+  margin-bottom: $cads-spacing-4;
+}
+.component-example__source {
+  .cads-disclosure {
+    margin-bottom: $cads-spacing-4;
+
+    &:last-of-type {
+      margin-bottom: 0;
+    }
+  }
+}

--- a/design-system-docs/frontend/styles/_feedback.scss
+++ b/design-system-docs/frontend/styles/_feedback.scss
@@ -1,0 +1,20 @@
+// ============================================================================
+// Listings
+// ============================================================================
+
+.feedback-prompt {
+  margin-bottom: $cads-spacing-7;
+  padding: $cads-spacing-4 0;
+  border: solid $cads-language__border-colour;
+  border-width: 1px 0;
+}
+.feedback-prompt__title {
+  @extend %cads-h4;
+
+  margin: 0 0 $cads-spacing-1 0;
+}
+.feedback-prompt__body {
+  @include cads-typographic-scale-text-small();
+
+  margin: 0;
+}

--- a/design-system-docs/frontend/styles/_layout.scss
+++ b/design-system-docs/frontend/styles/_layout.scss
@@ -1,0 +1,25 @@
+// ============================================================================
+// Listings
+// ============================================================================
+
+.sidebar {
+  margin-top: $cads-spacing-4;
+}
+
+.text-list {
+  margin-bottom: $cads-spacing-6;
+
+  &__title {
+    @extend %cads-h2;
+  }
+
+  &__links {
+    @extend %cads-list-no-bullet;
+
+    margin-bottom: $cads-spacing-6;
+
+    &:last-of-type {
+      margin-bottom: 0;
+    }
+  }
+}

--- a/design-system-docs/frontend/styles/index.scss
+++ b/design-system-docs/frontend/styles/index.scss
@@ -1,1 +1,6 @@
 @import '~@citizensadvice/design-system/scss/lib';
+
+@import 'layout';
+@import 'code';
+@import 'examples';
+@import 'feedback';

--- a/design-system-docs/src/_cads_components/targeted_content.md
+++ b/design-system-docs/src/_cads_components/targeted_content.md
@@ -1,5 +1,0 @@
----
-layout: component
----
-
-# Targeted Content

--- a/design-system-docs/src/_component_docs/targeted-content.md
+++ b/design-system-docs/src/_component_docs/targeted-content.md
@@ -1,0 +1,62 @@
+---
+layout: component
+title: Targeted Content
+---
+
+The targeted content component allows users to show and hide sections of related content on a page. It can help users scan and process content on a page more effectively.
+
+However, it does hide content from users and it can be easy for users to miss. When using it, you should aim to use **no more than 6** and you shouldn’t have a targeted content on its own.
+
+Because targeted contents hide content, they should always have a clear label/title that helps users understand what is in the section. You can use `h3` within them to break up the content.
+
+## When to use
+
+When content is only relevant to some particular users visiting the page.
+
+## When not to use
+
+They shouldn’t be used to make a page seem shorter, for example: using them to hide large chunks of content.
+If you find yourself using targeted content to do this, think about:
+
+- If you’re repeating content on the page and could consolidate it.
+- Using headings on the page instead.
+- If you need to move some of the content onto another page.
+
+## Examples
+
+### Default variant
+
+<%= render(Shared::ComponentExample.new("targeted_content_default")) %>
+
+### Adviser variant
+
+<%= render(Shared::ComponentExample.new("targeted_content_adviser")) %>
+
+## JavaScript behaviour
+
+Targeted content requires some additional JavaScript behaviour which can be initialised with:
+
+```js
+import initTargetedContent from '@citizensadvice/design-system/lib/targeted-content';
+initTargetedContent();
+```
+
+**Note**: If you are supporting IE 11 or earlier make sure you include an [Element.prototype.closest polyfill](https://www.npmjs.com/package/element-closest).
+
+### Fallback behaviour
+
+If JavaScript either fails or is disabled in the users browser the fallback is to show the content as open. Disable JavaScript for this page to see the fallback behaviour in action.
+
+## Using with Rails
+
+If you are using the `citizens_advice_components` gem you call the component from within a template using:
+
+```rb
+<%%= render(CitizensAdviceComponents::TargetedContent.new(
+  title: "Your title",
+  id: "targeted-content-example-id")
+  )) do
+    Your content
+  end
+%>
+```

--- a/design-system-docs/src/_component_examples/targeted_content_adviser.erb
+++ b/design-system-docs/src/_component_examples/targeted_content_adviser.erb
@@ -1,0 +1,13 @@
+---
+title: Adviser
+---
+<%= render(CitizensAdviceComponents::TargetedContent.new(type: :adviser,
+  title: "Students or self-sufficient people",
+  id: "targeted-content-adviser")) do %>
+  <p>You should apply to the EU Settlement Scheme if both:</p>
+  <ul>
+    <li>you’re in the UK by 31 December 2020</li>
+    <li>you have family in the UK from the EU, EEA or Switzerland</li>
+  </ul>
+  <p>You need to apply to the scheme even if you have a permanent residence card as it will not be valid after 31 December 2020</p>
+<% end %>

--- a/design-system-docs/src/_component_examples/targeted_content_default.erb
+++ b/design-system-docs/src/_component_examples/targeted_content_default.erb
@@ -1,0 +1,14 @@
+---
+title: Default
+---
+<%= render(CitizensAdviceComponents::TargetedContent.new(
+  title: "If you are a citizen of a country outside the EU, EEA or Switzerland",
+  id: "targeted-content-123")
+) do %>
+  <p>You should apply to the EU Settlement Scheme if both:</p>
+  <ul>
+    <li>you’re in the UK by 31 December 2020</li>
+    <li>you have family in the UK from the EU, EEA or Switzerland</li>
+  </ul>
+  <p>You need to apply to the scheme even if you have a permanent residence card as it will not be valid after 31 December 2020</p>
+<% end %>

--- a/design-system-docs/src/_components/shared/component_example.erb
+++ b/design-system-docs/src/_components/shared/component_example.erb
@@ -1,0 +1,22 @@
+<div class="component-example">
+  <div class="component-example__links">
+    <a href="<%= example.relative_url %>" rel="noreferrer" target="_blank">
+      Open example in a new tab
+    </a>
+  </div>
+  <div class="component-example__preview">
+    <% if iframe? %>
+      <iframe class="component-example__iframe js-component-example-iframe" title="<%= example.data.title.downcase %> example" src="<%= example.relative_url %>" frameborder="0" loading="lazy"></iframe>
+    <% else %>
+      <%= example.content %>
+    <% end %>
+  </div>
+  <div class="component-example__source">
+    <%= render(CitizensAdviceComponents::Disclosure.new(closed_summary: "HTML code for #{example.data.title.downcase} example")) do %>
+      <pre class="highlight"><code><%= raw highlighted_html %></code></pre>
+    <% end %>
+    <%= render(CitizensAdviceComponents::Disclosure.new(closed_summary: "ERB code for #{example.data.title.downcase} example")) do %>
+      <pre class="highlight"><code><%= raw highlighted_source %></code></pre>
+    <% end %>
+  </div>
+</div>

--- a/design-system-docs/src/_components/shared/component_example.rb
+++ b/design-system-docs/src/_components/shared/component_example.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require "htmlbeautifier"
+
+module Shared
+  class ComponentExample < ViewComponent::Base
+    include Bridgetown::ViewComponentHelpers
+
+    def initialize(slug, iframe: false)
+      super
+
+      @slug = slug
+      @iframe = iframe
+      @site = Bridgetown::Current.site
+    end
+
+    def render?
+      find_example.present?
+    end
+
+    def example
+      example_resource = find_example
+      # Make sure that rendered output is processed
+      example_resource.transformer.process!
+      example_resource
+    end
+
+    def find_example
+      @site.collections.component_examples.resources.find do |resource|
+        resource.data.slug == @slug
+      end
+    end
+
+    def iframe?
+      @iframe.present?
+    end
+
+    def highlighted_source
+      # @FIXME: There's probably some helper method to do this for us
+      lexer = Rouge::Lexers::ERB.new
+      formatter.format(lexer.lex(example.untransformed_content))
+    end
+
+    def highlighted_html
+      lexer = Rouge::Lexers::HTML.new
+      formatter.format(lexer.lex(beautified_content))
+    end
+
+    def beautified_content
+      ::HtmlBeautifier.beautify(example.content)
+    end
+
+    def formatter
+      Rouge::Formatters::HTML.new
+    end
+  end
+end

--- a/design-system-docs/src/_layouts/component.erb
+++ b/design-system-docs/src/_layouts/component.erb
@@ -1,4 +1,6 @@
 ---
+layout: default
+---
 
 <%= render(CitizensAdviceComponents::Breadcrumbs.new(
   links: [
@@ -17,9 +19,23 @@
           <%= content %>
         </div>
       </div>
+      <%= render "feedback_prompt" %>
     </div>
     <div class="cads-grid-col-md-4 sidebar">
-      <%# TODO: Add sidebar %>
+      <%=
+        render(CitizensAdviceComponents::SectionLinks.new(
+          title: "In this section",
+          section_title: resource.collection.metadata.name,
+          section_title_url: "/components"
+        )) do |c|
+          c.section_links(collections.component_docs.resources.map do |foundation|
+            { url: foundation.relative_url, title: foundation.data.title }
+          end)
+          # Need to pass in some content to avoid shadowing Bridgetowns content global
+          # We could probably avoid this by wrapping this in its own component?
+          ""
+        end
+      %>
     </div>
   </div>
 </main>

--- a/design-system-docs/src/_pages/components.erb
+++ b/design-system-docs/src/_pages/components.erb
@@ -1,0 +1,26 @@
+---
+title: Components
+layout: default
+---
+
+<%= render(CitizensAdviceComponents::Breadcrumbs.new(
+  links: [
+    { title: "Home", url: "/"},
+    { title: resource.data.title }
+  ]
+)) %>
+
+<main id="cads-main-content" class="cads-grid-container">
+  <div class="cads-grid-row">
+    <div class="cads-grid-col-md-8 cads-page-content">
+      <h1 class="cads-page-title"><%= resource.data.title %></h1>
+      <div class="text-list">
+        <ul class="text-list__links">
+          <% collections.component_docs.resources.each do |foundation| %>
+            <li><a href="<%= foundation.relative_url %>"><%= foundation.data.title %></a></li>
+          <% end %>
+        </ul>
+      </div>
+    </div>
+  </div>
+</main>

--- a/design-system-docs/src/_partials/_feedback_prompt.erb
+++ b/design-system-docs/src/_partials/_feedback_prompt.erb
@@ -1,0 +1,9 @@
+<div class="feedback-prompt">
+  <h2 class="feedback-prompt__title">Questions and contributions</h2>
+  <p class="feedback-prompt__body">
+    All design system discussions take place in the #design-system Slack channel.
+    For current issues, roadmap and other info see the
+    <a href="https://github.com/orgs/citizensadvice/projects/5">Github project board</a>
+    and <a href="https://github.com/citizensadvice/design-system-testing/issues">related issues</a>.
+  </p>
+</div>


### PR DESCRIPTION
Extracted from https://github.com/citizensadvice/design-system/pull/1874

Adds a basic component template and index page along with a ComponentExample view component which allows rendering a component example along with source code and generated HTML.

Opted not to extract the arguments table for now as I think that needs a little bit more thought.

![localhost_4000_components_targeted-content_](https://user-images.githubusercontent.com/123386/161061381-34b9c672-3049-4838-8360-e0fd8cafa287.png)
