### PR TITLE
Add consistent dev script for demo and docs site

### DIFF
--- a/demo/Procfile.dev
+++ b/demo/Procfile.dev
@@ -1,0 +1,2 @@
+web: bin/rails server -p 3000
+webpack: bin/webpack-dev-server

--- a/demo/bin/dev
+++ b/demo/bin/dev
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+if ! command -v foreman &> /dev/null
+then
+  echo "Installing foreman..."
+  gem install foreman
+fi
+
+foreman start -f Procfile.dev "$@"

--- a/design-system-docs/bin/dev
+++ b/design-system-docs/bin/dev
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -e
+
+cd "$(dirname "$0")/.."
+
+./bin/bridgetown start


### PR DESCRIPTION
Switching between the demo and docs site it would be useful to have a consistent start up script. A common Rails convention for this seems to be to have a `bin/dev` script.

**Bridgetown**

Adds a basic `bin/dev` script which delegates to `bin/bridgetown` start

**Demo app**

Adds a basic `bin/dev` script which uses foreman along with a Procfile to run the server and webpack-dev-server in a single command. Approach pinched from https://github.com/rails/cssbundling-rails

---

The upshot is that for each sub-project you can consistently run `bin/setup` to set up the project and `bin/dev` to start a dev server.