### PR TITLE
Pagination: Remove redundant role

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - 🔗 Tables: Add `scope: col` to `th` cells
 - 🎯 Targeted content: Fix validation issues with HTML
+- 🔗 Pagination links: Remove redundant `navigation` role
 
 ## <sub>v5.3.0-alpha.1</sub>
 

--- a/engine/app/components/citizens_advice_components/pagination.html.haml
+++ b/engine/app/components/citizens_advice_components/pagination.html.haml
@@ -1,4 +1,4 @@
-%nav{ role: "navigation", "aria-label": t(".aria_label") }
+%nav{ "aria-label": t(".aria_label") }
   %ul.cads-paging.cads-list-unordered__inline
     - links_to_show.each do |pagination_link|
       %li.cads-paging__item{ class: ("cads-paging__current" if pagination_link.current?) }

--- a/styleguide/examples/pagination/with_fifth_page.html
+++ b/styleguide/examples/pagination/with_fifth_page.html
@@ -1,4 +1,4 @@
-<nav aria-label="Pagination navigation" role="navigation">
+<nav aria-label="Pagination navigation">
   <ul class="cads-paging cads-list-unordered__inline">
     <li class="cads-paging__item">
       <a

--- a/styleguide/examples/pagination/with_first_page.html
+++ b/styleguide/examples/pagination/with_first_page.html
@@ -1,4 +1,4 @@
-<nav aria-label="Pagination navigation" role="navigation">
+<nav aria-label="Pagination navigation">
   <ul class="cads-paging cads-list-unordered__inline">
     <li class="cads-paging__item cads-paging__current">
       <a

--- a/styleguide/examples/pagination/with_last_page.html
+++ b/styleguide/examples/pagination/with_last_page.html
@@ -1,4 +1,4 @@
-<nav aria-label="Pagination navigation" role="navigation">
+<nav aria-label="Pagination navigation">
   <ul class="cads-paging cads-list-unordered__inline">
     <li class="cads-paging__item">
       <a

--- a/styleguide/examples/pagination/with_second_page.html
+++ b/styleguide/examples/pagination/with_second_page.html
@@ -1,4 +1,4 @@
-<nav aria-label="Pagination navigation" role="navigation">
+<nav aria-label="Pagination navigation">
   <ul class="cads-paging cads-list-unordered__inline">
     <li class="cads-paging__item">
       <a

--- a/styleguide/examples/pagination/with_tenth_page.html
+++ b/styleguide/examples/pagination/with_tenth_page.html
@@ -1,4 +1,4 @@
-<nav aria-label="Pagination navigation" role="navigation">
+<nav aria-label="Pagination navigation">
   <ul class="cads-paging cads-list-unordered__inline">
     <li class="cads-paging__item">
       <a


### PR DESCRIPTION
A role of navigation is implied when using the nav element. Flagged by cypress-html-validate as part of https://github.com/citizensadvice/design-system/pull/2099