### PR TITLE
fix: closing greedy nav on tab out if there are no header links

### DIFF
--- a/src/ts/greedy-nav/GreedyNav.ts
+++ b/src/ts/greedy-nav/GreedyNav.ts
@@ -604,20 +604,23 @@ export class GreedyNavMenu {
       navDropdownToggle.addEventListener(
         blurEventName,
         (e: FocusEvent): void => {
-          let lastItem: Nullable<HTMLElement> | undefined = null;
-          const headerLinksInNav: Nullable<HTMLElement> =
-            document.querySelector(
-              `${this.navDropdownSelector} .js-cads-copy-into-nav`
-            );
+          let lastItem: HTMLElement | null | undefined;
+          const headerLinksInNav: HTMLElement | null = document.querySelector(
+            `${this.navDropdownSelector} .js-cads-copy-into-nav`
+          );
 
-          if (headerLinksInNav?.offsetParent !== null) {
-            lastItem = headerLinksInNav?.querySelector(
+          if (headerLinksInNav?.offsetParent) {
+            lastItem = headerLinksInNav?.querySelector<HTMLElement>(
               '.js-cads-close-on-blur'
             );
-          } else {
+          } else if (headerLinksInNav?.offsetParent === null) {
+            // offsetParent returns null in this case as the header links in the nav have display: none
+            // using nth-last-child(2) as the last-child in this case is the hidden header nav links
             lastItem = this.navDropdown?.querySelector(
               `li:nth-last-child(2) a`
             );
+          } else {
+            lastItem = this.navDropdown?.querySelector(`li:last-child a`);
           }
 
           if (!parent(relatedTarget(e, this.document), this.toggleWrapper)) {


### PR DESCRIPTION
Fixes: Greedy Nav doesn't close when tabbing out if no header links are present [NP-1755](https://citizensadvice.atlassian.net/jira/software/c/projects/NP/boards/208?modal=detail&selectedIssue=NP-1755&search=greedy)
