### PR TITLE
Avoid double adding previews

### DIFF
--- a/demo/config/application.rb
+++ b/demo/config/application.rb
@@ -25,6 +25,5 @@ module Demo
   class Application < Rails::Application
     config.load_defaults 6.1
     config.view_component.default_preview_layout = "component_preview"
-    config.view_component.preview_paths << CitizensAdviceComponents::Engine.root.join("previews")
   end
 end


### PR DESCRIPTION
Component previews are already added to preview_paths by the engine code. We occasionally see odd load errors for some component previews and I wonder if it's because we were adding the preview paths twice. Either way, it's redundant so let's remove it.