### PR TITLE
Add basic foundations structure

### DIFF
--- a/design-system-docs/bridgetown.config.yml
+++ b/design-system-docs/bridgetown.config.yml
@@ -20,6 +20,9 @@ permalink: pretty
 template_engine: erb
 
 collections:
+  foundations:
+    output: true
+    name: Foundations
   component_docs:
     output: true
     sort_by: order

--- a/design-system-docs/src/_foundations/_defaults.yml
+++ b/design-system-docs/src/_foundations/_defaults.yml
@@ -1,0 +1,1 @@
+layout: foundations

--- a/design-system-docs/src/_foundations/icons.md
+++ b/design-system-docs/src/_foundations/icons.md
@@ -1,0 +1,5 @@
+---
+title: Icons
+---
+
+Icons should be informative and recognisable. They should only be used in a purposeful manner to maximise comprehension when you need to call attention to a particular action. Icons should be used in combination with a meaningful label or supporting text whenever possible. Avoid aria-labels if you are rendering the icon with visible text to prevent accessibility label duplication.

--- a/design-system-docs/src/_layouts/foundations.erb
+++ b/design-system-docs/src/_layouts/foundations.erb
@@ -1,0 +1,40 @@
+---
+layout: default
+---
+<%= render(CitizensAdviceComponents::Breadcrumbs.new(
+  links: [
+    { title: "Home", url: "/"},
+    { title: resource.collection.metadata.name, url: "/foundations" },
+    { title: resource.data.title }
+  ]
+)) %>
+
+<main id="cads-main-content" class="cads-grid-container">
+  <div class="cads-grid-row">
+    <div class="cads-grid-col-md-8">
+      <div class="cads-page-content">
+        <h1 class="cads-page-title"><%= resource.data.title %></h1>
+        <div class="cads-prose">
+          <%= content %>
+        </div>
+      </div>
+      <%= render "feedback_prompt" %>
+    </div>
+    <div class="cads-grid-col-md-4 sidebar">
+      <%=
+        render(CitizensAdviceComponents::SectionLinks.new(
+          title: "In this section",
+          section_title: resource.collection.metadata.name,
+          section_title_url: "/foundations"
+        )) do |c|
+          c.section_links(resource.collection.resources.map do |foundation|
+            { url: foundation.relative_url, title: foundation.data.title }
+          end)
+          # Need to pass in some content to avoid shadowing Bridgetowns content global
+          # We could probably avoid this by wrapping this in its own component?
+          ""
+        end
+      %>
+    </div>
+  </div>
+</main>

--- a/design-system-docs/src/_pages/foundations.erb
+++ b/design-system-docs/src/_pages/foundations.erb
@@ -1,0 +1,26 @@
+---
+title: Foundations
+layout: default
+---
+
+<%= render(CitizensAdviceComponents::Breadcrumbs.new(
+  links: [
+    { title: "Home", url: "/"},
+    { title: resource.data.title }
+  ]
+)) %>
+
+<main id="cads-main-content" class="cads-grid-container cads-page-content">
+  <div class="cads-grid-row">
+    <div class="cads-grid-col-md-8">
+      <h1 class="cads-page-title"><%= resource.data.title %></h1>
+      <div class="text-list">
+        <ul class="text-list__links">
+          <% collections.foundations.resources.each do |foundation| %>
+            <li><a href="<%= foundation.relative_url %>"><%= foundation.data.title %></a></li>
+          <% end %>
+        </ul>
+      </div>
+    </div>
+  </div>
+</main>


### PR DESCRIPTION
Extracts just the structural work for the foundations templates from work I've started on the icons page. Allows @marianayovcheva and I to use the same base to work from.

- Config
- Layout
- Index page
- Default frontmatter
- Minimal icons document