### PR TITLE
Compile assets in demo app test environment

### DIFF
--- a/contributing/testing.md
+++ b/contributing/testing.md
@@ -1,99 +1,32 @@
 # Testing
 
-## JS and Typescript
+## Linting
 
-We use Jest:
+We run `eslint`, `stylelint`, and `prettier` as lint checks.
+
+From the project root run:
+
+```sh
+npm run lint
+```
+
+## Unit tests
+
+We use Jest for basic unit tests for our JavaScript as well as testing sass output:
+
+From the project root run:
 
 ```sh
 npm run test
 ```
 
-from the project root.
+## Cypress tests
 
-## Acceptance testing
-
-We use Cypress, see the [demo app README for instructions on how to run these](../demo/README.md)
+We use Cypress for behavioural tests, see the [demo app README for instructions on how to run these](../demo/README.md)
 
 ## Visual regression testing
 
-We use BackstopJS to automate visual regression testing of components by comparing DOM screenshots over time.
-
-### Usage
-
-The tests are run inside of Docker to ensure consistency accross different environments (mac, windows and linux). You can install Docker by following the instructions at [docker.com](https://www.docker.com/products/docker-desktop).
-
-Backstop tests are run against the demo app. The following commands should all be run within `demo/`.
-
-#### Set up the demo app
-
-You can install backstop and set up the demo app by running the following from within the `demo/` directory:
-
-```sh
-./bin/setup
-```
-
-#### Compile packs
-
-**Note:** Ensure the build is up to date before compiling packs by running:
-
-```sh
-npm run build
-```
-
-from the project root.
-
-You will need to compile any changes to the build for the test environment, in
-the `demo` directory:
-
-```sh
-RAILS_ENV=test bin/rails webpacker:compile
-```
-
-You can also clobber the test packs:
-
-```sh
-RAILS_ENV=test bin/rails webpacker:clobber
-```
-
-#### Run tests
-
-First, run the demo app using:
-
-```sh
-./bin rails server -e test
-```
-
-With the demo app running, you can start the backstop tests using:
-
-```sh
-npm run backstop
-```
-
-#### Open the report
-
-After a test run is complete you can run view the report in a browser using:
-
-```sh
-npm run backstop:report
-```
-
-#### Approve changes
-
-If the test you ran looks good, then go ahead and approve it. Approving changes will update your reference files with the results from your last test. Future tests are compared against your most recent approved test screenshots.
-
-```
-npm run backstop:approve
-```
-
-### Run the tests for a specific set of scenarios:
-
-You can run tests for a specific set of scenarios by passing a filter to the backstop command where `Example` is the search term you want to filter by.
-
-```
-npm run backstop -- --filter=Example
-```
-
-For more advanced details see the [BackstopJS Github's page](https://github.com/garris/BackstopJS)
+We use Backstop for visual regression tests, see the [demo app README for instructions on how to run these](../demo/README.md)
 
 ## Accessibility testing
 

--- a/demo/README.md
+++ b/demo/README.md
@@ -10,7 +10,7 @@ This app:
 
 ### Run the setup script:
 
-```shell
+```sh
 ./bin/setup
 ```
 
@@ -18,22 +18,22 @@ This app:
 
 Ensure the build is up to date before compiling packs by running:
 
-```shell
+```sh
 npm run build
 ```
 
 from the project root and then:
 
-```shell
-RAILS_ENV=test ./bin/rails webpacker:compile
+```sh
+./bin/webpack
 ```
 
 from the `demo` directory.
 
 ### Start Rails:
 
-```shell
-./bin/rails s
+```sh
+./bin/dev
 ```
 
 The engine code bundles a set of component previews which can be seen at `http://localhost:3000/rails/view_components`.
@@ -51,3 +51,51 @@ Run all tests in a headless browser:
 ```
 ./bin/rails cypress:run
 ```
+
+## Running visual regression tests
+
+We use BackstopJS to automate visual regression testing of components by comparing DOM screenshots over time.
+
+### Usage
+
+The tests are run inside of Docker to ensure consistency across different environments (mac, windows and linux). You can install Docker by following the instructions at [docker.com](https://www.docker.com/products/docker-desktop).
+
+#### Run tests
+
+First, run the demo app using:
+
+```sh
+./bin rails server -e test
+```
+
+With the demo app running, you can start the backstop tests using:
+
+```sh
+npm run backstop
+```
+
+#### Open the report
+
+After a test run is complete you can run view the report in a browser using:
+
+```sh
+npm run backstop:report
+```
+
+#### Approve changes
+
+If the test you ran looks good, then go ahead and approve it. Approving changes will update your reference files with the results from your last test. Future tests are compared against your most recent approved test screenshots.
+
+```
+npm run backstop:approve
+```
+
+### Run the tests for a specific set of scenarios:
+
+You can run tests for a specific set of scenarios by passing a filter to the backstop command where `Example` is the search term you want to filter by.
+
+```
+npm run backstop -- --filter=Example
+```
+
+For more advanced details see the [BackstopJS Github's page](https://github.com/garris/BackstopJS)

--- a/demo/config/webpacker.yml
+++ b/demo/config/webpacker.yml
@@ -77,15 +77,12 @@ development:
 
 test:
   <<: *default
-  compile: false
-
-  # Compile test packs to a separate directory
-  public_output_path: packs-test
+  compile: true
 
 production:
   <<: *default
 
-  # Production depends on precompilation of packs prior to booting for performance.
+  # Production depends on pre-compilation of packs prior to booting for performance.
   compile: false
 
   # Extract and emit a css file


### PR DESCRIPTION
This should improve the new setup workflow a bit as it stops cypress tests from relying on a specific test asset build.

We don't really care about different environments for the demo app so we can stand to have more parity between them. Allows the test environment to automatically compile assets if it needs to and bundles them in the same directory, no need for a separate packs-test directory.

Simplifies some of the documentation now there should be fewer gotchas.