### PR TITLE
Header: Add missing type to search form in header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 **Bugfixes**
 
 - 👤 Header: Fix accessibility issue with search toggle
+- 👤 Header: Fix minor HTML validation issue with search form
 - 🧂 Tables: Add `scope: col` to `th` cells
 - 🎯 Targeted content: Fix validation issues with HTML
 - 🔗 Pagination links: Remove redundant `navigation` role

--- a/engine/app/components/citizens_advice_components/header.html.haml
+++ b/engine/app/components/citizens_advice_components/header.html.haml
@@ -39,6 +39,7 @@
                 "aria-label": t("citizens_advice_components.search.input_aria_label"),
                 class: "cads-search__input cads-input")
               = tag.button(name: nil,
+                type: "submit",
                 title: t("citizens_advice_components.search.submit_title"),
                 "data-testid": "search-button",
                 class: "cads-search__button") do

--- a/styleguide/examples/header/full_example.html
+++ b/styleguide/examples/header/full_example.html
@@ -85,6 +85,7 @@
               class="cads-search__input cads-input"
             />
             <button
+              type="submit"
               title="Submit search query"
               data-testid="search-button"
               class="cads-search__button"

--- a/styleguide/examples/header/minimal.html
+++ b/styleguide/examples/header/minimal.html
@@ -68,6 +68,7 @@
               class="cads-search__input cads-input"
             />
             <button
+              type="submit"
               title="Submit search query"
               data-testid="search-button"
               class="cads-search__button"

--- a/styleguide/examples/header/with_custom_account_link.html
+++ b/styleguide/examples/header/with_custom_account_link.html
@@ -87,6 +87,7 @@
               class="cads-search__input cads-input"
             />
             <button
+              type="submit"
               title="Submit search query"
               data-testid="search-button"
               class="cads-search__button"

--- a/styleguide/examples/header/with_custom_logo.html
+++ b/styleguide/examples/header/with_custom_logo.html
@@ -91,6 +91,7 @@
               class="cads-search__input cads-input"
             />
             <button
+              type="submit"
               title="Submit search query"
               data-testid="search-button"
               class="cads-search__button"

--- a/styleguide/examples/header/with_navigation.html
+++ b/styleguide/examples/header/with_navigation.html
@@ -85,6 +85,7 @@
               class="cads-search__input cads-input"
             />
             <button
+              type="submit"
               title="Submit search query"
               data-testid="search-button"
               class="cads-search__button"

--- a/styleguide/examples/sample_pages/content-sample.html
+++ b/styleguide/examples/sample_pages/content-sample.html
@@ -85,6 +85,7 @@
               class="cads-search__input cads-input"
             />
             <button
+              type="submit"
               title="Submit search query"
               data-testid="search-button"
               class="cads-search__button"

--- a/styleguide/examples/sample_pages/form-sample.html
+++ b/styleguide/examples/sample_pages/form-sample.html
@@ -98,6 +98,7 @@
               class="cads-search__input cads-input"
             />
             <button
+              type="submit"
               title="Submit search query"
               data-testid="search-button"
               class="cads-search__button"


### PR DESCRIPTION
Extracted from https://github.com/citizensadvice/design-system/pull/2099. Should specify that the button is a submit type.