### PR TITLE
On this page: Add missing button type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - 🧂 Tables: Add `scope: col` to `th` cells
 - 🎯 Targeted content: Fix validation issues with HTML
 - 🔗 Pagination links: Remove redundant `navigation` role
+- 📜 On this page: Add missing type to toggle buttons
 
 ## <sub>v5.3.0-alpha.1</sub>
 

--- a/engine/app/components/citizens_advice_components/on_this_page.html.haml
+++ b/engine/app/components/citizens_advice_components/on_this_page.html.haml
@@ -4,7 +4,7 @@
     - links.each do |link|
       %li.cads-on-this-page__list-item
         - if show_children_for?(link)
-          %button.cads-on-this-page__show.cads-icon_plus.cads-linkbutton.js-cads-on-this-page__toggle{aria: { expanded: false }, data: { testid: "on-this-page-toggle", toggle_target_id: "#{link.id}-list", label_when_hiding: "Show sub-headings for #{link.label}", label_when_showing: "Hide sub-headings for #{link.label}" } }
+          %button.cads-on-this-page__show.cads-icon_plus.cads-linkbutton.js-cads-on-this-page__toggle{ type: "button", aria: { expanded: false }, data: { testid: "on-this-page-toggle", toggle_target_id: "#{link.id}-list", label_when_hiding: "Show sub-headings for #{link.label}", label_when_showing: "Hide sub-headings for #{link.label}" } }
         %a.cads-on-this-page__link.cads-hyperlink{ href: "##{link.id}", data: { testid: "on-this-page-link" } }= link.label
         - if show_children_for?(link)
           %ul.cads-on-this-page__list.cads-on-this-page__list--nested{id: "#{link.id}-list", data: { testid: "on-this-page-children" } }

--- a/styleguide/examples/on_this_page/with_nested_links.html
+++ b/styleguide/examples/on_this_page/with_nested_links.html
@@ -19,6 +19,7 @@
         data-label-when-showing="Hide sub-headings for Link 2"
         data-testid="on-this-page-toggle"
         data-toggle-target-id="link-2-list"
+        type="button"
       ></button>
       <a
         class="cads-on-this-page__link cads-hyperlink"
@@ -64,6 +65,7 @@
         data-label-when-showing="Hide sub-headings for Link 4"
         data-testid="on-this-page-toggle"
         data-toggle-target-id="link-4-list"
+        type="button"
       ></button>
       <a
         class="cads-on-this-page__link cads-hyperlink"


### PR DESCRIPTION
Extracted from https://github.com/citizensadvice/design-system/pull/2099

Buttons should have an explicit type