### PR TITLE
Run docs build only when a label is added

### DIFF
--- a/.github/workflows/docs-workflow.yml
+++ b/.github/workflows/docs-workflow.yml
@@ -3,9 +3,12 @@ name: Design System Docs
 on:
   pull_request:
     types:
-      - opened # a PR is created
-      - synchronize # existing PR is updated
+      # Trigger when the pull request is labelled.
+      # Used to only deploy previews when the "docs preview" label is added.
       - labeled
+      # Trigger when an existing PR is updated.
+      # Used to make sure new previews are deployed for changes after the label is added.
+      - synchronize
   release:
     types:
       - created

--- a/.github/workflows/docs-workflow.yml
+++ b/.github/workflows/docs-workflow.yml
@@ -5,18 +5,19 @@ on:
     types:
       - opened # a PR is created
       - synchronize # existing PR is updated
+      - labeled
   release:
     types:
       - created
 
 jobs:
   # This job will:
-  #   * deploy a draft every time there is a pull request created or synchronized that is not on master branch
+  #   * deploy a draft every time there is a pull request created that has the expected label
   #   * comment on that pull request with the deploy URL
   deployPRDraft:
     name: Deploy draft to Netlify
     runs-on: ubuntu-latest
-    if: github.actor != 'dependabot[bot]' && github.event_name == 'pull_request' && github.ref != 'refs/heads/master'
+    if: github.actor != 'dependabot[bot]' && github.event_name == 'pull_request' && github.event.label.name == 'docs preview'
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3

--- a/.github/workflows/docs-workflow.yml
+++ b/.github/workflows/docs-workflow.yml
@@ -17,7 +17,7 @@ jobs:
   deployPRDraft:
     name: Deploy draft to Netlify
     runs-on: ubuntu-latest
-    if: github.actor != 'dependabot[bot]' && github.event_name == 'pull_request' && github.event.label.name == 'docs preview'
+    if: github.actor != 'dependabot[bot]' && github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'docs preview')
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,4 +4,5 @@
 - [Setup](./contributing/setup.md)
 - [Testing](./contributing/testing.md)
 - [Release process](./contributing/release-process.md)
+- [Documentation site](./contributing/documentation-site.md)
 - [Architecture Decision Records](./contributing/adr/)

--- a/contributing/adr/0004-only-run-docs-preview-build-when-a-label-is-added.md
+++ b/contributing/adr/0004-only-run-docs-preview-build-when-a-label-is-added.md
@@ -1,0 +1,31 @@
+# 4. Only run docs preview build when a label is added
+
+Date: 2022-04-20
+
+## Status
+
+Proposed
+
+## Context
+
+We currently run docs preview builds on all pull requests when they are opened or updated. This has a couple of trade-offs:
+
+- Previews are generated for every PR which can add noise if you don't want one, or are not ready for one yet.
+- Causes an error on pull requests from forks as the workflow doesn't have access to secrets
+
+## Decision
+
+We will only run the docs preview work flow when a "docs preview" label has been added to the pull request.
+
+## Consequences
+
+**Pros:**
+
+- Avoids noise on pull requests where you might not want, or be ready, for a docs site preview
+- Side-steps an issue with pull requests from forks where the workflow doesn't have access to secrets
+
+**Cons:**
+
+- Previews are not automatic, you have to to request one.
+
+We should revisit this decision if the need for automatic previews outweighs the benefits from having them be opt-in.

--- a/contributing/adr/README.md
+++ b/contributing/adr/README.md
@@ -3,5 +3,6 @@
 - [1. Record architecture decisions](0001-record-architecture-decisions.md)
 - [2. Run automated tests against demo app](0002-run-automated-tests-against-demo-app.md)
 - [3. Use Cypress for automated tests](0003-use-cypress-for-automated-tests.md)
+- [4. Only run docs preview build when a label is added](0004-only-run-docs-preview-build-when-a-label-is-added.md)
 
 We recommend installing and using [adr-tools](https://github.com/npryce/adr-tools) to create new decision records but you can also copy a previous one as a template.

--- a/contributing/documentation-site.md
+++ b/contributing/documentation-site.md
@@ -1,0 +1,7 @@
+# Documentation site
+
+We have a new documentation site under `design-system-docs`.
+
+This docs site is deployed via Netlify which allows us to access previews of work in progress changes. You can request a preview deploy for any pull request by adding the "docs preview" label.
+
+When the preview is ready a comment will be added to your pull request with a link to the preview site.

--- a/contributing/documentation-site.md
+++ b/contributing/documentation-site.md
@@ -5,3 +5,5 @@ We have a new documentation site under `design-system-docs`.
 This docs site is deployed via Netlify which allows us to access previews of work in progress changes. You can request a preview deploy for any pull request by adding the "docs preview" label.
 
 When the preview is ready a comment will be added to your pull request with a link to the preview site.
+
+This should not trigger a preview as the label has been removed.

--- a/contributing/documentation-site.md
+++ b/contributing/documentation-site.md
@@ -7,3 +7,5 @@ This docs site is deployed via Netlify which allows us to access previews of wor
 When the preview is ready a comment will be added to your pull request with a link to the preview site.
 
 This should not trigger a preview as the label has been removed.
+
+Note: Pull requests from forks will not be able to deploy a preview to Netlify as the workflow will not have access to the required secrets.


### PR DESCRIPTION
We currently run docs preview builds on all pull requests when they are opened or updated. This has a couple of trade-offs:

- Previews are generated for every PR which can add noise if you don't want one, or are not ready for one yet.
- Causes an error on pull requests from forks as the workflow doesn't have access to secrets

This pull request makes docs site previews opt-in by only running them when a label is added. Included the full context in an ADR added to this pull request.