### PR TITLE
Fix invalid table markup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## <sub>v5.3.0-alpha.1</sub>
 
+**Bugfixes**
+
+- 🧂 Tables: `thead` is no longer incorrectly nested within `tbody`
+
 #### _Jun. 1, 2022_
 
 **New**

--- a/engine/app/components/citizens_advice_components/table.html.haml
+++ b/engine/app/components/citizens_advice_components/table.html.haml
@@ -2,13 +2,12 @@
   %table.cads-table{ class: ("cads-table--captioned" if caption?) }
     - if caption?
       %caption= caption
+    %thead
+      %tr
+        - header.each do |head|
+          %th
+            %span.cads-table__content= head
     %tbody
-      %thead
-        %tr
-          - header.each do |head|
-            %th
-              %span.cads-table__content= head
-
       - rows.each do |row|
         %tr
           - header.zip(row).each do |(header, cell)|

--- a/engine/spec/components/citizens_advice_components/__snapshots__/table.snap
+++ b/engine/spec/components/citizens_advice_components/__snapshots__/table.snap
@@ -1,6 +1,5 @@
 <div class="cads-table-container">
 <table class="cads-table">
-<tbody>
 <thead>
 <tr>
 <th>
@@ -11,6 +10,7 @@
 </th>
 </tr>
 </thead>
+<tbody>
 <tr>
 <td>
 <span class="cads-table__th-heading">Your location</span>

--- a/styleguide/examples/sample_pages/content-sample.html
+++ b/styleguide/examples/sample_pages/content-sample.html
@@ -288,19 +288,19 @@
               <caption>
                 Post box collection times (Monday to Friday)
               </caption>
+              <thead>
+                <tr>
+                  <th>
+                    <span class="cads-table__content">Your location</span>
+                  </th>
+                  <th>
+                    <span class="cads-table__content"
+                      >Post box collection times</span
+                    >
+                  </th>
+                </tr>
+              </thead>
               <tbody>
-                <thead>
-                  <tr>
-                    <th>
-                      <span class="cads-table__content">Your location</span>
-                    </th>
-                    <th>
-                      <span class="cads-table__content"
-                        >Post box collection times</span
-                      >
-                    </th>
-                  </tr>
-                </thead>
                 <tr>
                   <td>
                     <span class="cads-table__th-heading">Your location</span>

--- a/styleguide/examples/table/example.html
+++ b/styleguide/examples/table/example.html
@@ -3,17 +3,17 @@
     <caption>
       Post box collection times (Monday to Friday)
     </caption>
+    <thead>
+      <tr>
+        <th>
+          <span class="cads-table__content">Your location</span>
+        </th>
+        <th>
+          <span class="cads-table__content">Post box collection times</span>
+        </th>
+      </tr>
+    </thead>
     <tbody>
-      <thead>
-        <tr>
-          <th>
-            <span class="cads-table__content">Your location</span>
-          </th>
-          <th>
-            <span class="cads-table__content">Post box collection times</span>
-          </th>
-        </tr>
-      </thead>
       <tr>
         <td>
           <span class="cads-table__th-heading">Your location</span>

--- a/styleguide/examples/table/long_table.html
+++ b/styleguide/examples/table/long_table.html
@@ -8,56 +8,56 @@
               <caption>
                 Client under pension age
               </caption>
+              <thead>
+                <tr>
+                  <th>
+                    <span class="cads-table__content">Rate</span>
+                  </th>
+                  <th>
+                    <span class="cads-table__content">From April 2010</span>
+                  </th>
+                  <th>
+                    <span class="cads-table__content">From April 2011</span>
+                  </th>
+                  <th>
+                    <span class="cads-table__content">From April 2012</span>
+                  </th>
+                  <th>
+                    <span class="cads-table__content">From April 2013</span>
+                  </th>
+                  <th>
+                    <span class="cads-table__content">From April 2014</span>
+                  </th>
+                  <th>
+                    <span class="cads-table__content">From April 2015</span>
+                  </th>
+                  <th>
+                    <span class="cads-table__content">From April 2016</span>
+                  </th>
+                  <th>
+                    <span class="cads-table__content">From April 2017</span>
+                  </th>
+                  <th>
+                    <span class="cads-table__content">From April 2018</span>
+                  </th>
+                  <th>
+                    <span class="cads-table__content">From April 2019</span>
+                  </th>
+                  <th>
+                    <span class="cads-table__content">From April 2020</span>
+                  </th>
+                  <th>
+                    <span class="cads-table__content">From April 2021</span>
+                  </th>
+                  <th>
+                    <span class="cads-table__content">From April 2022</span>
+                  </th>
+                  <th>
+                    <span class="cads-table__content">From April 2023</span>
+                  </th>
+                </tr>
+              </thead>
               <tbody>
-                <thead>
-                  <tr>
-                    <th>
-                      <span class="cads-table__content">Rate</span>
-                    </th>
-                    <th>
-                      <span class="cads-table__content">From April 2010</span>
-                    </th>
-                    <th>
-                      <span class="cads-table__content">From April 2011</span>
-                    </th>
-                    <th>
-                      <span class="cads-table__content">From April 2012</span>
-                    </th>
-                    <th>
-                      <span class="cads-table__content">From April 2013</span>
-                    </th>
-                    <th>
-                      <span class="cads-table__content">From April 2014</span>
-                    </th>
-                    <th>
-                      <span class="cads-table__content">From April 2015</span>
-                    </th>
-                    <th>
-                      <span class="cads-table__content">From April 2016</span>
-                    </th>
-                    <th>
-                      <span class="cads-table__content">From April 2017</span>
-                    </th>
-                    <th>
-                      <span class="cads-table__content">From April 2018</span>
-                    </th>
-                    <th>
-                      <span class="cads-table__content">From April 2019</span>
-                    </th>
-                    <th>
-                      <span class="cads-table__content">From April 2020</span>
-                    </th>
-                    <th>
-                      <span class="cads-table__content">From April 2021</span>
-                    </th>
-                    <th>
-                      <span class="cads-table__content">From April 2022</span>
-                    </th>
-                    <th>
-                      <span class="cads-table__content">From April 2023</span>
-                    </th>
-                  </tr>
-                </thead>
                 <tr>
                   <td>
                     <span class="cads-table__th-heading">Rate</span>

--- a/styleguide/examples/table/no_caption.html
+++ b/styleguide/examples/table/no_caption.html
@@ -1,16 +1,16 @@
 <div class="cads-table-container">
   <table class="cads-table">
+    <thead>
+      <tr>
+        <th>
+          <span class="cads-table__content">Your location</span>
+        </th>
+        <th>
+          <span class="cads-table__content">Post box collection times</span>
+        </th>
+      </tr>
+    </thead>
     <tbody>
-      <thead>
-        <tr>
-          <th>
-            <span class="cads-table__content">Your location</span>
-          </th>
-          <th>
-            <span class="cads-table__content">Post box collection times</span>
-          </th>
-        </tr>
-      </thead>
       <tr>
         <td>
           <span class="cads-table__th-heading">Your location</span>

--- a/styleguide/examples/targeted_content/adviser.html
+++ b/styleguide/examples/targeted_content/adviser.html
@@ -35,19 +35,17 @@
         <caption>
           Post box collection times (Monday to Friday)
         </caption>
+        <thead>
+          <tr>
+            <th>
+              <span class="cads-table__content">Your location</span>
+            </th>
+            <th>
+              <span class="cads-table__content">Post box collection times</span>
+            </th>
+          </tr>
+        </thead>
         <tbody>
-          <thead>
-            <tr>
-              <th>
-                <span class="cads-table__content">Your location</span>
-              </th>
-              <th>
-                <span class="cads-table__content"
-                  >Post box collection times</span
-                >
-              </th>
-            </tr>
-          </thead>
           <tr>
             <td>
               <span class="cads-table__th-heading">Your location</span>


### PR DESCRIPTION
I've been working with tables a lot this week and noticed that our markup is back to front 🙈 

Previously the thead was being rendered within the tbody. This is invalid according to the spec, a thead should always be outside the tbody.
