### PR TITLE
Release v5.3.0-alpha.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## <sub>v5.3.0-alpha.0</sub>
+
+#### _Apr. 21, 2022_
+
 **New**
 
 - 🔗 Links: Document links no longer present their appended file icon to screen

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@citizensadvice/design-system",
-  "version": "5.2.0",
+  "version": "5.3.0-alpha.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@citizensadvice/design-system",
-  "version": "5.2.0",
+  "version": "5.3.0-alpha.0",
   "description": "Citizens Advice Design System",
   "repository": "https://github.com/citizensadvice/design-system",
   "author": "Citizens Advice",


### PR DESCRIPTION
Includes the following

**New**

🔗 Links: Document links no longer present their appended file icon to screen readers
🔗 Links: Relflow long links so they do not add scrollbars to the viewport
🔓 Disclosure: Adds new Disclosure view component
🥾 Footer: Add more flexible feedback_link slot and deprecate feedback_url argument.
🥾 Footer: Support external icon for column links and deprecateicon property. Previous option was too generic, only support external links.
🥾 Footer: Fix accessibility issue with external link icons using old icon font and reading out content. Use new SVG icons.
🛤️ Expand version ranges for citizens_advice_components to support Rails 7

**Bugfixes**

🔗 Links: Fix external link styles when used outside of the main [www.citizensadvice.org.uk](http://www.citizensadvice.org.uk/)[](https://github.com/citizensadvice/design-system/blob/2f96f398c7bdf9dcc1cce6c3951e9ebb9881ecde/CHANGELOG.md#v520) domain.
🥾 Footer: Use simpler Time.current.year rather than Time.zone.today.year for footer year. Allows component to be more portable and usable outside of a Rails context.
🤫 Fix deprecation warning with newer versions of view_component