### PR TITLE
Tables: Add scope to th cells

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+**Bugfixes**
+
+- 🔗 Tables: Add `scope: col` to `th` cells
+
 ## <sub>v5.3.0-alpha.1</sub>
 
 **Bugfixes**

--- a/engine/app/components/citizens_advice_components/table.html.haml
+++ b/engine/app/components/citizens_advice_components/table.html.haml
@@ -5,7 +5,7 @@
     %thead
       %tr
         - header.each do |head|
-          %th
+          %th{ scope: "col" }
             %span.cads-table__content= head
     %tbody
       - rows.each do |row|

--- a/engine/spec/components/citizens_advice_components/__snapshots__/table.snap
+++ b/engine/spec/components/citizens_advice_components/__snapshots__/table.snap
@@ -2,10 +2,10 @@
 <table class="cads-table">
 <thead>
 <tr>
-<th>
+<th scope="col">
 <span class="cads-table__content">Your location</span>
 </th>
-<th>
+<th scope="col">
 <span class="cads-table__content">Post box collection times</span>
 </th>
 </tr>


### PR DESCRIPTION
Extracted from https://github.com/citizensadvice/design-system/pull/2099. Flagged by cypress-html-validate.

From https://webaim.org/techniques/tables/data#headers

> All <th> elements should generally always have a scope attribute. While screen readers may correctly guess whether a header is a column header or a row header based on the table layout, assigning a scope makes this unambiguous.