### PR TITLE
Feat/code copy

### DIFF
--- a/design-system-docs/frontend/javascript/code-copy/index.js
+++ b/design-system-docs/frontend/javascript/code-copy/index.js
@@ -1,0 +1,20 @@
+export default function initCodeCopy() {
+  const highlights = document.querySelectorAll('pre.highlight');
+  if (highlights) {
+    highlights.forEach(h => addCopyButton((h)))
+  }
+}
+
+function addCopyButton(highlight) {
+  const buttonDiv = document.createElement("div")
+  buttonDiv.classList.add("highlight__buttons")
+
+  const button = document.createElement("button")
+  button.classList.add('cads-button')
+  button.classList.add('cads-button__tertiary')
+  button.textContent = "Copy code"
+  highlight.classList.add('highlight--with-button')
+
+  buttonDiv.append(button)
+  highlight.prepend(buttonDiv)
+}

--- a/design-system-docs/frontend/javascript/code-copy/index.js
+++ b/design-system-docs/frontend/javascript/code-copy/index.js
@@ -1,20 +1,31 @@
+import copy from 'clipboard-copy';
+
 export default function initCodeCopy() {
   const highlights = document.querySelectorAll('pre.highlight');
   if (highlights) {
-    highlights.forEach(h => addCopyButton((h)))
+    highlights.forEach((h) => addCopyButton(h));
   }
 }
 
 function addCopyButton(highlight) {
-  const buttonDiv = document.createElement("div")
-  buttonDiv.classList.add("highlight__buttons")
+  const buttonDiv = document.createElement('div');
+  buttonDiv.classList.add('highlight__buttons');
 
-  const button = document.createElement("button")
-  button.classList.add('cads-button')
-  button.classList.add('cads-button__tertiary')
-  button.textContent = "Copy code"
-  highlight.classList.add('highlight--with-button')
+  const button = document.createElement('button');
+  button.classList.add('cads-button');
+  button.classList.add('cads-button__tertiary');
+  button.textContent = 'Copy code';
 
-  buttonDiv.append(button)
-  highlight.prepend(buttonDiv)
+  button.addEventListener('click', function () {
+    copyCode(highlight);
+  });
+
+  highlight.classList.add('highlight--with-button');
+
+  buttonDiv.append(button);
+  highlight.prepend(buttonDiv);
+}
+
+function copyCode(highlight) {
+  copy(highlight.querySelector('code').innerText);
 }

--- a/design-system-docs/frontend/javascript/index.js
+++ b/design-system-docs/frontend/javascript/index.js
@@ -2,6 +2,8 @@ import '../styles/index.scss';
 
 import initTargetedContent from '@citizensadvice/design-system/lib/targeted-content';
 import initDisclosure from '@citizensadvice/design-system/lib/disclosure/disclosure';
+import initCodeCopy from "./code-copy";
 
 initTargetedContent();
 initDisclosure();
+initCodeCopy();

--- a/design-system-docs/frontend/javascript/index.js
+++ b/design-system-docs/frontend/javascript/index.js
@@ -2,7 +2,7 @@ import '../styles/index.scss';
 
 import initTargetedContent from '@citizensadvice/design-system/lib/targeted-content';
 import initDisclosure from '@citizensadvice/design-system/lib/disclosure/disclosure';
-import initCodeCopy from "./code-copy";
+import initCodeCopy from './code-copy';
 
 initTargetedContent();
 initDisclosure();

--- a/design-system-docs/frontend/styles/_code.scss
+++ b/design-system-docs/frontend/styles/_code.scss
@@ -5,7 +5,6 @@
 code {
   line-height: 1rem;
   margin: 0 2px;
-  padding: $cads-spacing-1 $cads-spacing-2;
   border-radius: $cads-border-radius;
   background-color: #f8f8f8;
   font-size: 1rem;
@@ -18,8 +17,23 @@ pre code {
   overflow-x: auto;
   max-width: 100%;
   min-width: 100px;
-  padding: 20px;
   line-height: 1.5rem;
-  border: $cads-border-width-small $cads-language__border-colour solid;
   background-color: $cads-palette__white;
+}
+
+.highlight {
+  border: $cads-border-width-small $cads-language__border-colour solid;
+  padding: $cads-spacing-4;
+
+  &--with-button {
+    margin: 0;
+  }
+
+  button {
+    font-family: $cads-font-family;
+  }
+  > .highlight {
+    border: none;
+    padding: 0;
+  }
 }

--- a/design-system-docs/frontend/styles/_code.scss
+++ b/design-system-docs/frontend/styles/_code.scss
@@ -22,6 +22,7 @@ pre code {
 }
 
 .highlight {
+  margin-bottom: $cads-spacing-6;
   border: $cads-border-width-small $cads-language__border-colour solid;
   padding: $cads-spacing-4;
 

--- a/design-system-docs/package.json
+++ b/design-system-docs/package.json
@@ -25,5 +25,8 @@
   },
   "resolutions": {
     "postcss-focus-within": "^4.0.0"
+  },
+  "dependencies": {
+    "clipboard-copy": "^4.0.1"
   }
 }

--- a/design-system-docs/yarn.lock
+++ b/design-system-docs/yarn.lock
@@ -535,6 +535,11 @@ ci-info@^3.2.0:
   resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-3.3.1.tgz#58331f6f472a25fe3a50a351ae3052936c2c7f32"
   integrity sha512-SXgeMX9VwDe7iFFaEWkA5AstuER9YKqy4EhHqr4DVqkwmD9rpVimkMKWHdjn30Ja45txyjhSn63lVX69eVCckg==
 
+clipboard-copy@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/clipboard-copy/-/clipboard-copy-4.0.1.tgz#326ef9726d4ffe72d9a82a7bbe19379de692017d"
+  integrity sha512-wOlqdqziE/NNTUJsfSgXmBMIrYmfd5V0HCGsR8uAKHcg+h9NENWINcfRjtWGU77wDHC8B8ijV4hMTGYbrKovng==
+
 clone-deep@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/clone-deep/-/clone-deep-4.0.1.tgz#c19fd9bdbbf85942b4fd979c84dcf7d5f07c2387"


### PR DESCRIPTION
Adds the `Copy code` button to code blocks rendered both in markup and in the `ComponentExample` component.  The functional part of the feature requires JS anyway, so the button and styles are added using JS too.

I'll add wider support for non-js in a different PR - but for this the button just doesn't appear (which is what we want).

There is a slight change from the figma designs - wrapping the code isn't very helpful most of the time, so I had to move the button.  I'll check it with @JamesR-CA 

![image](https://user-images.githubusercontent.com/2331893/176235609-2fc2ff45-9f49-4b85-bf03-0688323a28f1.png)
