### PR TITLE
Feat/code example styles

### DIFF
--- a/design-system-docs/frontend/styles/_code.scss
+++ b/design-system-docs/frontend/styles/_code.scss
@@ -3,20 +3,23 @@
 // ============================================================================
 
 code {
-  line-height: 1;
+  line-height: 1rem;
   margin: 0 2px;
   padding: $cads-spacing-1 $cads-spacing-2;
   border-radius: $cads-border-radius;
   background-color: #f8f8f8;
+  font-size: 1rem;
 }
 
 pre code {
   display: block;
-  background: none;
-  white-space: pre;
+  white-space: pre-wrap;
   -webkit-overflow-scrolling: touch;
-  overflow-x: scroll;
+  overflow-x: auto;
   max-width: 100%;
   min-width: 100px;
   padding: 20px;
+  line-height: 1.5rem;
+  border: $cads-border-width-small $cads-language__border-colour solid;
+  background-color: $cads-palette__white;
 }

--- a/design-system-docs/frontend/styles/_examples.scss
+++ b/design-system-docs/frontend/styles/_examples.scss
@@ -5,19 +5,17 @@
 .component-example {
   border: 1px solid $cads-language__border-colour;
   margin-bottom: $cads-spacing-6;
+  padding: $cads-spacing-5;
 }
-.component-example__links,
-.component-example__source {
-  padding: $cads-spacing-3 $cads-spacing-4;
-}
+
 .component-example__links {
   text-align: right;
   @include cads-typographic-scale-text-small();
 }
 .component-example__preview {
-  border: solid $cads-language__border-colour;
+  border: none;
   border-width: 1px 0;
-  padding: $cads-spacing-4;
+  padding: $cads-spacing-4 0;
 }
 .component-example__iframe {
   display: block;

--- a/design-system-docs/plugins/builders/cads_builder.rb
+++ b/design-system-docs/plugins/builders/cads_builder.rb
@@ -3,6 +3,7 @@
 require "view_component/engine"
 require "citizens_advice_components"
 require "haml/plugin"
+require_relative "cads_theme"
 
 ActionView::Template.register_template_handler(:haml, Haml::Plugin)
 
@@ -15,6 +16,7 @@ module Builders
   class CadsBuilder < SiteBuilder
     def build
       load_cads
+      CadsTheme.register('cads-theme')
     end
 
     def load_cads

--- a/design-system-docs/plugins/builders/cads_theme.rb
+++ b/design-system-docs/plugins/builders/cads_theme.rb
@@ -1,0 +1,10 @@
+module Builders
+  class CadsTheme < Rouge::CSSTheme
+    name 'cads-theme'
+
+    style Text,       :fg => '#161616'
+    style Keyword,    :fg => '#004B88', :bold => true
+    style Literal,    :fg => '#006278'
+
+  end
+end

--- a/design-system-docs/src/_layouts/default.erb
+++ b/design-system-docs/src/_layouts/default.erb
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="robots" content="noindex, nofollow">
     <link rel="stylesheet" href="<%= webpack_path "css" %>" />
-    <style><%= Rouge::Theme.find('github').render(scope: '.highlight') %></style>
+    <style><%= Rouge::Theme.find('cads-theme').render(scope: '.highlight') %></style>
   </head>
   <body>
     <%= render CitizensAdviceComponents::Header.new do |c| %>


### PR DESCRIPTION
Brings the `code` blocks and `ComponentExample`... component closer to the Figma designs.

Adds a custom theme in site builder dir, registers it with `Rouge` and renders the theme in the default layout.  I'm not sure how much value the brand colours add, but it's better than it was!

![image](https://user-images.githubusercontent.com/2331893/176215960-31a723e4-ed43-4461-bafa-2cfdba9d51bd.png)
