### PR TITLE
Add basic code styles to new docs site

### DIFF
--- a/design-system-docs/frontend/styles/_code.scss
+++ b/design-system-docs/frontend/styles/_code.scss
@@ -2,6 +2,14 @@
 // Code styles
 // ============================================================================
 
+code {
+  line-height: 1;
+  margin: 0 2px;
+  padding: $cads-spacing-1 $cads-spacing-2;
+  border-radius: $cads-border-radius;
+  background-color: #f8f8f8;
+}
+
 pre code {
   display: block;
   background: none;


### PR DESCRIPTION
Adds some basic inline code styles so they complement the existing block code examples.

<img width="713" alt="image" src="https://user-images.githubusercontent.com/123386/165980871-8af872b5-cdcc-4473-b88a-d5ab632bd2e5.png">

