### PR TITLE
Run CI on pull_request event

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -1,6 +1,7 @@
 name: Continuous Integration
 on:
   push:
+  pull_request:
   schedule:
     - cron: '0 2 * * *'
 

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -1,6 +1,8 @@
 name: Continuous Integration
 on:
   push:
+    branches:
+      - main
   pull_request:
   schedule:
     - cron: '0 2 * * *'


### PR DESCRIPTION
Pull requests from forks like https://github.com/citizensadvice/design-system/pull/1925 are not running any jobs. This is probably because we only trigger on the push event. It's likely we should be running on the `pull_request` event too.