### PR TITLE
Migrate Grid foundations

### DIFF
--- a/design-system-docs/bridgetown.config.yml
+++ b/design-system-docs/bridgetown.config.yml
@@ -30,6 +30,6 @@ collections:
     permalink: /components/:slug/
   component_examples:
     output: true
-    permalink: /examples/:slug/
+    permalink: /examples/:categories/:slug/
 # pagination:
 #   enabled: true

--- a/design-system-docs/frontend/styles/_examples.scss
+++ b/design-system-docs/frontend/styles/_examples.scss
@@ -4,12 +4,20 @@
 
 .component-example {
   border: 1px solid $cads-language__border-colour;
-  padding: $cads-spacing-5;
   margin-bottom: $cads-spacing-6;
+}
+.component-example__links,
+.component-example__source {
+  padding: $cads-spacing-3 $cads-spacing-4;
 }
 .component-example__links {
   text-align: right;
-  margin-bottom: $cads-spacing-5;
+  @include cads-typographic-scale-text-small();
+}
+.component-example__preview {
+  border: solid $cads-language__border-colour;
+  border-width: 1px 0;
+  padding: $cads-spacing-4;
 }
 .component-example__iframe {
   display: block;
@@ -19,7 +27,6 @@
   min-width: 230px;
   min-height: 60px;
   overflow: auto;
-  margin-bottom: $cads-spacing-4;
 }
 .component-example__source {
   .cads-disclosure {
@@ -28,5 +35,8 @@
     &:last-of-type {
       margin-bottom: 0;
     }
+  }
+  .cads-disclosure__toggle {
+    @include cads-typographic-scale-text-small();
   }
 }

--- a/design-system-docs/frontend/styles/_foundations.scss
+++ b/design-system-docs/frontend/styles/_foundations.scss
@@ -1,6 +1,15 @@
 // ============================================================================
-// Icons
+// Foundations
 // ============================================================================
+
+// Grid examples
+
+.grid-example {
+  padding: $cads-spacing-4;
+  background-color: $cads-palette__light-grey;
+}
+
+// Icons
 
 .icon-grid {
   display: grid;

--- a/design-system-docs/frontend/styles/index.scss
+++ b/design-system-docs/frontend/styles/index.scss
@@ -3,7 +3,7 @@
 @import 'layout';
 @import 'code';
 @import 'examples';
-@import 'icons';
+@import 'foundations';
 @import 'feedback';
 @import 'sizing-border';
 @import 'spacing-block';

--- a/design-system-docs/src/_component_docs/_defaults.yml
+++ b/design-system-docs/src/_component_docs/_defaults.yml
@@ -1,0 +1,1 @@
+layout: component

--- a/design-system-docs/src/_component_docs/targeted-content.md
+++ b/design-system-docs/src/_component_docs/targeted-content.md
@@ -1,5 +1,4 @@
 ---
-layout: component
 title: Targeted Content
 ---
 
@@ -26,11 +25,11 @@ If you find yourself using targeted content to do this, think about:
 
 ### Default variant
 
-<%= render(Shared::ComponentExample.new("targeted_content_default")) %>
+<%= render(Shared::ComponentExample.new(:targeted_content, :default)) %>
 
 ### Adviser variant
 
-<%= render(Shared::ComponentExample.new("targeted_content_adviser")) %>
+<%= render(Shared::ComponentExample.new(:targeted_content, :adviser)) %>
 
 ## JavaScript behaviour
 

--- a/design-system-docs/src/_component_examples/_defaults.yml
+++ b/design-system-docs/src/_component_examples/_defaults.yml
@@ -1,0 +1,4 @@
+layout: component_example
+show_html: true
+show_source: true
+iframe: false

--- a/design-system-docs/src/_component_examples/_foundations/_defaults.yml
+++ b/design-system-docs/src/_component_examples/_foundations/_defaults.yml
@@ -1,0 +1,3 @@
+category: foundations
+show_source: false
+iframe: true

--- a/design-system-docs/src/_component_examples/_foundations/grid_basic.erb
+++ b/design-system-docs/src/_component_examples/_foundations/grid_basic.erb
@@ -1,0 +1,12 @@
+---
+title: Basic grid
+---
+<div class="cads-grid-container">
+  <div class="cads-grid-row">
+    <div class="cads-grid-col-8">
+      <div class="grid-example">
+        This text is constrained to 8 columns
+      </div>
+    </div>
+  </div>
+</div>

--- a/design-system-docs/src/_component_examples/_foundations/grid_multi_column.erb
+++ b/design-system-docs/src/_component_examples/_foundations/grid_multi_column.erb
@@ -1,0 +1,13 @@
+---
+title: Multi column grid
+---
+<div class="cads-grid-container">
+  <div class="cads-grid-row">
+    <div class="cads-grid-col-8">
+      <div class="grid-example">8 columns</div>
+    </div>
+    <div class="cads-grid-col-4">
+      <div class="grid-example">4 columns</div>
+    </div>
+  </div>
+</div>

--- a/design-system-docs/src/_component_examples/_foundations/grid_responsive.erb
+++ b/design-system-docs/src/_component_examples/_foundations/grid_responsive.erb
@@ -1,0 +1,10 @@
+---
+title: Responsive grid
+---
+<div class="cads-grid-container">
+  <div class="cads-grid-row">
+    <div class="cads-grid-col-md-8 cads-grid-col-lg-10">
+      <div class="grid-example">I vary based on breakpoint</div>
+    </div>
+  </div>
+</div>

--- a/design-system-docs/src/_component_examples/_targeted_content/_defaults.yml
+++ b/design-system-docs/src/_component_examples/_targeted_content/_defaults.yml
@@ -1,0 +1,1 @@
+category: targeted_content

--- a/design-system-docs/src/_component_examples/_targeted_content/adviser.erb
+++ b/design-system-docs/src/_component_examples/_targeted_content/adviser.erb
@@ -1,10 +1,8 @@
 ---
-title: Default
 ---
-<%= render(CitizensAdviceComponents::TargetedContent.new(
-  title: "If you are a citizen of a country outside the EU, EEA or Switzerland",
-  id: "targeted-content-123")
-) do %>
+<%= render(CitizensAdviceComponents::TargetedContent.new(type: :adviser,
+  title: "Students or self-sufficient people",
+  id: "targeted-content-adviser")) do %>
   <p>You should apply to the EU Settlement Scheme if both:</p>
   <ul>
     <li>you’re in the UK by 31 December 2020</li>

--- a/design-system-docs/src/_component_examples/_targeted_content/adviser.erb
+++ b/design-system-docs/src/_component_examples/_targeted_content/adviser.erb
@@ -1,4 +1,5 @@
 ---
+title: Adviser
 ---
 <%= render(CitizensAdviceComponents::TargetedContent.new(type: :adviser,
   title: "Students or self-sufficient people",

--- a/design-system-docs/src/_component_examples/_targeted_content/default.erb
+++ b/design-system-docs/src/_component_examples/_targeted_content/default.erb
@@ -1,4 +1,5 @@
 ---
+title: Default
 ---
 <%= render(CitizensAdviceComponents::TargetedContent.new(
   title: "If you are a citizen of a country outside the EU, EEA or Switzerland",

--- a/design-system-docs/src/_component_examples/_targeted_content/default.erb
+++ b/design-system-docs/src/_component_examples/_targeted_content/default.erb
@@ -1,9 +1,9 @@
 ---
-title: Adviser
 ---
-<%= render(CitizensAdviceComponents::TargetedContent.new(type: :adviser,
-  title: "Students or self-sufficient people",
-  id: "targeted-content-adviser")) do %>
+<%= render(CitizensAdviceComponents::TargetedContent.new(
+  title: "If you are a citizen of a country outside the EU, EEA or Switzerland",
+  id: "targeted-content-123")
+) do %>
   <p>You should apply to the EU Settlement Scheme if both:</p>
   <ul>
     <li>you’re in the UK by 31 December 2020</li>

--- a/design-system-docs/src/_components/shared/component_example.erb
+++ b/design-system-docs/src/_components/shared/component_example.erb
@@ -12,11 +12,15 @@
     <% end %>
   </div>
   <div class="component-example__source">
-    <%= render(CitizensAdviceComponents::Disclosure.new(closed_summary: "HTML code for #{example.data.title.downcase} example")) do %>
-      <pre class="highlight"><code><%= raw highlighted_html %></code></pre>
+    <% if show_html? %>
+      <%= render(CitizensAdviceComponents::Disclosure.new(closed_summary: "HTML code for #{example.data.title.downcase} example")) do %>
+        <pre class="highlight"><code><%= raw highlighted_html %></code></pre>
+      <% end %>
     <% end %>
-    <%= render(CitizensAdviceComponents::Disclosure.new(closed_summary: "ERB code for #{example.data.title.downcase} example")) do %>
-      <pre class="highlight"><code><%= raw highlighted_source %></code></pre>
+    <% if show_source? %>
+      <%= render(CitizensAdviceComponents::Disclosure.new(closed_summary: "ERB code for #{example.data.title.downcase} example")) do %>
+        <pre class="highlight"><code><%= raw highlighted_source %></code></pre>
+      <% end %>
     <% end %>
   </div>
 </div>

--- a/design-system-docs/src/_components/shared/component_example.rb
+++ b/design-system-docs/src/_components/shared/component_example.rb
@@ -6,11 +6,11 @@ module Shared
   class ComponentExample < ViewComponent::Base
     include Bridgetown::ViewComponentHelpers
 
-    def initialize(slug, iframe: false)
+    def initialize(category, slug)
       super
 
+      @category = category
       @slug = slug
-      @iframe = iframe
       @site = Bridgetown::Current.site
     end
 
@@ -27,12 +27,21 @@ module Shared
 
     def find_example
       @site.collections.component_examples.resources.find do |resource|
-        resource.data.slug == @slug
+        resource.data.categories.include?(@category.to_s) &&
+          resource.data.slug == @slug.to_s
       end
     end
 
     def iframe?
-      @iframe.present?
+      example.data[:iframe].present?
+    end
+
+    def show_html?
+      example.data[:show_html].present?
+    end
+
+    def show_source?
+      example.data[:show_source].present?
     end
 
     def highlighted_source

--- a/design-system-docs/src/_foundations/grid.md
+++ b/design-system-docs/src/_foundations/grid.md
@@ -1,0 +1,27 @@
+---
+title: Grid
+---
+
+## Basic grids
+
+Grids are made up of three parts:
+
+- A `.cads-grid-container` wrapper element
+- One or more `.cads-grid-row` elements to demarcate grid rows
+- A combination of `.cads-grid-col-*` classes to demarcate grid columns
+
+<%= render(Shared::ComponentExample.new(:foundations, :grid_basic)) %>
+
+## Multi-column grids
+
+Grids are 12 columns by default (although this can be configured by overriding the `$cads-grid-columns` variable). You can combine a number of column sizes within a grid row.
+
+<%= render(Shared::ComponentExample.new(:foundations, :grid_multi_column)) %>
+
+## Responsive grids
+
+If you want variable grid columns at different breakpoints you can use `sm`, `md`, and `lg` variants of the `.cads-grid-col` classes to control this.
+
+The following example has a column which is 10 columns at large breakpoints, 8 at medium breakpoints, and full-width at small breakpoints.
+
+<%= render(Shared::ComponentExample.new(:foundations, :grid_responsive)) %>

--- a/design-system-docs/src/_layouts/component_example.erb
+++ b/design-system-docs/src/_layouts/component_example.erb
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="<%= site.locale %>">
+  <head>
+    <meta charset="utf-8" />
+    <%= seo %>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="robots" content="noindex, nofollow">
+    <link rel="stylesheet" href="<%= webpack_path "css" %>" />
+  </head>
+  <body>
+    <%= yield %>
+    <script src="<%= webpack_path "js" %>" defer></script>
+  </body>
+</html>


### PR DESCRIPTION
Migrates the grid foundations page to the new docs site. Closes #1973

Includes some notable changes to the component examples to allow us to decide whether to show html or erb source samples:

- Allow component examples to be grouped by category
- Allow option to show just HTML or just ERB source
- Update styles to improve boundary between example UI and the example itself
- Add a minimal component example layout

<img width="702" alt="image" src="https://user-images.githubusercontent.com/123386/166912830-45f5fe71-2b43-411e-9e8d-0ac9d651ccdb.png">
