### PR TITLE
Use capybara page method in tests

### DIFF
--- a/engine/spec/components/citizens_advice_components/asset_hyperlink_spec.rb
+++ b/engine/spec/components/citizens_advice_components/asset_hyperlink_spec.rb
@@ -11,6 +11,6 @@ RSpec.describe CitizensAdviceComponents::AssetHyperlink, type: :component do
 
   it "renders link with text" do
     render_inline component
-    expect(rendered_content).to have_link "Test PDF 6.15 MB"
+    expect(page).to have_link "Test PDF 6.15 MB"
   end
 end

--- a/engine/spec/components/citizens_advice_components/badge_spec.rb
+++ b/engine/spec/components/citizens_advice_components/badge_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe CitizensAdviceComponents::Badge, type: :component do
   it "does not render when type is missing" do
     without_fetch_or_fallback_raises do
       render_inline component
-      expect(page).not_to have_selector ".cads-badge"
+      expect(page).to have_no_selector ".cads-badge"
     end
   end
 

--- a/engine/spec/components/citizens_advice_components/badge_spec.rb
+++ b/engine/spec/components/citizens_advice_components/badge_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe CitizensAdviceComponents::Badge, type: :component do
   it "does not render when type is missing" do
     without_fetch_or_fallback_raises do
       render_inline component
-      expect(rendered_content.at(".cads-badge")).not_to be_present
+      expect(page).not_to have_selector ".cads-badge"
     end
   end
 
@@ -19,7 +19,7 @@ RSpec.describe CitizensAdviceComponents::Badge, type: :component do
 
     it "has the correct label" do
       render_inline component
-      expect(rendered_content).to have_selector ".cads-badge--example", text: "Example"
+      expect(page).to have_selector ".cads-badge--example", text: "Example"
     end
 
     context "when welsh language" do
@@ -27,7 +27,7 @@ RSpec.describe CitizensAdviceComponents::Badge, type: :component do
 
       it "has translated label" do
         render_inline component
-        expect(rendered_content).to have_text "Enghraifft"
+        expect(page).to have_text "Enghraifft"
       end
     end
   end
@@ -37,7 +37,7 @@ RSpec.describe CitizensAdviceComponents::Badge, type: :component do
 
     it "has the correct label" do
       render_inline component
-      expect(rendered_content).to have_selector ".cads-badge--important", text: "Important"
+      expect(page).to have_selector ".cads-badge--important", text: "Important"
     end
 
     context "when welsh language" do
@@ -45,7 +45,7 @@ RSpec.describe CitizensAdviceComponents::Badge, type: :component do
 
       it "has translated label" do
         render_inline component
-        expect(rendered_content).to have_text "Pwysig"
+        expect(page).to have_text "Pwysig"
       end
     end
   end
@@ -55,7 +55,7 @@ RSpec.describe CitizensAdviceComponents::Badge, type: :component do
 
     it "has the correct label" do
       render_inline component
-      expect(rendered_content).to have_selector ".cads-badge--adviser", text: "Adviser"
+      expect(page).to have_selector ".cads-badge--adviser", text: "Adviser"
     end
 
     context "when welsh language" do
@@ -63,7 +63,7 @@ RSpec.describe CitizensAdviceComponents::Badge, type: :component do
 
       it "has translated label" do
         render_inline component
-        expect(rendered_content).to have_text "Cynghorydd"
+        expect(page).to have_text "Cynghorydd"
       end
     end
   end

--- a/engine/spec/components/citizens_advice_components/button_spec.rb
+++ b/engine/spec/components/citizens_advice_components/button_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe CitizensAdviceComponents::Button, type: :component do
 
     it "renders button" do
       render_inline component
-      expect(rendered_content).to have_selector ".cads-button", text: "Example"
+      expect(page).to have_selector ".cads-button", text: "Example"
     end
   end
 
@@ -19,7 +19,7 @@ RSpec.describe CitizensAdviceComponents::Button, type: :component do
       it "renders a primary button" do
         without_fetch_or_fallback_raises do
           render_inline component
-          expect(rendered_content).to have_css ".cads-button__primary"
+          expect(page).to have_selector ".cads-button__primary"
         end
       end
     end
@@ -29,7 +29,7 @@ RSpec.describe CitizensAdviceComponents::Button, type: :component do
 
       it "renders a primary button" do
         render_inline component
-        expect(rendered_content).to have_css ".cads-button__primary"
+        expect(page).to have_selector ".cads-button__primary"
       end
     end
 
@@ -38,7 +38,7 @@ RSpec.describe CitizensAdviceComponents::Button, type: :component do
 
       it "renders a secondary button" do
         render_inline component
-        expect(rendered_content).to have_css ".cads-button__secondary"
+        expect(page).to have_selector ".cads-button__secondary"
       end
     end
   end
@@ -52,7 +52,7 @@ RSpec.describe CitizensAdviceComponents::Button, type: :component do
       it "renders a button type" do
         without_fetch_or_fallback_raises do
           render_inline component
-          expect(rendered_content).to have_css("[type='button']")
+          expect(page).to have_selector("[type='button']")
         end
       end
     end
@@ -62,7 +62,7 @@ RSpec.describe CitizensAdviceComponents::Button, type: :component do
 
       it "renders a submit button" do
         render_inline component
-        expect(rendered_content).to have_css("[type='submit']")
+        expect(page).to have_selector("[type='submit']")
       end
     end
   end
@@ -76,7 +76,7 @@ RSpec.describe CitizensAdviceComponents::Button, type: :component do
 
     it "allows additional attributes" do
       render_inline component
-      expect(rendered_content).to have_css("[data-testid='example']")
+      expect(page).to have_selector("[data-testid='example']")
     end
   end
 
@@ -88,7 +88,7 @@ RSpec.describe CitizensAdviceComponents::Button, type: :component do
         c.icon_left { "Left slot" }
       end
 
-      expect(rendered_content).to have_css ".cads-button__icon-left", text: "Left slot"
+      expect(page).to have_selector ".cads-button__icon-left", text: "Left slot"
     end
 
     it "renders right icon slot" do
@@ -96,7 +96,7 @@ RSpec.describe CitizensAdviceComponents::Button, type: :component do
         c.icon_right { "Right slot" }
       end
 
-      expect(rendered_content).to have_css ".cads-button__icon-right", text: "Right slot"
+      expect(page).to have_selector ".cads-button__icon-right", text: "Right slot"
     end
   end
 end

--- a/engine/spec/components/citizens_advice_components/contact_details_spec.rb
+++ b/engine/spec/components/citizens_advice_components/contact_details_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe CitizensAdviceComponents::ContactDetails, type: :component do
 
     it "renders content block" do
       render_inline component
-      expect(rendered_content).to have_selector ".cads-contact-details", text: "Example content"
+      expect(page).to have_selector ".cads-contact-details", text: "Example content"
     end
   end
 
@@ -15,7 +15,7 @@ RSpec.describe CitizensAdviceComponents::ContactDetails, type: :component do
 
     it "does not render" do
       render_inline component
-      expect(rendered_content).to have_no_selector ".cads-contact-details"
+      expect(page).to have_no_selector ".cads-contact-details"
     end
   end
 end

--- a/engine/spec/components/citizens_advice_components/footer_spec.rb
+++ b/engine/spec/components/citizens_advice_components/footer_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe CitizensAdviceComponents::Footer, type: :component do
       end
 
       it { is_expected.to have_link default_text, href: "https://example.com/" }
-      it { is_expected.not_to have_selector "[target=_blank]", text: default_text }
+      it { is_expected.to have_no_selector "[target=_blank]", text: default_text }
     end
 
     context "with custom title" do

--- a/engine/spec/components/citizens_advice_components/page_review_spec.rb
+++ b/engine/spec/components/citizens_advice_components/page_review_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe CitizensAdviceComponents::PageReview, type: :component do
 
   it "renders a formatted date" do
     render_inline component
-    expect(rendered_content).to have_text "Page last reviewed on 12 June 2021"
+    expect(page).to have_text "Page last reviewed on 12 June 2021"
   end
 
   context "when no date" do
@@ -21,7 +21,7 @@ RSpec.describe CitizensAdviceComponents::PageReview, type: :component do
 
     it "does not render" do
       render_inline component
-      expect(rendered_content).to have_no_selector ".cads-page-review"
+      expect(page).to have_no_selector ".cads-page-review"
     end
   end
 
@@ -30,7 +30,7 @@ RSpec.describe CitizensAdviceComponents::PageReview, type: :component do
 
     it "renders date with custom format" do
       render_inline component
-      expect(rendered_content).to have_text "Page last reviewed on Jun 12"
+      expect(page).to have_text "Page last reviewed on Jun 12"
     end
   end
 
@@ -39,7 +39,7 @@ RSpec.describe CitizensAdviceComponents::PageReview, type: :component do
 
     it "has translated date" do
       render_inline component
-      expect(rendered_content).to have_text "Adolygwyd y dudalen ar 12 Mehefin 2021"
+      expect(page).to have_text "Adolygwyd y dudalen ar 12 Mehefin 2021"
     end
   end
 end

--- a/engine/spec/components/citizens_advice_components/table_spec.rb
+++ b/engine/spec/components/citizens_advice_components/table_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe CitizensAdviceComponents::Table, type: :component do
 
     it "does not render" do
       render_inline component
-      expect(rendered_content).to have_no_table
+      expect(page).to have_no_table
     end
   end
 
@@ -32,7 +32,7 @@ RSpec.describe CitizensAdviceComponents::Table, type: :component do
 
     it "does not render" do
       render_inline component
-      expect(rendered_content).to have_no_table
+      expect(page).to have_no_table
     end
   end
 
@@ -60,7 +60,7 @@ RSpec.describe CitizensAdviceComponents::Table, type: :component do
 
     it "renders a caption" do
       render_inline component
-      expect(rendered_content).to have_css "caption", text: "Example caption"
+      expect(page).to have_selector "caption", text: "Example caption"
     end
   end
 


### PR DESCRIPTION
As of the latest version of view_component `rendered_component` was renamed to `rendered_content` and subsequently marked as deprecated.

Apparently the intent was for this to be a private method and for tests to prefer using the capybara `page` method.

Most of our tests already do this, so replace all remaining uses of `rendered_content` with `page`.
