### PR TITLE
Feat/migrate typography

### DIFF
--- a/design-system-docs/frontend/styles/_foundations.scss
+++ b/design-system-docs/frontend/styles/_foundations.scss
@@ -47,3 +47,16 @@
   margin-right: $cads-spacing-2;
   box-shadow: 0 0 1px rgba(0, 0, 0, 0.5);
 }
+
+// Typography
+
+// all foundation body copy is wrapped in a .cads-prose for the docs site
+.cads-prose {
+  .my-small-paragraph {
+    @extend %cads-paragraph-small;
+  }
+
+  .my-plain-list {
+    @extend %cads-list-no-bullet;
+  }
+}

--- a/design-system-docs/src/_component_examples/_foundations/typography_external_link.erb
+++ b/design-system-docs/src/_component_examples/_foundations/typography_external_link.erb
@@ -1,0 +1,13 @@
+---
+title: External link
+iframe: false
+---
+
+<div class="cads-prose">
+  <p>
+    A <a href="http://www.example.com/unvisted" class="cads-hyperlink--external">cads-hyperlink--external</a> link, displayed in a paragraph.
+  </p>
+  <p>
+    This is a link to an <a href="https://www.example.com" rel="external">external site</a>, while this link is within <a href="https://www.citizensadvice.org.uk/immigration">Citizens Advice</a>
+  </p>
+</div>

--- a/design-system-docs/src/_component_examples/_foundations/typography_headings.erb
+++ b/design-system-docs/src/_component_examples/_foundations/typography_headings.erb
@@ -1,0 +1,11 @@
+---
+title: Headings
+iframe: false
+---
+
+<div class="cads-prose">
+  <h1 class="my-h1">Heading level 1</h1>
+  <h2 class="my-h2">Heading level 2</h2>
+  <h3 class="my-h3">Heading level 3</h3>
+  <h4 class="my-h4">Heading level 4</h4>
+</div>

--- a/design-system-docs/src/_component_examples/_foundations/typography_link.erb
+++ b/design-system-docs/src/_component_examples/_foundations/typography_link.erb
@@ -1,0 +1,5 @@
+---
+title: Link
+iframe: false
+---
+<p><a href="">cads-hyperlink</a></p>

--- a/design-system-docs/src/_component_examples/_foundations/typography_ordered_list.erb
+++ b/design-system-docs/src/_component_examples/_foundations/typography_ordered_list.erb
@@ -1,0 +1,12 @@
+---
+title: Ordered list
+iframe: false
+---
+
+<div class="cads-prose">
+  <ol>
+    <li>Lorem ipsum dolor sit amet, consectetuer adipiscing elit.</li>
+    <li> Aliquam <a href="#"> auctor dapibus neque </a> </li>
+    <li>Vestibulum auctor dapibus neque.</li>
+  </ol>
+</div>

--- a/design-system-docs/src/_component_examples/_foundations/typography_paragraph.erb
+++ b/design-system-docs/src/_component_examples/_foundations/typography_paragraph.erb
@@ -1,0 +1,7 @@
+---
+title: Paragraph
+iframe: false
+---
+<div class="cads-prose">
+  <p>The default paragraph font size is 18px on large screens and 16px on small screens.</p>
+</div>

--- a/design-system-docs/src/_component_examples/_foundations/typography_plain_list.erb
+++ b/design-system-docs/src/_component_examples/_foundations/typography_plain_list.erb
@@ -1,0 +1,9 @@
+---
+title: Plain list
+iframe: false
+---
+<ul class="my-plain-list">
+  <li>Lorem ipsum dolor sit amet, consectetuer adipiscing elit.</li>
+  <li> Aliquam <a href="#"> auctor dapibus neque </a> </li>
+  <li>Vestibulum auctor dapibus neque.</li>
+</ul>

--- a/design-system-docs/src/_component_examples/_foundations/typography_small_paragraph.erb
+++ b/design-system-docs/src/_component_examples/_foundations/typography_small_paragraph.erb
@@ -1,0 +1,7 @@
+---
+title: Small paragraph
+iframe: false
+---
+
+<p class="my-small-paragraph">Small paragraph font size is 16px on large screens and 14px on smaller screens.</p>
+

--- a/design-system-docs/src/_component_examples/_foundations/typography_unordered_list.erb
+++ b/design-system-docs/src/_component_examples/_foundations/typography_unordered_list.erb
@@ -1,0 +1,12 @@
+---
+title: Unordered list
+iframe: false
+---
+
+<div class="cads-prose">
+  <ul>
+    <li>Lorem ipsum dolor sit amet, consectetuer adipiscing elit.</li>
+    <li> Aliquam <a href="#"> auctor dapibus neque </a> </li>
+    <li>Vestibulum auctor dapibus neque.</li>
+  </ul>
+</div>

--- a/design-system-docs/src/_foundations/typography.md
+++ b/design-system-docs/src/_foundations/typography.md
@@ -10,7 +10,6 @@ Our typeface is Open Sans, it's modern, easy to read and available to download f
 
 Use small text for metadata and some UI components. The majority of your body copy should use the standard 18px font size.
 
-
 <%= render(Shared::ComponentExample.new(:foundations, :typography_small_paragraph)) %>
 
 Paragraph styles have been created using placeholders and extended into the relevant classes for components that consume them.
@@ -142,7 +141,6 @@ If your links appear within a `.cads-prose` container this style is automaticall
 
 Unordered lists should be used to show collections of items where their order does not have meaning, for example the criteria for claiming a particular benefit.
 
-
 <%= render(Shared::ComponentExample.new(:foundations, :typography_unordered_list)) %>
 
 You can extend the following placeholder to achieve the correct unordered list styling outside of a `.cads-prose` element.
@@ -172,7 +170,6 @@ You can extend the following placeholder to achieve the correct plain list styli
 
 Ordered lists should be used to show collections of items where the order does have meaning, for example the steps in a process.
 
-
 <%= render(Shared::ComponentExample.new(:foundations, :typography_ordered_list)) %>
 
 You can use the following placeholders to achieve the correct ordered list styling outside of a `.cads-prose` element.
@@ -183,4 +180,3 @@ You can use the following placeholders to achieve the correct ordered list styli
   ...
 }
 ```
-

--- a/design-system-docs/src/_foundations/typography.md
+++ b/design-system-docs/src/_foundations/typography.md
@@ -1,0 +1,212 @@
+---
+title: Typography
+---
+
+Our typeface is Open Sans, it's modern, easy to read and available to download for free. We use font weight bold (700) and normal (400) on our websites.
+
+## Body
+
+<%= render(Shared::ComponentExample.new(:foundations, :typography_paragraph)) %>
+
+Use small text for metadata and some UI components. The majority of your body copy should use the standard 18px font size.
+
+export const paragraphSmallHtml = `<p class="my-small-paragraph">Small paragraph font size is 16px on large screens and 14px on smaller screens.</p>`;
+
+// small paragraph story
+
+### Technical implementation
+
+Paragraph styles have been created using placeholders and extended into the relevant classes for components that consume them.
+
+If you need to achieve these styles outside of a `.cads-prose` element, you will need to extend these placeholders.
+
+```scss
+.my-paragraph {
+  @extend %cads-paragraph;
+}
+
+.my-small-paragraph {
+  @extend %cads-paragraph-small;
+}
+```
+
+If you need to apply the `%cads-paragraph` styles to `p` elements that you cannot add a class to, for example content from a CMS or rich text editor, wrap them in a `.cads-prose` element:
+
+```html
+<main class="cads-prose">
+  <p>
+    Your family members who are citizens of countries outside the EU, EEA or
+    Switzerland might be able to apply to the EU Settlement Scheme if one of the
+    following applies
+  </p>
+</main>
+```
+
+## Headings
+
+Make sure to use the appropriate <h#> level, and don't skip heading levels.
+
+H4s are available for custom designed components or pages. Do not use for advice content. If using an H4 in your designs, make sure to use correct heading levels.
+
+export const headingsHtml = `<h1 class="my-h1">Heading level 1</h1><h2 class="my-h2">Heading level 2</h2><h3 class="my-h3">Heading level 3</h3><h4 class="my-h4">Heading level 4</h4></div>`;
+
+// headings story
+
+### Technical implementation
+
+When building new components, avoid using line height for spacing and alignment. Use the typographic scale that is established.
+
+Heading styles have been created using placeholders and extended into the relevant classes for components that consume them.
+
+If you need to achieve these styles outside of a `.cads-prose` element, you will need to extend these placeholders.
+
+```scss
+.my-h1 {
+  @extend %cads-h1;
+}
+
+.my-h2 {
+  @extend %cads-h2;
+}
+
+.my-h3 {
+  @extend %cads-h3;
+}
+
+.my-title-that-looks-like-an-h4 {
+  @extend %cads-h4;
+}
+```
+
+export const headingsProseHtml =
+'<div class="cads-prose"><h1>Heading 1</h1><h2>Heading 2</h2><h3>Heading 3</h3></div>';
+
+If you need to apply these styles to heading elements that you cannot add a class to, for example content from a CMS or rich text editor, wrap them in a `.cads-prose` element:
+
+```html
+<main class="cads-prose">
+  <h1>Your options if you're in the UK illegally</h1>
+  <h2>Get immigration advice</h2>
+  <h3>If you're a British citizen</h3>
+  <p>
+    Your family members who are citizens of countries outside the EU, EEA or
+    Switzerland might be able to apply to the EU Settlement Scheme if one of the
+    following applies
+  </p>
+</main>
+```
+
+#### Adjacent Heading Mixin
+
+To ensure that headings have the correct margins applied inside the `.cads-prose` element, a mixin has been used that will add the correct margin. This is automatically applied to the relevant elements that appear in a `.cads-prose` wrapper.
+
+```scss
+@include cads-adjacent-heading-margin($margin);
+```
+
+If you are creating components that will live inside a `.cads-prose` element and that will enclose an `h2` or `h3` heading, you will need to add the mixin to the class that is enclosing the heading.
+
+For example, you have created a `.my-new-component` div that wraps a header and a button, which is itself inside the `.cads-prose` element:
+
+```html
+<main class="cads-prose">
+  <h2>Some heading</h2>
+  <p>Some content</p>
+  <div class="my-new-component">
+    <h2>My reference heading</h2>
+    <button>Add reference</button>
+  </div>
+</main>
+```
+
+To ensure the appropriate margin between the `<p>` and the `<div>` in the above example, use the mixin in your new component:
+
+```scss
+.my-new-component {
+    @include cads-adjacent-heading-margin($cads-spacing-7);
+    ...
+}
+```
+
+## Links
+
+Links are blue and underlined by default. Avoid opening links in a new tab, as it can confuse some users.
+
+export const linkTextHtml = `<p class="my-paragraph"><a href="">cads-hyperlink</a></p>`;
+
+// links story
+
+Read our guidance about using <a href ="?path=/docs/components-buttons--primary">buttons as links</a>.
+
+### External Links
+
+When you link to a page external to your website add the `.cads-hyperlink--external` class to display an icon after the link.
+
+If your links appear within a `.cads-prose` container this style is automatically applied for all links with a `rel=external` attribute or that don't match the value set for `$cads-internal-link-domain` (defaults to `https:/www.citizensadvice.org.uk`).
+
+export const externalLinkHTML = `
+<p class="my-paragraph">
+  A <a href="http://www.example.com/unvisted" class="cads-hyperlink--external">cads-hyperlink--external</a> link, displayed in a paragraph.
+</p>
+<main class="cads-prose">
+  <p>This is a link to an <a href="https://www.example.com" rel="external">external site</a>, while this link is within <a href="https://www.citizensadvice.org.uk/immigration">Citizens Advice</a></p>
+</main>
+`;
+
+// external links story
+
+
+## Lists
+
+### Unordered lists
+
+#### Standard
+
+Unordered lists should be used to show collections of items where their order does not have meaning, for example the criteria for claiming a particular benefit.
+
+// unordered list story
+
+##### Technical Implementation
+
+You can extend the following placeholder to achieve the correct unordered list styling outside of a `.cads-prose` element.
+
+```scss
+.my-unordered-list {
+  @extend %cads-list-unordered;
+}
+```
+
+#### Plain
+
+In some situations, you will want the styles of an unordered list without the bullet points - for example to present a list of links on a summary page.
+
+// plain list story
+
+##### Technical Implementation
+
+You can extend the following placeholder to achieve the correct plain list styling outside of a `.cads-prose` element.
+
+```scss
+.my-plain-list {
+  @extend %cads-list-no-bullet;
+  ...
+}
+```
+
+### Ordered lists
+
+Ordered lists should be used to show collections of items where the order does have meaning, for example the steps in a process.
+
+// ordered list story
+
+#### Technical Implementation
+
+You can use the following placeholders to achieve the correct ordered list styling outside of a `.cads-prose` element.
+
+```scss
+.my-ordered-list {
+  @extend %cads-list-ordered;
+  ...
+}
+```
+

--- a/design-system-docs/src/_foundations/typography.md
+++ b/design-system-docs/src/_foundations/typography.md
@@ -10,11 +10,8 @@ Our typeface is Open Sans, it's modern, easy to read and available to download f
 
 Use small text for metadata and some UI components. The majority of your body copy should use the standard 18px font size.
 
-export const paragraphSmallHtml = `<p class="my-small-paragraph">Small paragraph font size is 16px on large screens and 14px on smaller screens.</p>`;
 
-// small paragraph story
-
-### Technical implementation
+<%= render(Shared::ComponentExample.new(:foundations, :typography_small_paragraph)) %>
 
 Paragraph styles have been created using placeholders and extended into the relevant classes for components that consume them.
 
@@ -48,11 +45,7 @@ Make sure to use the appropriate <h#> level, and don't skip heading levels.
 
 H4s are available for custom designed components or pages. Do not use for advice content. If using an H4 in your designs, make sure to use correct heading levels.
 
-export const headingsHtml = `<h1 class="my-h1">Heading level 1</h1><h2 class="my-h2">Heading level 2</h2><h3 class="my-h3">Heading level 3</h3><h4 class="my-h4">Heading level 4</h4></div>`;
-
-// headings story
-
-### Technical implementation
+<%= render(Shared::ComponentExample.new(:foundations, :typography_headings)) %>
 
 When building new components, avoid using line height for spacing and alignment. Use the typographic scale that is established.
 
@@ -78,9 +71,6 @@ If you need to achieve these styles outside of a `.cads-prose` element, you will
 }
 ```
 
-export const headingsProseHtml =
-'<div class="cads-prose"><h1>Heading 1</h1><h2>Heading 2</h2><h3>Heading 3</h3></div>';
-
 If you need to apply these styles to heading elements that you cannot add a class to, for example content from a CMS or rich text editor, wrap them in a `.cads-prose` element:
 
 ```html
@@ -96,7 +86,7 @@ If you need to apply these styles to heading elements that you cannot add a clas
 </main>
 ```
 
-#### Adjacent Heading Mixin
+### Adjacent Heading Mixin
 
 To ensure that headings have the correct margins applied inside the `.cads-prose` element, a mixin has been used that will add the correct margin. This is automatically applied to the relevant elements that appear in a `.cads-prose` wrapper.
 
@@ -132,9 +122,7 @@ To ensure the appropriate margin between the `<p>` and the `<div>` in the above 
 
 Links are blue and underlined by default. Avoid opening links in a new tab, as it can confuse some users.
 
-export const linkTextHtml = `<p class="my-paragraph"><a href="">cads-hyperlink</a></p>`;
-
-// links story
+<%= render(Shared::ComponentExample.new(:foundations, :typography_link)) %>
 
 Read our guidance about using <a href ="?path=/docs/components-buttons--primary">buttons as links</a>.
 
@@ -144,17 +132,7 @@ When you link to a page external to your website add the `.cads-hyperlink--exter
 
 If your links appear within a `.cads-prose` container this style is automatically applied for all links with a `rel=external` attribute or that don't match the value set for `$cads-internal-link-domain` (defaults to `https:/www.citizensadvice.org.uk`).
 
-export const externalLinkHTML = `
-<p class="my-paragraph">
-  A <a href="http://www.example.com/unvisted" class="cads-hyperlink--external">cads-hyperlink--external</a> link, displayed in a paragraph.
-</p>
-<main class="cads-prose">
-  <p>This is a link to an <a href="https://www.example.com" rel="external">external site</a>, while this link is within <a href="https://www.citizensadvice.org.uk/immigration">Citizens Advice</a></p>
-</main>
-`;
-
-// external links story
-
+<%= render(Shared::ComponentExample.new(:foundations, :typography_external_link)) %>
 
 ## Lists
 
@@ -164,9 +142,8 @@ export const externalLinkHTML = `
 
 Unordered lists should be used to show collections of items where their order does not have meaning, for example the criteria for claiming a particular benefit.
 
-// unordered list story
 
-##### Technical Implementation
+<%= render(Shared::ComponentExample.new(:foundations, :typography_unordered_list)) %>
 
 You can extend the following placeholder to achieve the correct unordered list styling outside of a `.cads-prose` element.
 
@@ -180,9 +157,7 @@ You can extend the following placeholder to achieve the correct unordered list s
 
 In some situations, you will want the styles of an unordered list without the bullet points - for example to present a list of links on a summary page.
 
-// plain list story
-
-##### Technical Implementation
+<%= render(Shared::ComponentExample.new(:foundations, :typography_plain_list)) %>
 
 You can extend the following placeholder to achieve the correct plain list styling outside of a `.cads-prose` element.
 
@@ -197,9 +172,8 @@ You can extend the following placeholder to achieve the correct plain list styli
 
 Ordered lists should be used to show collections of items where the order does have meaning, for example the steps in a process.
 
-// ordered list story
 
-#### Technical Implementation
+<%= render(Shared::ComponentExample.new(:foundations, :typography_ordered_list)) %>
 
 You can use the following placeholders to achieve the correct ordered list styling outside of a `.cads-prose` element.
 


### PR DESCRIPTION
Migrates the ol' typography page into the new docs format.  `iframe: false` added to these so that the examples display with desktop styles rather than mobile ones.

#1980 

![image](https://user-images.githubusercontent.com/2331893/176192519-48ef4cb0-e03e-4ec4-8c30-fd7890dc3ef8.png)
