### PR TITLE
Adding Asset hyperlink to the new docs site

### DIFF
--- a/design-system-docs/src/_component_docs/asset-hyperlink.md
+++ b/design-system-docs/src/_component_docs/asset-hyperlink.md
@@ -1,0 +1,24 @@
+---
+title: Asset hyperlink
+---
+
+<%= render(Shared::ComponentExample.new(:asset_hyperlink, :default)) %>
+
+## Using with Rails
+
+If you are using the `citizens_advice_components` gem, you can call the component from within a template using:
+
+```rb
+<%%= render(
+  CitizensAdviceComponents::AssetHyperlink.new(
+    href: "https://example.com",
+    description: "Test PDF",
+    size: 6_444_516
+  )
+  end
+%>
+```
+
+### View Component Options
+
+<%= render Shared::ArgumentsTable.new(:asset_hyperlink) %>

--- a/design-system-docs/src/_component_examples/_asset_hyperlink/_defaults.yml
+++ b/design-system-docs/src/_component_examples/_asset_hyperlink/_defaults.yml
@@ -1,0 +1,1 @@
+category: asset_hyperlink

--- a/design-system-docs/src/_component_examples/_asset_hyperlink/default.erb
+++ b/design-system-docs/src/_component_examples/_asset_hyperlink/default.erb
@@ -1,0 +1,11 @@
+---
+title: Default
+---
+<%= render(
+      CitizensAdviceComponents::AssetHyperlink.new(
+        href: "https://example.com",
+        description: "Test PDF",
+        size: 6_444_516
+      )
+    )
+%>

--- a/design-system-docs/src/_data/component_arguments.yml
+++ b/design-system-docs/src/_data/component_arguments.yml
@@ -1,3 +1,10 @@
+asset_hyperlink:
+  - argument: href
+    description: Required, link to the asset
+  - argument: description
+    description: Required, description of the asset
+  - argument: size
+    description: Required, size in bytes
 targeted_content:
   - argument: id
     description: Required, unique ID


### PR DESCRIPTION
Two questions that will potentially go into separate PRs:

- Should we include 'On this page' for the foundation pages as well?
- Should I remove the external icon after the hyperlink? 
![image](https://user-images.githubusercontent.com/94383569/176450420-307d4922-c0c6-4c7a-a6e1-0b5717865b6b.png)