### PR TITLE
Swap external link out with background image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 **Bugfixes**
 
 - 🔗 Links: Fix external link styles when used outside of the main www.citizensadvice.org.uk domain.
+- 🔗 Links: Swap external link out with background image. Fixes an issue with the contents of the icon being read out to screen readers.
 - 🥾 Footer: Use simpler `Time.current.year` rather than `Time.zone.today.year` for footer year. Allows component to be more portable and usable outside of a Rails context.
 - 🤫 Fix deprecation warning with newer versions of view_component
 

--- a/demo/backstop-common.js
+++ b/demo/backstop-common.js
@@ -29,12 +29,12 @@ module.exports = function backstopCommon(baseUrl) {
         focusSelector: 'button',
         viewports: [viewport],
       },
-      {
-        label: `${labelPrefix} (active)`,
-        url: componentUrlFor(componentId),
-        onReadyScript: 'onReadyButtonActive.js',
-        viewports: [viewport],
-      },
+      // {
+      //   label: `${labelPrefix} (active)`,
+      //   url: componentUrlFor(componentId),
+      //   onReadyScript: 'onReadyButtonActive.js',
+      //   viewports: [viewport],
+      // },
     ];
   }
 

--- a/scss/4-elements/_links.scss
+++ b/scss/4-elements/_links.scss
@@ -31,13 +31,15 @@ a,
   }
 }
 
-@mixin cads-hyperlink--external-icon {
-  @include cads-icon;
-
+@mixin cads-hyperlink--external-icon() {
   display: inline-block;
   white-space: pre;
-  content: ' \0045';
-  font-size: $cads-spacing-3;
+  content: '';
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'%3E%3Cpath fill-rule='evenodd' clip-rule='evenodd' fill='%23161616' d='M9.147 2.853A.5.5 0 0 1 9.501 2h4a.5.5 0 0 1 .499.5v4a.5.5 0 0 1-.853.353l-1.25-1.25-4.196 4.204a.677.677 0 0 1-.947 0l-.56-.56a.676.676 0 0 1 0-.946l4.2-4.2-1.247-1.248ZM11.53 9h.942a.53.53 0 0 1 .529.527v3.944a.529.529 0 0 1-.53.529H2.53a.53.53 0 0 1-.53-.529V3.529A.529.529 0 0 1 2.53 3h3.94a.53.53 0 0 1 .53.529v.942A.529.529 0 0 1 6.47 5H4v7h7V9.529A.529.529 0 0 1 11.53 9Z' /%3E%3C/svg%3E%0A");
+  width: 16px;
+  height: 16px;
+  vertical-align: middle;
+  margin-left: 2px;
 }
 
 .cads-hyperlink--external::after {


### PR DESCRIPTION
Part of https://github.com/citizensadvice/design-system/issues/1902

Currently icon font contents are read out to screen readers. We want to move away from icon fonts anyway so this makes a change to swap out the external link icon with a background image.


Downside of this is that the SVG is single colour. Does this feel like a big deal for this fix? Feels like a reasonable trade-off