### PR TITLE
feat: add no-js support

### DIFF
--- a/design-system-docs/frontend/javascript/index.js
+++ b/design-system-docs/frontend/javascript/index.js
@@ -4,6 +4,11 @@ import initTargetedContent from '@citizensadvice/design-system/lib/targeted-cont
 import initDisclosure from '@citizensadvice/design-system/lib/disclosure/disclosure';
 import initCodeCopy from './code-copy';
 
-initTargetedContent();
-initDisclosure();
-initCodeCopy();
+try {
+  initTargetedContent();
+  initDisclosure();
+  initCodeCopy();
+} catch (error) {
+  document.querySelector('html').classList.add('no-js');
+  throw error;
+}

--- a/design-system-docs/src/_layouts/component_example.erb
+++ b/design-system-docs/src/_layouts/component_example.erb
@@ -1,11 +1,14 @@
 <!doctype html>
-<html lang="<%= site.locale %>">
+<html class="no-js" lang="<%= site.locale %>">
   <head>
     <meta charset="utf-8" />
     <%= seo %>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="robots" content="noindex, nofollow">
     <link rel="stylesheet" href="<%= webpack_path "css" %>" />
+    <script type="application/javascript">
+      document.querySelector('html').classList.remove('no-js');
+    </script>
   </head>
   <body>
     <%= yield %>

--- a/design-system-docs/src/_layouts/default.erb
+++ b/design-system-docs/src/_layouts/default.erb
@@ -1,10 +1,13 @@
 <!doctype html>
-<html lang="<%= site.locale %>">
+<html lang="<%= site.locale %>" class="no-js">
   <head>
     <meta charset="utf-8" />
     <%= seo %>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="robots" content="noindex, nofollow">
+    <script type="application/javascript">
+      document.querySelector('html').classList.remove('no-js');
+    </script>
     <link rel="stylesheet" href="<%= webpack_path "css" %>" />
     <style><%= Rouge::Theme.find('cads-theme').render(scope: '.highlight') %></style>
   </head>


### PR DESCRIPTION
Adds no-js support to the docs site, based on the same model as public website:
- add `html.no-js` to the default layout
- remove it again in a `script` block in the `head`
- add some error handling in the main js file