### PR TITLE
Add full colour foundations page

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -21,3 +21,4 @@ lib/
 /design-system-docs/output/
 /design-system-docs/.bridgetown-webpack/
 /design-system-docs/.bridgetown-cache/
+/design-system-docs/src/_data/colour_language.json

--- a/design-system-docs/Gemfile
+++ b/design-system-docs/Gemfile
@@ -26,8 +26,8 @@ gem "puma", "~> 5.6"
 gem "citizens_advice_components", path: "../engine"
 
 group :bridgetown_plugins do
-  gem "bridgetown-view-component", "~> 1.0"
   gem "bridgetown-seo-tag"
+  gem "bridgetown-view-component", "~> 1.0"
 end
 
 group :development, :test do

--- a/design-system-docs/frontend/styles/_foundations.scss
+++ b/design-system-docs/frontend/styles/_foundations.scss
@@ -36,3 +36,14 @@
     display: block;
   }
 }
+
+// Colours
+
+.colour-swatch {
+  display: block;
+  float: left;
+  width: 20px;
+  height: 20px;
+  margin-right: $cads-spacing-2;
+  box-shadow: 0 0 1px rgba(0, 0, 0, 0.5);
+}

--- a/design-system-docs/package.json
+++ b/design-system-docs/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "scripts": {
     "webpack-build": "webpack --mode production",
-    "webpack-dev": "webpack --mode development -w"
+    "webpack-dev": "webpack --mode development -w",
+    "update-colour-data": "npx sass-export --dependencies='../scss/1-settings/' ../scss/1-settings/_colour-language.scss -o src/_data/colour_language.json"
   },
   "devDependencies": {
     "@citizensadvice/design-system": "file:..",
@@ -15,6 +16,7 @@
     "mini-css-extract-plugin": "^1.3.1",
     "resolve-url-loader": "^4.0.0",
     "sass": "^1.52.2",
+    "sass-export": "^2.1.0",
     "sass-loader": "^8.0.2",
     "webpack": "5.72.1",
     "webpack-cli": "4.7.2",

--- a/design-system-docs/src/_components/shared/colour_table.rb
+++ b/design-system-docs/src/_components/shared/colour_table.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+module Shared
+  class ColourTable < ViewComponent::Base
+    Bridgetown::ViewComponentHelpers.allow_rails_helpers :tag
+
+    include Bridgetown::ViewComponentHelpers
+
+    def initialize(colour_mappings)
+      super
+
+      @colour_mappings = colour_mappings
+      @site = Bridgetown::Current.site
+    end
+
+    def call
+      render CitizensAdviceComponents::Table.new(
+        header: [
+          "Colour",
+          "Variable",
+          "Hex code"
+        ],
+        rows: rows
+      )
+    end
+
+    def rows
+      @colour_mappings.map do |(description, colour_key)|
+        colour = colour_for(colour_key)
+
+        [
+          tag.div do
+            swatch_for(colour["compiledValue"]) + description
+          end,
+          tag.code("$cads-language__#{colour_key}"),
+          tag.code(colour["compiledValue"])
+        ]
+      end
+    end
+
+    def swatch_for(colour_value)
+      tag.span(class: "colour-swatch", style: "background-color: #{colour_value}")
+    end
+
+    def colour_for(colour_key)
+      @site.data.colour_language.variables.find do |variable|
+        variable.name.include?(colour_key)
+      end
+    end
+  end
+end

--- a/design-system-docs/src/_data/colour_language.json
+++ b/design-system-docs/src/_data/colour_language.json
@@ -1,0 +1,264 @@
+{
+  "variables": [
+    {
+      "name": "$cads-language-_brand-primary",
+      "value": "palette.$cads-palette__heritage-blue",
+      "compiledValue": "#004b88"
+    },
+    {
+      "name": "$cads-language-_brand-secondary",
+      "value": "palette.$cads-palette__heritage-yellow",
+      "compiledValue": "#fcbb69"
+    },
+    {
+      "name": "$cads-language-_brand-primary-contrast",
+      "value": "palette.$cads-palette__white",
+      "compiledValue": "#fff"
+    },
+    {
+      "name": "$cads-language-_brand-adviser",
+      "value": "palette.$cads-palette__blue-adviser",
+      "compiledValue": "#006278"
+    },
+    {
+      "name": "$cads-language-_text-colour",
+      "value": "palette.$cads-palette__black",
+      "compiledValue": "#161616"
+    },
+    {
+      "name": "$cads-language-_secondary-text-colour",
+      "value": "palette.$cads-palette__dark-grey",
+      "compiledValue": "#4a4e4f"
+    },
+    {
+      "name": "$cads-language-_link-colour",
+      "value": "palette.$cads-palette__heritage-blue",
+      "compiledValue": "#004b88"
+    },
+    {
+      "name": "$cads-language-_link-hover-colour",
+      "value": "palette.$cads-palette__heritage-blue-dark",
+      "compiledValue": "#012760"
+    },
+    {
+      "name": "$cads-language-_link-visited-colour",
+      "value": "palette.$cads-palette__purple",
+      "compiledValue": "#8f3ea3"
+    },
+    {
+      "name": "$cads-language-_link-active-colour",
+      "value": "palette.$cads-palette__dark-grey",
+      "compiledValue": "#4a4e4f"
+    },
+    {
+      "name": "$cads-language-_hover-background-colour",
+      "value": "palette.$cads-palette__blue-light",
+      "compiledValue": "#f2f8ff"
+    },
+    {
+      "name": "$cads-language-_focus-colour",
+      "value": "palette.$cads-palette__yellow",
+      "compiledValue": "#ffd250"
+    },
+    {
+      "name": "$cads-language-_focus-border-colour",
+      "value": "palette.$cads-palette__dark-grey",
+      "compiledValue": "#4a4e4f"
+    },
+    {
+      "name": "$cads-language-_focus-text-colour",
+      "value": "palette.$cads-palette__black",
+      "compiledValue": "#161616"
+    },
+    {
+      "name": "$cads-language-_input-border-colour",
+      "value": "palette.$cads-palette__mid-grey",
+      "compiledValue": "#8d9093"
+    },
+    {
+      "name": "$cads-language-_border-colour",
+      "value": "palette.$cads-palette__light-grey",
+      "compiledValue": "#e5e5e5"
+    },
+    {
+      "name": "$cads-language-_error-colour",
+      "value": "palette.$cads-palette__red",
+      "compiledValue": "#df3034"
+    },
+    {
+      "name": "$cads-language-_primary-button-colour",
+      "value": "palette.$cads-palette__teal",
+      "compiledValue": "#018176"
+    },
+    {
+      "name": "$cads-language-_primary-button-text-colour",
+      "value": "palette.$cads-palette__white",
+      "compiledValue": "#fff"
+    },
+    {
+      "name": "$cads-language-_primary-button-hover-colour",
+      "value": "palette.$cads-palette__teal-dark",
+      "compiledValue": "#006159"
+    },
+    {
+      "name": "$cads-language-_secondary-button-hover-colour",
+      "value": "$cads-language__hover-background-colour",
+      "compiledValue": "#f2f8ff"
+    },
+    {
+      "name": "$cads-language-_tertiary-button-dark-hover-background-colour",
+      "value": "palette.$cads-palette__heritage-blue-dark",
+      "compiledValue": "#012760"
+    },
+    {
+      "name": "$cads-language-_tertiary-button-dark-hover-colour",
+      "value": "$cads-language__brand-primary-contrast",
+      "compiledValue": "#fff"
+    },
+    {
+      "name": "$cads-language-_tertiary-button-dark-hover-border-colour",
+      "value": "$cads-language__brand-primary-contrast",
+      "compiledValue": "#fff"
+    },
+    {
+      "name": "$cads-language-_button-shadow-colour",
+      "value": "palette.$cads-palette__teal-dark",
+      "compiledValue": "#006159"
+    },
+    {
+      "name": "$cads-language-_warning-colour",
+      "value": "palette.$cads-palette__red",
+      "compiledValue": "#df3034"
+    },
+    {
+      "name": "$cads-language-_success-colour",
+      "value": "palette.$cads-palette__green",
+      "compiledValue": "#0a8600"
+    },
+    {
+      "name": "$cads-language-_nav-hover-background-colour",
+      "value": "palette.$cads-palette__heritage-blue-dark",
+      "compiledValue": "#012760"
+    },
+    {
+      "name": "$cads-language-_nav-hover-border-colour",
+      "value": "palette.$cads-palette__heritage-blue-dark",
+      "compiledValue": "#012760"
+    },
+    {
+      "name": "$cads-header-_background-colour",
+      "value": "palette.$cads-palette__white",
+      "compiledValue": "#fff"
+    },
+    {
+      "name": "$cads-header-_link-colour",
+      "value": "$cads-language__link-colour",
+      "compiledValue": "#004b88"
+    },
+    {
+      "name": "$cads-header-_link-hover-colour",
+      "value": "$cads-language__link-hover-colour",
+      "compiledValue": "#012760"
+    },
+    {
+      "name": "$cads-header-_hover-background-colour",
+      "value": "$cads-language__hover-background-colour",
+      "compiledValue": "#f2f8ff"
+    },
+    {
+      "name": "$cads-header-_link-visited-colour",
+      "value": "$cads-language__link-visited-colour",
+      "compiledValue": "#8f3ea3"
+    },
+    {
+      "name": "$cads-header-_link-active-colour",
+      "value": "$cads-language__link-active-colour",
+      "compiledValue": "#4a4e4f"
+    },
+    {
+      "name": "$cads-header-_link-focus-highlight-colour",
+      "value": "palette.$cads-palette__black",
+      "compiledValue": "#161616"
+    },
+    {
+      "name": "$cads-header-_link-focus-colour",
+      "value": "$cads-language__focus-colour",
+      "compiledValue": "#ffd250"
+    },
+    {
+      "name": "$cads-header-_sign-out-background-colour",
+      "value": "$cads-language__brand-primary-contrast",
+      "compiledValue": "#fff"
+    },
+    {
+      "name": "$cads-header-_sign-out-colour",
+      "value": "$cads-language__primary-button-colour",
+      "compiledValue": "#018176"
+    },
+    {
+      "name": "$cads-header-_sign-out-border-colour",
+      "value": "$cads-language__primary-button-colour",
+      "compiledValue": "#018176"
+    },
+    {
+      "name": "$cads-footer-_divider-colour",
+      "value": "$cads-language__brand-primary",
+      "compiledValue": "#004b88"
+    },
+    {
+      "name": "$cads-footer-_background-colour",
+      "value": "palette.$cads-palette__blue-light",
+      "compiledValue": "#f2f8ff"
+    },
+    {
+      "name": "$cads-footer-_text-colour",
+      "value": "palette.$cads-palette__black",
+      "compiledValue": "#161616"
+    },
+    {
+      "name": "$cads-footer-_text-secondary-colour",
+      "value": "$cads-language__brand-primary",
+      "compiledValue": "#004b88"
+    },
+    {
+      "name": "$cads-footer-_link-colour",
+      "value": "$cads-language__link-colour",
+      "compiledValue": "#004b88"
+    },
+    {
+      "name": "$cads-footer-_link-hover-colour",
+      "value": "$cads-language__link-hover-colour",
+      "compiledValue": "#012760"
+    },
+    {
+      "name": "$cads-footer-_hover-background-colour",
+      "value": "$cads-language__hover-background-colour",
+      "compiledValue": "#f2f8ff"
+    },
+    {
+      "name": "$cads-footer-_link-visited-colour",
+      "value": "$cads-language__link-visited-colour",
+      "compiledValue": "#8f3ea3"
+    },
+    {
+      "name": "$cads-footer-_link-active-colour",
+      "value": "$cads-language__link-active-colour",
+      "compiledValue": "#4a4e4f"
+    },
+    {
+      "name": "$cads-footer-_link-focus-colour",
+      "value": "palette.$cads-palette__black",
+      "compiledValue": "#161616"
+    },
+    {
+      "name": "$cads-footer-_link-focus-background-colour",
+      "value": "$cads-language__focus-colour",
+      "compiledValue": "#ffd250"
+    },
+    {
+      "name": "$cads-footer-_link-focus-border-colour",
+      "value": "palette.$cads-palette__black",
+      "compiledValue": "#161616"
+    }
+  ]
+}

--- a/design-system-docs/src/_foundations/colours.md
+++ b/design-system-docs/src/_foundations/colours.md
@@ -1,0 +1,81 @@
+---
+title: Colours
+---
+
+We use colour language to dictate what our digital colours are and how they should be used. Use the colour language for the purpose that is defined – for example, use ‘input-border-colour’ for form inputs.
+
+The same colour is sometimes repeated because it’s used in different ways – for example, the ‘Important callout’ and ‘Error’ colour are both using the hex value #DF3034. This means we can change the 'Important callout' colour without affecting the 'Error' colour.
+
+## Brand
+
+Brand colours are usually used in global components such as ‘Global Navigation’ to enhance branding and create a consistent look on the website.
+
+<%= render(Shared::ColourTable.new([
+['Brand primary', 'brand-primary'],
+['Brand secondary', 'brand-secondary']
+])) %>
+
+### Text
+
+There are 2 shades of Text colour. Choose the colours carefully based on the importance of the information.
+
+<%= render(Shared::ColourTable.new([
+['Text', 'text-colour'],
+['Secondary text', 'secondary-text-colour']
+])) %>
+
+### Links
+
+There are various colours for different interaction states. When different coloured backgrounds are used in designs, **make sure the colour contrast ratio of all the interaction states meets at least 4.5:1** – this is the same for typography.
+
+<%= render(Shared::ColourTable.new([
+['Link', 'link-colour'],
+['Visited', 'link-visited-colour'],
+['Hover', 'link-hover-colour'],
+['Hover background', 'hover-background-colour'],
+['Active', 'link-active-colour'],
+])) %>
+
+### Focus
+
+<%= render(Shared::ColourTable.new([
+['Link', 'focus-colour'],
+['Focus text', 'focus-text-colour'],
+])) %>
+
+### Border
+
+Use the ‘Input border’ for interactive elements like input boxes so it meets the contrast ratio of 3:1. ‘Border’ is usually used for decorative lines and dividers.
+
+<%= render(Shared::ColourTable.new([
+['Input border', 'input-border-colour'],
+['Border', 'border-colour'],
+])) %>
+
+### Buttons
+
+<%= render(Shared::ColourTable.new([
+['Button', 'primary-button-colour'],
+['Button hover', 'primary-button-hover-colour'],
+])) %>
+
+### Adviser
+
+Only use ‘Adviser’ colours for adviser-related components, like ‘Adviser callout’. This is also the brand colour for AdviserNet.
+
+<%= render(Shared::ColourTable.new([
+['Adviser', 'brand-adviser']
+])) %>
+
+## Accessibility
+
+In order to meet [level AA of WCAG 2.1](https://www.w3.org/TR/WCAG21/), make sure the colour contrast ratio meets:
+
+- 4.5:1 for typography
+- 3:1 for interactive elements
+
+Don’t use colour alone to communicate information. This means users who can’t see colours, or who have difficulty telling different colours apart, have some other way to do so.
+
+## Implementation
+
+Use the sass variables instead of the hex codes. This means you’ll always be using the most recent colour palette. Only use the sass variables in the context they’re designed for. Otherwise, use the colour palette.

--- a/design-system-docs/yarn.lock
+++ b/design-system-docs/yarn.lock
@@ -24,7 +24,7 @@
     js-tokens "^4.0.0"
 
 "@citizensadvice/design-system@file:..":
-  version "5.3.0-alpha.0"
+  version "5.3.0-alpha.1"
   dependencies:
     jest-environment-jsdom "^28.0.2"
 
@@ -432,6 +432,11 @@ asynckit@^0.4.0:
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
   integrity sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==
 
+balanced-match@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
+  integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
+
 big.js@^5.2.2:
   version "5.2.2"
   resolved "https://registry.yarnpkg.com/big.js/-/big.js-5.2.2.tgz#65f0af382f578bcdc742bd9c281e9cb2d7768328"
@@ -441,6 +446,14 @@ binary-extensions@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.2.0.tgz#75f502eeaf9ffde42fc98829645be4ea76bd9e2d"
   integrity sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==
+
+brace-expansion@^1.1.7:
+  version "1.1.11"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"
+  integrity sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==
+  dependencies:
+    balanced-match "^1.0.0"
+    concat-map "0.0.1"
 
 braces@^3.0.2, braces@~3.0.2:
   version "3.0.2"
@@ -576,6 +589,11 @@ commander@^7.0.0:
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-7.2.0.tgz#a36cb57d0b501ce108e4d20559a150a391d97ab7"
   integrity sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==
+
+concat-map@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
+  integrity sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==
 
 convert-source-map@^1.7.0:
   version "1.8.0"
@@ -971,6 +989,11 @@ form-data@^4.0.0:
     combined-stream "^1.0.8"
     mime-types "^2.1.12"
 
+fs.realpath@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
+  integrity sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==
+
 fsevents@~2.3.2:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.2.tgz#8a526f78b8fdf4623b709e0b975c52c24c02fd1a"
@@ -997,6 +1020,18 @@ glob-to-regexp@^0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz#c75297087c851b9a578bd217dd59a92f59fe546e"
   integrity sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==
+
+glob@^7.1.6:
+  version "7.2.3"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.2.3.tgz#b8df0fb802bbfa8e89bd1d938b4e16578ed44f2b"
+  integrity sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^3.1.1"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
 
 graceful-fs@^4.1.2, graceful-fs@^4.2.4, graceful-fs@^4.2.9:
   version "4.2.10"
@@ -1075,6 +1110,19 @@ import-local@^3.0.2:
   dependencies:
     pkg-dir "^4.2.0"
     resolve-cwd "^3.0.0"
+
+inflight@^1.0.4:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/inflight/-/inflight-1.0.6.tgz#49bd6331d7d02d0c09bc910a1075ba8165b56df9"
+  integrity sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==
+  dependencies:
+    once "^1.3.0"
+    wrappy "1"
+
+inherits@2:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
+  integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
 
 interpret@^2.2.0:
   version "2.2.0"
@@ -1353,6 +1401,13 @@ mini-css-extract-plugin@^1.3.1:
     schema-utils "^3.0.0"
     webpack-sources "^1.1.0"
 
+minimatch@^3.1.1:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.1.2.tgz#19cd194bfd3e428f049a70817c038d89ab4be35b"
+  integrity sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==
+  dependencies:
+    brace-expansion "^1.1.7"
+
 minimist@^1.2.0, minimist@^1.2.5:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
@@ -1389,6 +1444,13 @@ nwsapi@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/nwsapi/-/nwsapi-2.2.0.tgz#204879a9e3d068ff2a55139c2c772780681a38b7"
   integrity sha512-h2AatdwYH+JHiZpv7pt/gSX1XoRGb7L/qSIeuqA6GwYoF9w1vP1cw42TO0aI2pNyshRK5893hNSl+1//vHK7hQ==
+
+once@^1.3.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
+  integrity sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==
+  dependencies:
+    wrappy "1"
 
 onetime@^5.1.2:
   version "5.1.2"
@@ -1437,6 +1499,11 @@ path-exists@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-4.0.0.tgz#513bdbe2d3b95d7762e8c1137efa195c6c61b5b3"
   integrity sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==
+
+path-is-absolute@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
+  integrity sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==
 
 path-key@^3.0.0, path-key@^3.1.0:
   version "3.1.1"
@@ -1634,6 +1701,15 @@ safe-buffer@~5.1.1:
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
 
+sass-export@^2.1.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/sass-export/-/sass-export-2.1.1.tgz#f871dfd8140597003443bdfe77bba9db5aba4b09"
+  integrity sha512-+GXM79FmkswGm6wtfXwt0hiM34/Yt5qUG2XBEQc3P7JCQJj3ZwEZ4+NoFhRv2H5xkNUZ8wd5ji9tyPFPdJY/qw==
+  dependencies:
+    glob "^7.1.6"
+    minimist "^1.2.5"
+    sass "^1.32.8"
+
 sass-loader@^8.0.2:
   version "8.0.2"
   resolved "https://registry.yarnpkg.com/sass-loader/-/sass-loader-8.0.2.tgz#debecd8c3ce243c76454f2e8290482150380090d"
@@ -1644,6 +1720,15 @@ sass-loader@^8.0.2:
     neo-async "^2.6.1"
     schema-utils "^2.6.1"
     semver "^6.3.0"
+
+sass@^1.32.8:
+  version "1.52.3"
+  resolved "https://registry.yarnpkg.com/sass/-/sass-1.52.3.tgz#b7cc7ffea2341ccc9a0c4fd372bf1b3f9be1b6cb"
+  integrity sha512-LNNPJ9lafx+j1ArtA7GyEJm9eawXN8KlA1+5dF6IZyoONg1Tyo/g+muOsENWJH/2Q1FHbbV4UwliU0cXMa/VIA==
+  dependencies:
+    chokidar ">=3.0.0 <4.0.0"
+    immutable "^4.0.0"
+    source-map-js ">=0.6.2 <2.0.0"
 
 sass@^1.52.2:
   version "1.52.2"
@@ -2037,6 +2122,11 @@ word-wrap@~1.2.3:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.3.tgz#610636f6b1f703891bd34771ccb17fb93b47079c"
   integrity sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==
+
+wrappy@1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
+  integrity sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==
 
 ws@^8.2.3:
   version "8.6.0"


### PR DESCRIPTION
Uses sass-export to export a json representation of the colour language to src/_data which is made available within bridgetown. This lets us port the equivalent colour tables from storybook.

This data file will need syncing with `npm run update-colour-language` if we change the values but this happens infrequently enough that this is fine to do manually when that happens.