### PR TITLE
Add support for component arguments table

### DIFF
--- a/design-system-docs/src/_component_docs/targeted-content.md
+++ b/design-system-docs/src/_component_docs/targeted-content.md
@@ -60,3 +60,9 @@ If you are using the `citizens_advice_components` gem you call the component fro
   end
 %>
 ```
+
+### Component arguments
+
+The component accepts a `content` block for the main contents along with the following arguments:
+
+<%= render Shared::ArgumentsTable.new(:targeted_content) %>

--- a/design-system-docs/src/_components/shared/arguments_table.rb
+++ b/design-system-docs/src/_components/shared/arguments_table.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module Shared
+  class ArgumentsTable < ViewComponent::Base
+    Bridgetown::ViewComponentHelpers.allow_rails_helpers :tag
+
+    include Bridgetown::ViewComponentHelpers
+
+    def initialize(component_name)
+      super
+
+      @component_name = component_name
+      @site = Bridgetown::Current.site
+    end
+
+    def call
+      render CitizensAdviceComponents::Table.new(
+        header: %w[Argument Description],
+        rows: data.map do |item|
+          [tag.code(item[:argument]), item[:description]]
+        end
+      )
+    end
+
+    def render?
+      data.any?
+    end
+
+    def data
+      # Maps to keys in _data/component_arguments.yml
+      @site.data.component_arguments[@component_name].to_a
+    end
+  end
+end

--- a/design-system-docs/src/_data/component_arguments.yml
+++ b/design-system-docs/src/_data/component_arguments.yml
@@ -1,0 +1,11 @@
+targeted_content:
+  - argument: id
+    description: Required, unique ID
+  - argument: title
+    description: Required, title string
+  - argument: type
+    description: Optional, one of public or adviser. Defaults to public
+  - argument: heading_level
+    description: Optional, sets the heading level of the title. Defaults to 2
+  - argument: close_button
+    description: Optional, include close button at the end of content. Defaults to true


### PR DESCRIPTION
Extracts out a revised approach to component arguments tables from https://github.com/citizensadvice/design-system/pull/1874

Longer term we'd like to pull this data from yard or something similar, so using an approach that pulls from data files makes sense for now.

Makes a simple `_data/component_arguments.yml` file containing argument data and then extracts that within a shared component based on a key.

<img width="736" alt="Screenshot 2022-05-04 at 17 34 47" src="https://user-images.githubusercontent.com/123386/166728881-5fd30f8e-9b44-432a-9161-5185331de8ed.png">
