### PR TITLE
Asset hyperlink icons work with screen readers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 **New**
+
+- 🔗 Links: Document links no longer present their appended file icon to screen
+  readers
 - 🔗 Links: Relflow long links so they do not add scrollbars to the viewport
 - 🔓 Disclosure: Adds new `Disclosure` view component
 - 🥾 Footer: Add more flexible `feedback_link` slot and deprecate `feedback_url` argument.

--- a/engine/app/components/citizens_advice_components/asset_hyperlink.html.haml
+++ b/engine/app/components/citizens_advice_components/asset_hyperlink.html.haml
@@ -1,5 +1,5 @@
 %a{ href: href }
   = description
   %span.cads-asset-type<
-    %span.cads-icon_file
+    %span.cads-icon_file{ "aria-hidden": "true" }
     \ #{number_to_human_size(size)}

--- a/styleguide/examples/asset_hyperlink/example.html
+++ b/styleguide/examples/asset_hyperlink/example.html
@@ -1,6 +1,6 @@
 <a href="https://example.com">
   Test PDF
   <span class="cads-asset-type"
-    ><span class="cads-icon_file"></span> 6.15 MB</span
+    ><span class="cads-icon_file" aria-hidden="true"></span> 6.15 MB</span
   >
 </a>


### PR DESCRIPTION
We were migrating a corporate page[1] and when we ran an accessibility check we found that the icons used in asset download links don't read meaningfully to screenreaders[2]. And would be a possible fail at level A.

[1] https://cdn.develop.content.citizensadvice.org.uk/about-us/our-work/our-prevention-work/BESN
[2] https://www.w3.org/WAI/WCAG21/Understanding/non-text-content.html