### PR TITLE
feat: adding spacing & sizing page

### DIFF
--- a/design-system-docs/frontend/styles/_sizing-border.scss
+++ b/design-system-docs/frontend/styles/_sizing-border.scss
@@ -1,0 +1,19 @@
+.sizing-border {
+  display: inline-block;
+  width: 100px;
+  height: 40px;
+  vertical-align: middle;
+  border: solid $cads-border-width-small $cads-language__border-colour;
+  margin-left: 11px;
+  margin-right: 11px;
+
+  &--medium {
+    border: solid $cads-border-width-medium $cads-language__border-colour;
+    margin-left: 10px;
+  }
+
+  &--large {
+    border: solid $cads-border-width-large $cads-language__border-colour;
+    margin-left: 10px;
+  }
+}

--- a/design-system-docs/frontend/styles/_spacing-block.scss
+++ b/design-system-docs/frontend/styles/_spacing-block.scss
@@ -1,0 +1,23 @@
+$cads-spacers: (
+  (
+    0: 0,
+    1: $cads-spacing-1,
+    2: $cads-spacing-2,
+    3: $cads-spacing-3,
+    4: $cads-spacing-4,
+    5: $cads-spacing-5,
+    6: $cads-spacing-6,
+    7: $cads-spacing-7,
+  )
+);
+
+@each $size, $length in $cads-spacers {
+  .spacing-block-#{$size} {
+    display: inline-block;
+    vertical-align: middle;
+    background: rgba($cads-language__border-colour, 0.4);
+    border: dotted 1px $cads-language__border-colour;
+    width: $length;
+    height: $length;
+  }
+}

--- a/design-system-docs/frontend/styles/index.scss
+++ b/design-system-docs/frontend/styles/index.scss
@@ -4,3 +4,5 @@
 @import 'code';
 @import 'examples';
 @import 'feedback';
+@import 'sizing-border';
+@import 'spacing-block';

--- a/design-system-docs/src/_components/foundations/borders_table.rb
+++ b/design-system-docs/src/_components/foundations/borders_table.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module Foundations
+  class BordersTable < ViewComponent::Base
+    include Bridgetown::ViewComponentHelpers
+
+    def call
+      render(
+        CitizensAdviceComponents::Table.new(
+          header: %w[Variables Example Size],
+          rows: [
+            [
+              "$cads-border-width-small",
+              "<div class='sizing-border' />",
+              "1px"
+            ],
+            [
+              "$cads-border-width-medium",
+              "<div class='sizing-border sizing-border--medium' />",
+              "2px"
+            ],
+            [
+              "$cads-border-width-large",
+              "<div class='sizing-border sizing-border--large' />",
+              "4px"
+            ],
+          ])
+      )
+    end
+  end
+end

--- a/design-system-docs/src/_components/foundations/spacing_table.rb
+++ b/design-system-docs/src/_components/foundations/spacing_table.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+module Foundations
+  class SpacingTable < ViewComponent::Base
+    include Bridgetown::ViewComponentHelpers
+
+    def call
+      render(
+        CitizensAdviceComponents::Table.new(
+          header: %w[Variables Example Size],
+          rows: [
+            [
+              "$cads-spacing-1",
+              "<div class='spacing-block-1' />",
+              "4px"
+            ],
+            [
+              "$cads-spacing-2",
+              "<div class='spacing-block-2' />",
+              "8px"
+            ],
+            [
+              "$cads-spacing-3",
+              "<div class='spacing-block-3' />",
+              "12px"
+            ],
+            [
+              "$cads-spacing-4",
+              "<div class='spacing-block-4' />",
+              "16px"
+            ],
+            [
+              "$cads-spacing-5",
+              "<div class='spacing-block-5' />",
+              "24px"
+            ],
+            [
+              "$cads-spacing-6",
+              "<div class='spacing-block-6' />",
+              "32px"
+            ],
+            [
+              "$cads-spacing-7",
+              "<div class='spacing-block-7' />",
+              "40px"
+            ],
+          ])
+      )
+    end
+  end
+end

--- a/design-system-docs/src/_foundations/spacing-and-sizing.md
+++ b/design-system-docs/src/_foundations/spacing-and-sizing.md
@@ -8,76 +8,8 @@ All page content should be limited to 1200px wide. Use the `$cads-max-content-si
 
 Spacing variables can be used directly in your SASS.
 
-<%= render(
-CitizensAdviceComponents::Table.new(
-header: [
-"Variables",
-"Example",
-"Size"
-],
-rows: [
-[
-"$cads-spacing-1",
-"<div class='spacing-block-1' />",
-"4px"
-],
-[
-"$cads-spacing-2",
-"<div class='spacing-block-2' />",
-"8px"
-],
-[
-"$cads-spacing-3",
-"<div class='spacing-block-3' />",
-"12px"
-],
-[
-"$cads-spacing-4",
-"<div class='spacing-block-4' />",
-"16px"
-],
-[
-"$cads-spacing-5",
-"<div class='spacing-block-5' />",
-"24px"
-],
-[
-"$cads-spacing-6",
-"<div class='spacing-block-6' />",
-"32px"
-],
-[
-"$cads-spacing-7",
-"<div class='spacing-block-7' />",
-"40px"
-],
-])
-) %>
+<%= render(Foundations::SpacingTable.new) %>
 
 ## Borders widths
 
-<%= render(
-CitizensAdviceComponents::Table.new(
-header: [
-"Variables",
-"Example",
-"Size"
-],
-rows: [
-[
-"$cads-border-width-small",
-"<div class='sizing-border' />",
-"1px"
-],
-[
-"$cads-border-width-medium",
-"<div class='sizing-border sizing-border--medium' />",
-"2px"
-],
-[
-"$cads-border-width-large",
-"<div class='sizing-border sizing-border--large' />",
-"4px"
-],
-])
-) %>
+<%= render(Foundations::BordersTable.new) %>

--- a/design-system-docs/src/_foundations/spacing-and-sizing.md
+++ b/design-system-docs/src/_foundations/spacing-and-sizing.md
@@ -1,0 +1,83 @@
+---
+title: Spacing & Sizing
+---
+
+All page content should be limited to 1200px wide. Use the `$cads-max-content-size` variable for setting the `width` or apply the `.cads-max-content-width` class to restrict the content of your components on large screen sizes.
+
+## Spacing
+
+Spacing variables can be used directly in your SASS.
+
+<%= render(
+CitizensAdviceComponents::Table.new(
+header: [
+"Variables",
+"Example",
+"Size"
+],
+rows: [
+[
+"$cads-spacing-1",
+"<div class='spacing-block-1' />",
+"4px"
+],
+[
+"$cads-spacing-2",
+"<div class='spacing-block-2' />",
+"8px"
+],
+[
+"$cads-spacing-3",
+"<div class='spacing-block-3' />",
+"12px"
+],
+[
+"$cads-spacing-4",
+"<div class='spacing-block-4' />",
+"16px"
+],
+[
+"$cads-spacing-5",
+"<div class='spacing-block-5' />",
+"24px"
+],
+[
+"$cads-spacing-6",
+"<div class='spacing-block-6' />",
+"32px"
+],
+[
+"$cads-spacing-7",
+"<div class='spacing-block-7' />",
+"40px"
+],
+])
+) %>
+
+## Borders widths
+
+<%= render(
+CitizensAdviceComponents::Table.new(
+header: [
+"Variables",
+"Example",
+"Size"
+],
+rows: [
+[
+"$cads-border-width-small",
+"<div class='sizing-border' />",
+"1px"
+],
+[
+"$cads-border-width-medium",
+"<div class='sizing-border sizing-border--medium' />",
+"2px"
+],
+[
+"$cads-border-width-large",
+"<div class='sizing-border sizing-border--large' />",
+"4px"
+],
+])
+) %>


### PR DESCRIPTION
Adding Spacing & Sizing page. Using the existing cads table component. Moved and renamed already existing css from the styleguide to the docs (i.e `_spacing-block.scss` and `_sizing-border.scss`)