### PR TITLE
Upgrade to stylelint v14

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6134,6 +6134,12 @@
         "minimist": "^1.2.0"
       }
     },
+    "@csstools/selector-specificity": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@csstools/selector-specificity/-/selector-specificity-2.0.1.tgz",
+      "integrity": "sha512-aG20vknL4/YjQF9BSV7ts4EWm/yrjagAN7OWBNmlbEOUiu0llj4OGrFoOKK3g2vey4/p2omKCoHrWtPxSwV3HA==",
+      "dev": true
+    },
     "@discoveryjs/json-ext": {
       "version": "0.5.5",
       "resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.5.tgz",
@@ -11942,25 +11948,6 @@
         }
       }
     },
-    "@stylelint/postcss-css-in-js": {
-      "version": "0.37.2",
-      "resolved": "https://registry.npmjs.org/@stylelint/postcss-css-in-js/-/postcss-css-in-js-0.37.2.tgz",
-      "integrity": "sha512-nEhsFoJurt8oUmieT8qy4nk81WRHmJynmVwn/Vts08PL9fhgIsMhk1GId5yAN643OzqEEb5S/6At2TZW7pqPDA==",
-      "dev": true,
-      "requires": {
-        "@babel/core": ">=7.9.0"
-      }
-    },
-    "@stylelint/postcss-markdown": {
-      "version": "0.36.2",
-      "resolved": "https://registry.npmjs.org/@stylelint/postcss-markdown/-/postcss-markdown-0.36.2.tgz",
-      "integrity": "sha512-2kGbqUVJUGE8dM+bMzXG/PYUWKkjLIkRLWNh39OaADkiabDRdw8ATFCgbMz5xdIcvwspPAluSL7uY+ZiTWdWmQ==",
-      "dev": true,
-      "requires": {
-        "remark": "^13.0.0",
-        "unist-util-find-all-after": "^3.0.2"
-      }
-    },
     "@testing-library/dom": {
       "version": "8.14.0",
       "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-8.14.0.tgz",
@@ -12348,9 +12335,9 @@
       "dev": true
     },
     "@types/minimist": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.1.tgz",
-      "integrity": "sha512-fZQQafSREFyuZcdWFAExYjBiCL7AUCdgsk80iO0q4yihYYdcIiH28CcuPTGFgLOCC8RlW49GSQxdHwZP+I7CNg==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.2.tgz",
+      "integrity": "sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==",
       "dev": true
     },
     "@types/node": {
@@ -16211,20 +16198,12 @@
       "dev": true,
       "requires": {
         "is-regexp": "^2.0.0"
-      },
-      "dependencies": {
-        "is-regexp": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-2.1.0.tgz",
-          "integrity": "sha512-OZ4IlER3zmRIoB9AqNhEggVxqIH4ofDns5nRrPS6yQxXE1TPCUpFznBfRQmQa8uC+pXqjMnukiJBxCisIxiLGA==",
-          "dev": true
-        }
       }
     },
     "co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-      "integrity": "sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==",
+      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
       "dev": true
     },
     "code-point-at": {
@@ -16847,6 +16826,12 @@
       "integrity": "sha512-Ufadglr88ZLsrvS11gjeu/40Lw74D9Am/Jpr3LlYm5Q4ZP5KdlUhG+6u2EjyXeZcxmZ2h1ebCKngDjolpeLHpg==",
       "dev": true
     },
+    "css-functions-list": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/css-functions-list/-/css-functions-list-3.1.0.tgz",
+      "integrity": "sha512-/9lCvYZaUbBGvYUgYGFJ4dcYiyqdhSjG7IPVluoV8A1ILjkF7ilmhp1OGUz8n+nmBcu0RNrQAzgD8B6FJbrt2w==",
+      "dev": true
+    },
     "css-loader": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-3.6.0.tgz",
@@ -17253,13 +17238,13 @@
     "decamelize": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
       "dev": true
     },
     "decamelize-keys": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/decamelize-keys/-/decamelize-keys-1.1.0.tgz",
-      "integrity": "sha1-0XGoeTMlKAfrPLYdwcFEXQeN8tk=",
+      "integrity": "sha512-ocLWuYzRPoS9bfiSdDd3cxvrzovVMZnRDVEzAs+hWIVXGDbHxWMECij2OBuyB/An0FFW/nLuq6Kv1i/YC5Qfzg==",
       "dev": true,
       "requires": {
         "decamelize": "^1.1.0",
@@ -17269,7 +17254,7 @@
         "map-obj": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
-          "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
+          "integrity": "sha512-7N/q3lyZ+LVCp7PzuxrJr4KMbBE2hW7BT7YNia330OFxIf4d3r5zVpicP2650l7CPN6RM9zOJRl3NGpqSiw3Eg==",
           "dev": true
         }
       }
@@ -17288,7 +17273,7 @@
     "dedent": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
-      "integrity": "sha512-Q6fKUPqnAHAyhiUgFU7BUzLiv0kd8saH9al7tnu5Q/okj6dnupxyTgFIBjVzJATdfIAm9NAsvXNzjaKa+bxVyA==",
+      "integrity": "sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw=",
       "dev": true
     },
     "deep-is": {
@@ -17495,30 +17480,6 @@
         "utila": "~0.4"
       }
     },
-    "dom-serializer": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.2.2.tgz",
-      "integrity": "sha512-2/xPb3ORsQ42nHYiSunXkDjPLBaEj/xTwUO4B7XCZQTRk7EBtTOPaygh10YAAh2OI1Qrp6NWfpAhzswj0ydt9g==",
-      "dev": true,
-      "requires": {
-        "domelementtype": "^2.0.1",
-        "entities": "^2.0.0"
-      },
-      "dependencies": {
-        "domelementtype": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.0.1.tgz",
-          "integrity": "sha512-5HOHUDsYZWV8FGWN0Njbr/Rn7f/eWSQi1v7+HsUVwXgn8nWWlL64zKDkS0n8ZmQ3mlWOMuXOnR+7Nx/5tMO5AQ==",
-          "dev": true
-        },
-        "entities": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/entities/-/entities-2.0.3.tgz",
-          "integrity": "sha512-MyoZ0jgnLvB2X3Lg5HqpFmn1kybDiIfEQmKzTb5apr51Rb+T3KdmMiqa70T+bhGnyv7bQ6WMj2QMHpGMmlrUYQ==",
-          "dev": true
-        }
-      }
-    },
     "dom-walk": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.2.tgz",
@@ -17529,12 +17490,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.2.0.tgz",
       "integrity": "sha512-jnjyiM6eRyZl2H+W8Q/zLMA481hzi0eszAaBUzIVnmYVDBbnLxVNnfu1HgEBvCbL+71FrxMl3E6lpKH7Ge3OXA==",
-      "dev": true
-    },
-    "domelementtype": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz",
-      "integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w==",
       "dev": true
     },
     "domexception": {
@@ -17552,25 +17507,6 @@
           "integrity": "sha512-VlZwKPCkYKxQgeSbH5EyngOmRp7Ww7I9rQLERETtf5ofd9pGeswWiOtogpEO850jziPRarreGxn5QIiTqpb2wA==",
           "dev": true
         }
-      }
-    },
-    "domhandler": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.2.tgz",
-      "integrity": "sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==",
-      "dev": true,
-      "requires": {
-        "domelementtype": "1"
-      }
-    },
-    "domutils": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.7.0.tgz",
-      "integrity": "sha512-Lgd2XcJ/NjEw+7tFvfKxOzCYKZsdct5lczQ2ZaQY8Djz7pfAD3Gbp8ySJWtreII/vDlMVmxwa6pHmdxIYgttDg==",
-      "dev": true,
-      "requires": {
-        "dom-serializer": "0",
-        "domelementtype": "1"
       }
     },
     "dot-case": {
@@ -17793,12 +17729,6 @@
           }
         }
       }
-    },
-    "entities": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
-      "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w==",
-      "dev": true
     },
     "errno": {
       "version": "0.1.8",
@@ -18928,7 +18858,7 @@
     "exit": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
-      "integrity": "sha512-Zk/eNKV2zbjpKzrsQ+n1G6poVbErQxJ0LBOJXaKZ1EViLzH+hrLu9cdXI4zw9dBQJslwBEpbQ2P1oS7nDxs6jQ==",
+      "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
       "dev": true
     },
     "expand-brackets": {
@@ -20216,17 +20146,8 @@
     "globjoin": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/globjoin/-/globjoin-0.1.4.tgz",
-      "integrity": "sha1-L0SUrIkZ43Z8XLtpHp9GMyQoXUM=",
+      "integrity": "sha512-xYfnw62CKG8nLkZBfWbhWwDw02CHty86jfPcc2cr3ZfeuK9ysoVPPEUxf21bAD/rWAgk52SuBrLJlefNy8mvFg==",
       "dev": true
-    },
-    "gonzales-pe": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/gonzales-pe/-/gonzales-pe-4.3.0.tgz",
-      "integrity": "sha512-otgSPpUmdWJ43VXyiNgEYE4luzHCL2pz4wQ0OnDluC6Eg4Ko3Vexy/SrSynglw/eR+OhkzmqFCZa/OFa/RgAOQ==",
-      "dev": true,
-      "requires": {
-        "minimist": "^1.2.5"
-      }
     },
     "graceful-fs": {
       "version": "4.2.4",
@@ -20714,33 +20635,6 @@
         "pretty-error": "^2.1.1",
         "tapable": "^1.1.3",
         "util.promisify": "1.0.0"
-      }
-    },
-    "htmlparser2": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.10.1.tgz",
-      "integrity": "sha512-IgieNijUMbkDovyoKObU1DUhm1iwNYE/fuifEoEHfd1oZKZDaONBSkal7Y01shxsM49R4XaMdGez3WnF9UfiCQ==",
-      "dev": true,
-      "requires": {
-        "domelementtype": "^1.3.1",
-        "domhandler": "^2.3.0",
-        "domutils": "^1.5.1",
-        "entities": "^1.1.1",
-        "inherits": "^2.0.1",
-        "readable-stream": "^3.1.1"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "3.6.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-          "dev": true,
-          "requires": {
-            "inherits": "^2.0.3",
-            "string_decoder": "^1.1.1",
-            "util-deprecate": "^1.0.1"
-          }
-        }
       }
     },
     "http-errors": {
@@ -21528,6 +21422,12 @@
       "requires": {
         "has-symbols": "^1.0.1"
       }
+    },
+    "is-regexp": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-2.1.0.tgz",
+      "integrity": "sha512-OZ4IlER3zmRIoB9AqNhEggVxqIH4ofDns5nRrPS6yQxXE1TPCUpFznBfRQmQa8uC+pXqjMnukiJBxCisIxiLGA==",
+      "dev": true
     },
     "is-root": {
       "version": "2.1.0",
@@ -25010,7 +24910,7 @@
     "json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
-      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
       "dev": true
     },
     "json5": {
@@ -25065,9 +24965,9 @@
       "dev": true
     },
     "known-css-properties": {
-      "version": "0.21.0",
-      "resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.21.0.tgz",
-      "integrity": "sha512-sZLUnTqimCkvkgRS+kbPlYW5o8q5w1cu+uIisKpEWkj31I8mx8kNG162DwRav8Zirkva6N5uoFsm9kzK4mUXjw==",
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.25.0.tgz",
+      "integrity": "sha512-b0/9J1O9Jcyik1GC6KC42hJ41jKwdO/Mq8Mdo5sYN+IuRTXs2YFHZC3kZSx6ueusqa95x3wLYe/ytKjbAfGixA==",
       "dev": true
     },
     "lazy-universal-dotenv": {
@@ -25155,12 +25055,6 @@
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
     },
-    "lodash.clonedeep": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
-      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
-      "dev": true
-    },
     "lodash.debounce": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
@@ -25171,12 +25065,6 @@
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.difference/-/lodash.difference-4.5.0.tgz",
       "integrity": "sha1-nMtOUF1Ia5FlE0V3KIWi3yf9AXw=",
-      "dev": true
-    },
-    "lodash.flatten": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
-      "integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8=",
       "dev": true
     },
     "lodash.forown": {
@@ -25218,7 +25106,7 @@
     "lodash.truncate": {
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.truncate/-/lodash.truncate-4.4.2.tgz",
-      "integrity": "sha1-WjUNoLERO4N+z//VgSy+WNbq4ZM=",
+      "integrity": "sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==",
       "dev": true
     },
     "lodash.uniq": {
@@ -25236,12 +25124,6 @@
         "chalk": "^4.1.0",
         "is-unicode-supported": "^0.1.0"
       }
-    },
-    "longest-streak": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-2.0.4.tgz",
-      "integrity": "sha512-vM6rUVCVUJJt33bnmHiZEvr7wPT78ztX7rojL+LW51bHtLh6HTjx84LA5W4+oa6aKEJA7jJu5LR6vQRBpA5DVg==",
-      "dev": true
     },
     "loose-envify": {
       "version": "1.4.0",
@@ -25291,7 +25173,7 @@
     "lz-string": {
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.4.4.tgz",
-      "integrity": "sha512-0ckx7ZHRPqb0oUm8zNr+90mtf9DQB60H1wMCjBtfi62Kl3a7JbHob6gA2bC+xRvZoOL+1hzUK8jeuEIQE8svEQ==",
+      "integrity": "sha1-wNjq82BZ9wV5bh40SBHPTEmNOiY=",
       "dev": true
     },
     "make-dir": {
@@ -25328,9 +25210,9 @@
       "dev": true
     },
     "map-obj": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.2.1.tgz",
-      "integrity": "sha512-+WA2/1sPmDj1dlvvJmB5G6JKfY9dpn7EVBUL06+y6PoljPkh+6V1QihwxNkbcGxCRjt2b0F9K0taiCuo7MbdFQ==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.3.0.tgz",
+      "integrity": "sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ==",
       "dev": true
     },
     "map-or-similar": {
@@ -25406,27 +25288,6 @@
         "unist-util-visit": "^2.0.0"
       }
     },
-    "mdast-util-from-markdown": {
-      "version": "0.8.5",
-      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-0.8.5.tgz",
-      "integrity": "sha512-2hkTXtYYnr+NubD/g6KGBS/0mFmBcifAsI0yIWRiRo0PjVs6SSOSOdtzbp6kSGnShDN6G5aWZpKQ2lWRy27mWQ==",
-      "dev": true,
-      "requires": {
-        "@types/mdast": "^3.0.0",
-        "mdast-util-to-string": "^2.0.0",
-        "micromark": "~2.11.0",
-        "parse-entities": "^2.0.0",
-        "unist-util-stringify-position": "^2.0.0"
-      },
-      "dependencies": {
-        "mdast-util-to-string": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-2.0.0.tgz",
-          "integrity": "sha512-AW4DRS3QbBayY/jJmD8437V1Gombjf8RSOUCMFBuo5iHi58AGEgVCKQ+ezHkZZDpAQS75hcBMpLqjpJTjtUL7w==",
-          "dev": true
-        }
-      }
-    },
     "mdast-util-to-hast": {
       "version": "10.0.1",
       "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-10.0.1.tgz",
@@ -25441,28 +25302,6 @@
         "unist-util-generated": "^1.0.0",
         "unist-util-position": "^3.0.0",
         "unist-util-visit": "^2.0.0"
-      }
-    },
-    "mdast-util-to-markdown": {
-      "version": "0.6.5",
-      "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-0.6.5.tgz",
-      "integrity": "sha512-XeV9sDE7ZlOQvs45C9UKMtfTcctcaj/pGwH8YLbMHoMOXNNCn2LsqVQOqrF1+/NU8lKDAqozme9SCXWyo9oAcQ==",
-      "dev": true,
-      "requires": {
-        "@types/unist": "^2.0.0",
-        "longest-streak": "^2.0.0",
-        "mdast-util-to-string": "^2.0.0",
-        "parse-entities": "^2.0.0",
-        "repeat-string": "^1.0.0",
-        "zwitch": "^1.0.0"
-      },
-      "dependencies": {
-        "mdast-util-to-string": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-2.0.0.tgz",
-          "integrity": "sha512-AW4DRS3QbBayY/jJmD8437V1Gombjf8RSOUCMFBuo5iHi58AGEgVCKQ+ezHkZZDpAQS75hcBMpLqjpJTjtUL7w==",
-          "dev": true
-        }
       }
     },
     "mdast-util-to-string": {
@@ -25544,106 +25383,33 @@
       },
       "dependencies": {
         "hosted-git-info": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.0.2.tgz",
-          "integrity": "sha512-c9OGXbZ3guC/xOlCg1Ci/VgWlwsqDv1yMQL1CWqXDL0hDjXuNcq0zuR4xqPSuasI3kqFDhqSyTjREz5gzq0fXg==",
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
+          "integrity": "sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==",
           "dev": true,
           "requires": {
             "lru-cache": "^6.0.0"
           }
         },
         "is-core-module": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.3.0.tgz",
-          "integrity": "sha512-xSphU2KG9867tsYdLD4RWQ1VqdFl4HTO9Thf3I/3dLEfr0dbPTWKsuCKrgqMljg4nPE+Gq0VCnzT3gr0CyBmsw==",
+          "version": "2.9.0",
+          "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.9.0.tgz",
+          "integrity": "sha512-+5FPy5PnwmO3lvfMb0AsoPaBG+5KHUI0wYFXOtYPnVVVspTFUuMZNfNaNVRt3FZadstu2c8x23vykRW/NBoU6A==",
           "dev": true,
           "requires": {
             "has": "^1.0.3"
           }
         },
         "normalize-package-data": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.2.tgz",
-          "integrity": "sha512-6CdZocmfGaKnIHPVFhJJZ3GuR8SsLKvDANFp47Jmy51aKIr8akjAWTSxtpI+MBgBFdSMRyo4hMpDlT6dTffgZg==",
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.3.tgz",
+          "integrity": "sha512-p2W1sgqij3zMMyRC067Dg16bfzVH+w7hyegmpIvZ4JNjqtGOVAIvLmjBx3yP7YTe9vKJgkoNOPjwQGogDoMXFA==",
           "dev": true,
           "requires": {
             "hosted-git-info": "^4.0.1",
-            "resolve": "^1.20.0",
+            "is-core-module": "^2.5.0",
             "semver": "^7.3.4",
             "validate-npm-package-license": "^3.0.1"
-          }
-        },
-        "read-pkg": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
-          "integrity": "sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==",
-          "dev": true,
-          "requires": {
-            "@types/normalize-package-data": "^2.4.0",
-            "normalize-package-data": "^2.5.0",
-            "parse-json": "^5.0.0",
-            "type-fest": "^0.6.0"
-          },
-          "dependencies": {
-            "hosted-git-info": {
-              "version": "2.8.9",
-              "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
-              "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
-              "dev": true
-            },
-            "normalize-package-data": {
-              "version": "2.5.0",
-              "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
-              "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
-              "dev": true,
-              "requires": {
-                "hosted-git-info": "^2.1.4",
-                "resolve": "^1.10.0",
-                "semver": "2 || 3 || 4 || 5",
-                "validate-npm-package-license": "^3.0.1"
-              }
-            },
-            "semver": {
-              "version": "5.7.1",
-              "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-              "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-              "dev": true
-            },
-            "type-fest": {
-              "version": "0.6.0",
-              "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
-              "integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
-              "dev": true
-            }
-          }
-        },
-        "read-pkg-up": {
-          "version": "7.0.1",
-          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-7.0.1.tgz",
-          "integrity": "sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==",
-          "dev": true,
-          "requires": {
-            "find-up": "^4.1.0",
-            "read-pkg": "^5.2.0",
-            "type-fest": "^0.8.1"
-          },
-          "dependencies": {
-            "type-fest": {
-              "version": "0.8.1",
-              "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
-              "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
-              "dev": true
-            }
-          }
-        },
-        "resolve": {
-          "version": "1.20.0",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
-          "integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
-          "dev": true,
-          "requires": {
-            "is-core-module": "^2.2.0",
-            "path-parse": "^1.0.6"
           }
         },
         "type-fest": {
@@ -25653,9 +25419,9 @@
           "dev": true
         },
         "yargs-parser": {
-          "version": "20.2.7",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.7.tgz",
-          "integrity": "sha512-FiNkvbeHzB/syOjIUxFDCnhSfzAL8R5vs40MgLFBorXACCOAEaWu0gRZl14vG8MR9AOJIZbmkjhusqBYZ3HTHw==",
+          "version": "20.2.9",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+          "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
           "dev": true
         }
       }
@@ -25689,33 +25455,6 @@
       "resolved": "https://registry.npmjs.org/microevent.ts/-/microevent.ts-0.1.1.tgz",
       "integrity": "sha512-jo1OfR4TaEwd5HOrt5+tAZ9mqT4jmpNAusXtyfNzqVm9uiSYFZlKM1wYL4oU7azZW/PxQW53wM0S6OR1JHNa2g==",
       "dev": true
-    },
-    "micromark": {
-      "version": "2.11.4",
-      "resolved": "https://registry.npmjs.org/micromark/-/micromark-2.11.4.tgz",
-      "integrity": "sha512-+WoovN/ppKolQOFIAajxi7Lu9kInbPxFuTBVEavFcL8eAfVstoc5MocPmqBeAdBOJV00uaVjegzH4+MA0DN/uA==",
-      "dev": true,
-      "requires": {
-        "debug": "^4.0.0",
-        "parse-entities": "^2.0.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "4.3.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
-          "dev": true,
-          "requires": {
-            "ms": "2.1.2"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-          "dev": true
-        }
-      }
     },
     "micromatch": {
       "version": "3.1.10",
@@ -25837,13 +25576,13 @@
         "arrify": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-          "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
+          "integrity": "sha512-3CYzex9M9FGQjCGMGyi6/31c8GJbgb0qGyrx5HWxPd0aCwh4cB2YjMb2Xf9UuoogrMrlO9cTqnB5rI5GHZTcUA==",
           "dev": true
         },
         "is-plain-obj": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
-          "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
+          "integrity": "sha512-yvkRyxmFKEOQ4pNXCmJG5AEQNlXJS5LaONXo5/cLdTZdWvsZ1ioJEonLGAosKlMWE8lwUy/bJzMjcw8az73+Fg==",
           "dev": true
         }
       }
@@ -26183,12 +25922,6 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
       "integrity": "sha1-LRDAa9/TEuqXd2laTShDlFa3WUI=",
-      "dev": true
-    },
-    "normalize-selector": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/normalize-selector/-/normalize-selector-0.2.0.tgz",
-      "integrity": "sha1-0LFF62kRicY6eNIB3E/bEpPvDAM=",
       "dev": true
     },
     "normalize-url": {
@@ -27394,37 +27127,20 @@
         "postcss-resolve-nested-selector": "^0.1.1"
       },
       "dependencies": {
-        "chalk": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
-          },
-          "dependencies": {
-            "supports-color": {
-              "version": "5.5.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-              "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-              "dev": true,
-              "requires": {
-                "has-flag": "^3.0.0"
-              }
-            }
-          }
+        "picocolors": {
+          "version": "0.2.1",
+          "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-0.2.1.tgz",
+          "integrity": "sha512-cMlDqaLEqfSaW8Z7N5Jw+lyIW869EzT73/F5lhtY9cLGoVxSXznfgfXMO0Z5K0o0Q2TkTXq+0KFsdnSe3jDViA==",
+          "dev": true
         },
         "postcss": {
-          "version": "7.0.36",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.36.tgz",
-          "integrity": "sha512-BebJSIUMwJHRH0HAQoxN4u1CN86glsrwsW0q7T+/m44eXOUAxSNdHRkNZPYz5vVUbg17hFgOQDE7fZk7li3pZw==",
+          "version": "7.0.39",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.39.tgz",
+          "integrity": "sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==",
           "dev": true,
           "requires": {
-            "chalk": "^2.4.2",
-            "source-map": "^0.6.1",
-            "supports-color": "^6.1.0"
+            "picocolors": "^0.2.1",
+            "source-map": "^0.6.1"
           }
         },
         "source-map": {
@@ -27432,15 +27148,6 @@
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
           "dev": true
-        },
-        "supports-color": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^3.0.0"
-          }
         }
       }
     },
@@ -27835,74 +27542,6 @@
         }
       }
     },
-    "postcss-html": {
-      "version": "0.36.0",
-      "resolved": "https://registry.npmjs.org/postcss-html/-/postcss-html-0.36.0.tgz",
-      "integrity": "sha512-HeiOxGcuwID0AFsNAL0ox3mW6MHH5cstWN1Z3Y+n6H+g12ih7LHdYxWwEA/QmrebctLjo79xz9ouK3MroHwOJw==",
-      "dev": true,
-      "requires": {
-        "htmlparser2": "^3.10.0"
-      }
-    },
-    "postcss-less": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/postcss-less/-/postcss-less-3.1.4.tgz",
-      "integrity": "sha512-7TvleQWNM2QLcHqvudt3VYjULVB49uiW6XzEUFmvwHzvsOEF5MwBrIXZDJQvJNFGjJQTzSzZnDoCJ8h/ljyGXA==",
-      "dev": true,
-      "requires": {
-        "postcss": "^7.0.14"
-      },
-      "dependencies": {
-        "chalk": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
-          },
-          "dependencies": {
-            "supports-color": {
-              "version": "5.5.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-              "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-              "dev": true,
-              "requires": {
-                "has-flag": "^3.0.0"
-              }
-            }
-          }
-        },
-        "postcss": {
-          "version": "7.0.36",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.36.tgz",
-          "integrity": "sha512-BebJSIUMwJHRH0HAQoxN4u1CN86glsrwsW0q7T+/m44eXOUAxSNdHRkNZPYz5vVUbg17hFgOQDE7fZk7li3pZw==",
-          "dev": true,
-          "requires": {
-            "chalk": "^2.4.2",
-            "source-map": "^0.6.1",
-            "supports-color": "^6.1.0"
-          }
-        },
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true
-        },
-        "supports-color": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^3.0.0"
-          }
-        }
-      }
-    },
     "postcss-load-config": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-3.1.0.tgz",
@@ -27993,7 +27632,7 @@
     "postcss-media-query-parser": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/postcss-media-query-parser/-/postcss-media-query-parser-0.2.3.tgz",
-      "integrity": "sha1-J7Ocb02U+Bsac7j3Y1HGCeXO8kQ=",
+      "integrity": "sha512-3sOlxmbKcSHMjlUXQZKQ06jOswE7oVkXPxmZdoB1r5l0q6gTFTQSHxNxOrCccElbW7dxNytifNEo8qidX2Vsig==",
       "dev": true
     },
     "postcss-merge-longhand": {
@@ -28561,186 +28200,20 @@
     "postcss-resolve-nested-selector": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/postcss-resolve-nested-selector/-/postcss-resolve-nested-selector-0.1.1.tgz",
-      "integrity": "sha1-Kcy8fDfe36wwTp//C/FZaz9qDk4=",
+      "integrity": "sha512-HvExULSwLqHLgUy1rl3ANIqCsvMS0WHss2UOsXhXnQaZ9VCc2oBvIpXrl00IUFT5ZDITME0o6oiXeiHr2SAIfw==",
       "dev": true
     },
     "postcss-safe-parser": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/postcss-safe-parser/-/postcss-safe-parser-4.0.2.tgz",
-      "integrity": "sha512-Uw6ekxSWNLCPesSv/cmqf2bY/77z11O7jZGPax3ycZMFU/oi2DMH9i89AdHc1tRwFg/arFoEwX0IS3LCUxJh1g==",
-      "dev": true,
-      "requires": {
-        "postcss": "^7.0.26"
-      },
-      "dependencies": {
-        "chalk": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
-          },
-          "dependencies": {
-            "supports-color": {
-              "version": "5.5.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-              "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-              "dev": true,
-              "requires": {
-                "has-flag": "^3.0.0"
-              }
-            }
-          }
-        },
-        "postcss": {
-          "version": "7.0.36",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.36.tgz",
-          "integrity": "sha512-BebJSIUMwJHRH0HAQoxN4u1CN86glsrwsW0q7T+/m44eXOUAxSNdHRkNZPYz5vVUbg17hFgOQDE7fZk7li3pZw==",
-          "dev": true,
-          "requires": {
-            "chalk": "^2.4.2",
-            "source-map": "^0.6.1",
-            "supports-color": "^6.1.0"
-          }
-        },
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true
-        },
-        "supports-color": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^3.0.0"
-          }
-        }
-      }
-    },
-    "postcss-sass": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/postcss-sass/-/postcss-sass-0.4.4.tgz",
-      "integrity": "sha512-BYxnVYx4mQooOhr+zer0qWbSPYnarAy8ZT7hAQtbxtgVf8gy+LSLT/hHGe35h14/pZDTw1DsxdbrwxBN++H+fg==",
-      "dev": true,
-      "requires": {
-        "gonzales-pe": "^4.3.0",
-        "postcss": "^7.0.21"
-      },
-      "dependencies": {
-        "chalk": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
-          },
-          "dependencies": {
-            "supports-color": {
-              "version": "5.5.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-              "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-              "dev": true,
-              "requires": {
-                "has-flag": "^3.0.0"
-              }
-            }
-          }
-        },
-        "postcss": {
-          "version": "7.0.36",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.36.tgz",
-          "integrity": "sha512-BebJSIUMwJHRH0HAQoxN4u1CN86glsrwsW0q7T+/m44eXOUAxSNdHRkNZPYz5vVUbg17hFgOQDE7fZk7li3pZw==",
-          "dev": true,
-          "requires": {
-            "chalk": "^2.4.2",
-            "source-map": "^0.6.1",
-            "supports-color": "^6.1.0"
-          }
-        },
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true
-        },
-        "supports-color": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^3.0.0"
-          }
-        }
-      }
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-safe-parser/-/postcss-safe-parser-6.0.0.tgz",
+      "integrity": "sha512-FARHN8pwH+WiS2OPCxJI8FuRJpTVnn6ZNFiqAM2aeW2LwTHWWmWgIyKC6cUo0L8aeKiF/14MNvnpls6R2PBeMQ==",
+      "dev": true
     },
     "postcss-scss": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/postcss-scss/-/postcss-scss-2.1.1.tgz",
-      "integrity": "sha512-jQmGnj0hSGLd9RscFw9LyuSVAa5Bl1/KBPqG1NQw9w8ND55nY4ZEsdlVuYJvLPpV+y0nwTV5v/4rHPzZRihQbA==",
-      "dev": true,
-      "requires": {
-        "postcss": "^7.0.6"
-      },
-      "dependencies": {
-        "chalk": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
-          },
-          "dependencies": {
-            "supports-color": {
-              "version": "5.5.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-              "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-              "dev": true,
-              "requires": {
-                "has-flag": "^3.0.0"
-              }
-            }
-          }
-        },
-        "postcss": {
-          "version": "7.0.36",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.36.tgz",
-          "integrity": "sha512-BebJSIUMwJHRH0HAQoxN4u1CN86glsrwsW0q7T+/m44eXOUAxSNdHRkNZPYz5vVUbg17hFgOQDE7fZk7li3pZw==",
-          "dev": true,
-          "requires": {
-            "chalk": "^2.4.2",
-            "source-map": "^0.6.1",
-            "supports-color": "^6.1.0"
-          }
-        },
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true
-        },
-        "supports-color": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^3.0.0"
-          }
-        }
-      }
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/postcss-scss/-/postcss-scss-4.0.4.tgz",
+      "integrity": "sha512-aBBbVyzA8b3hUL0MGrpydxxXKXFZc5Eqva0Q3V9qsBOLEMsjb6w49WfpsoWzpEgcqJGW4t7Rio8WXVU9Gd8vWg==",
+      "dev": true
     },
     "postcss-selector-parser": {
       "version": "6.0.2",
@@ -28770,12 +28243,6 @@
           "dev": true
         }
       }
-    },
-    "postcss-syntax": {
-      "version": "0.36.2",
-      "resolved": "https://registry.npmjs.org/postcss-syntax/-/postcss-syntax-0.36.2.tgz",
-      "integrity": "sha512-nBRg/i7E3SOHWxF3PpF5WnJM/jQ1YpY9000OaVXlAQj6Zp/kIqJxEDWIZ67tAd7NLuk7zqN4yqe9nc0oNAOs1w==",
-      "dev": true
     },
     "postcss-unique-selectors": {
       "version": "5.1.1",
@@ -29633,6 +29100,37 @@
         }
       }
     },
+    "read-pkg": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
+      "integrity": "sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==",
+      "dev": true,
+      "requires": {
+        "@types/normalize-package-data": "^2.4.0",
+        "normalize-package-data": "^2.5.0",
+        "parse-json": "^5.0.0",
+        "type-fest": "^0.6.0"
+      },
+      "dependencies": {
+        "type-fest": {
+          "version": "0.6.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
+          "integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
+          "dev": true
+        }
+      }
+    },
+    "read-pkg-up": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-7.0.1.tgz",
+      "integrity": "sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==",
+      "dev": true,
+      "requires": {
+        "find-up": "^4.1.0",
+        "read-pkg": "^5.2.0",
+        "type-fest": "^0.8.1"
+      }
+    },
     "readable-stream": {
       "version": "2.3.7",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
@@ -29817,28 +29315,6 @@
       "resolved": "https://registry.npmjs.org/relateurl/-/relateurl-0.2.7.tgz",
       "integrity": "sha1-VNvzd+UUQKypCkzSdGANP/LYiKk=",
       "dev": true
-    },
-    "remark": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/remark/-/remark-13.0.0.tgz",
-      "integrity": "sha512-HDz1+IKGtOyWN+QgBiAT0kn+2s6ovOxHyPAFGKVE81VSzJ+mq7RwHFledEvB5F1p4iJvOah/LOKdFuzvRnNLCA==",
-      "dev": true,
-      "requires": {
-        "remark-parse": "^9.0.0",
-        "remark-stringify": "^9.0.0",
-        "unified": "^9.1.0"
-      },
-      "dependencies": {
-        "remark-parse": {
-          "version": "9.0.0",
-          "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-9.0.0.tgz",
-          "integrity": "sha512-geKatMwSzEXKHuzBNU1z676sGcDcFoChMK38TgdHJNAYfFtsfHDQG7MoJAjs6sgYMqyLduCYWDIWZIxiPeafEw==",
-          "dev": true,
-          "requires": {
-            "mdast-util-from-markdown": "^0.8.0"
-          }
-        }
-      }
     },
     "remark-external-links": {
       "version": "8.0.0",
@@ -30107,15 +29583,6 @@
       "dev": true,
       "requires": {
         "mdast-squeeze-paragraphs": "^4.0.0"
-      }
-    },
-    "remark-stringify": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-9.0.1.tgz",
-      "integrity": "sha512-mWmNg3ZtESvZS8fv5PTvaPckdL4iNlCHTt8/e/8oN08nArHRHjNZMKzA/YW3+p7/lYqIw4nx1XsjCBo/AxNChg==",
-      "dev": true,
-      "requires": {
-        "mdast-util-to-markdown": "^0.6.0"
       }
     },
     "remove-trailing-separator": {
@@ -31217,12 +30684,6 @@
       "integrity": "sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q==",
       "dev": true
     },
-    "specificity": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/specificity/-/specificity-0.4.1.tgz",
-      "integrity": "sha512-1klA3Gi5PD1Wv9Q0wUoOQN1IWAuPu0D1U03ThXTr0cJ20+/iq2tHSDnK7Kk/0LXJ1ztUB2/1Os0wKmfyNgUQfg==",
-      "dev": true
-    },
     "split-string": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
@@ -31754,7 +31215,7 @@
     "style-search": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/style-search/-/style-search-0.1.0.tgz",
-      "integrity": "sha1-eVjHk+R+MuB9K1yv5cC/jhLneQI=",
+      "integrity": "sha512-Dj1Okke1C3uKKwQcetra4jSuk0DqbzbYtXipzFlFMZtowbF1x7BKJwB9AayVMyFARvU8EDrZdcax4At/452cAg==",
       "dev": true
     },
     "style-to-object": {
@@ -31789,81 +31250,58 @@
       }
     },
     "stylelint": {
-      "version": "13.13.1",
-      "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-13.13.1.tgz",
-      "integrity": "sha512-Mv+BQr5XTUrKqAXmpqm6Ddli6Ief+AiPZkRsIrAoUKFuq/ElkUh9ZMYxXD0iQNZ5ADghZKLOWz1h7hTClB7zgQ==",
+      "version": "14.9.1",
+      "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-14.9.1.tgz",
+      "integrity": "sha512-RdAkJdPiLqHawCSnu21nE27MjNXaVd4WcOHA4vK5GtIGjScfhNnaOuWR2wWdfKFAvcWQPOYe311iveiVKSmwsA==",
       "dev": true,
       "requires": {
-        "@stylelint/postcss-css-in-js": "^0.37.2",
-        "@stylelint/postcss-markdown": "^0.36.2",
-        "autoprefixer": "^9.8.6",
+        "@csstools/selector-specificity": "^2.0.1",
         "balanced-match": "^2.0.0",
-        "chalk": "^4.1.1",
-        "cosmiconfig": "^7.0.0",
-        "debug": "^4.3.1",
+        "colord": "^2.9.2",
+        "cosmiconfig": "^7.0.1",
+        "css-functions-list": "^3.1.0",
+        "debug": "^4.3.4",
         "execall": "^2.0.0",
-        "fast-glob": "^3.2.5",
+        "fast-glob": "^3.2.11",
         "fastest-levenshtein": "^1.0.12",
         "file-entry-cache": "^6.0.1",
         "get-stdin": "^8.0.0",
         "global-modules": "^2.0.0",
-        "globby": "^11.0.3",
+        "globby": "^11.1.0",
         "globjoin": "^0.1.4",
-        "html-tags": "^3.1.0",
-        "ignore": "^5.1.8",
+        "html-tags": "^3.2.0",
+        "ignore": "^5.2.0",
         "import-lazy": "^4.0.0",
         "imurmurhash": "^0.1.4",
-        "known-css-properties": "^0.21.0",
-        "lodash": "^4.17.21",
-        "log-symbols": "^4.1.0",
+        "is-plain-object": "^5.0.0",
+        "known-css-properties": "^0.25.0",
         "mathml-tag-names": "^2.1.3",
         "meow": "^9.0.0",
-        "micromatch": "^4.0.4",
-        "normalize-selector": "^0.2.0",
-        "postcss": "^7.0.35",
-        "postcss-html": "^0.36.0",
-        "postcss-less": "^3.1.4",
+        "micromatch": "^4.0.5",
+        "normalize-path": "^3.0.0",
+        "picocolors": "^1.0.0",
+        "postcss": "^8.4.14",
         "postcss-media-query-parser": "^0.2.3",
         "postcss-resolve-nested-selector": "^0.1.1",
-        "postcss-safe-parser": "^4.0.2",
-        "postcss-sass": "^0.4.4",
-        "postcss-scss": "^2.1.1",
-        "postcss-selector-parser": "^6.0.5",
-        "postcss-syntax": "^0.36.2",
-        "postcss-value-parser": "^4.1.0",
+        "postcss-safe-parser": "^6.0.0",
+        "postcss-selector-parser": "^6.0.10",
+        "postcss-value-parser": "^4.2.0",
         "resolve-from": "^5.0.0",
-        "slash": "^3.0.0",
-        "specificity": "^0.4.1",
-        "string-width": "^4.2.2",
-        "strip-ansi": "^6.0.0",
+        "string-width": "^4.2.3",
+        "strip-ansi": "^6.0.1",
         "style-search": "^0.1.0",
-        "sugarss": "^2.0.0",
+        "supports-hyperlinks": "^2.2.0",
         "svg-tags": "^1.0.0",
-        "table": "^6.6.0",
+        "table": "^6.8.0",
         "v8-compile-cache": "^2.3.0",
-        "write-file-atomic": "^3.0.3"
+        "write-file-atomic": "^4.0.1"
       },
       "dependencies": {
         "ansi-regex": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
           "dev": true
-        },
-        "autoprefixer": {
-          "version": "9.8.6",
-          "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-9.8.6.tgz",
-          "integrity": "sha512-XrvP4VVHdRBCdX1S3WXVD8+RyG9qeb1D5Sn1DeLiG2xfSpzellk5k54xbUERJ3M5DggQxes39UGOTP8CFrEGbg==",
-          "dev": true,
-          "requires": {
-            "browserslist": "^4.12.0",
-            "caniuse-lite": "^1.0.30001109",
-            "colorette": "^1.2.1",
-            "normalize-range": "^0.1.2",
-            "num2fraction": "^1.2.2",
-            "postcss": "^7.0.32",
-            "postcss-value-parser": "^4.1.0"
-          }
         },
         "balanced-match": {
           "version": "2.0.0",
@@ -31881,9 +31319,9 @@
           }
         },
         "cosmiconfig": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.0.0.tgz",
-          "integrity": "sha512-pondGvTuVYDk++upghXJabWzL6Kxu6f26ljFw64Swq9v6sQPUL3EUlVDV56diOjpCayKihL6hVe8exIACU4XcA==",
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.0.1.tgz",
+          "integrity": "sha512-a1YWNUV2HwGimB7dU2s1wUMurNKjpx60HxBB6xUM8Re+2s1g1IIfJvFR0/iCF+XHdE0GMTKTuLR32UQff4TEyQ==",
           "dev": true,
           "requires": {
             "@types/parse-json": "^4.0.0",
@@ -31894,9 +31332,9 @@
           }
         },
         "debug": {
-          "version": "4.3.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+          "version": "4.3.4",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+          "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
           "dev": true,
           "requires": {
             "ms": "2.1.2"
@@ -31909,17 +31347,16 @@
           "dev": true
         },
         "fast-glob": {
-          "version": "3.2.5",
-          "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.5.tgz",
-          "integrity": "sha512-2DtFcgT68wiTTiwZ2hNdJfcHNke9XOfnwmBRWXhmeKM8rF0TGwmC/Qto3S7RoZKp5cilZbxzO5iTNTQsJ+EeDg==",
+          "version": "3.2.11",
+          "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.11.tgz",
+          "integrity": "sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==",
           "dev": true,
           "requires": {
             "@nodelib/fs.stat": "^2.0.2",
             "@nodelib/fs.walk": "^1.2.3",
-            "glob-parent": "^5.1.0",
+            "glob-parent": "^5.1.2",
             "merge2": "^1.3.0",
-            "micromatch": "^4.0.2",
-            "picomatch": "^2.2.1"
+            "micromatch": "^4.0.4"
           }
         },
         "fill-range": {
@@ -31941,18 +31378,30 @@
           }
         },
         "globby": {
-          "version": "11.0.3",
-          "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.3.tgz",
-          "integrity": "sha512-ffdmosjA807y7+lA1NM0jELARVmYul/715xiILEjo3hBLPTcirgQNnXECn5g3mtR8TOLCVbkfua1Hpen25/Xcg==",
+          "version": "11.1.0",
+          "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+          "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
           "dev": true,
           "requires": {
             "array-union": "^2.1.0",
             "dir-glob": "^3.0.1",
-            "fast-glob": "^3.1.1",
-            "ignore": "^5.1.4",
-            "merge2": "^1.3.0",
+            "fast-glob": "^3.2.9",
+            "ignore": "^5.2.0",
+            "merge2": "^1.4.1",
             "slash": "^3.0.0"
           }
+        },
+        "html-tags": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/html-tags/-/html-tags-3.2.0.tgz",
+          "integrity": "sha512-vy7ClnArOZwCnqZgvv+ddgHgJiAFXe3Ge9ML5/mBctVJoUoYPCdxVucOywjDARn6CVoh3dRSFdPHy2sX80L0Wg==",
+          "dev": true
+        },
+        "ignore": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
+          "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
+          "dev": true
         },
         "is-fullwidth-code-point": {
           "version": "3.0.0",
@@ -31966,38 +31415,20 @@
           "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
           "dev": true
         },
-        "lodash": {
-          "version": "4.17.21",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+        "is-plain-object": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+          "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
           "dev": true
         },
-        "log-symbols": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
-          "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
-          "dev": true,
-          "requires": {
-            "chalk": "^4.1.0",
-            "is-unicode-supported": "^0.1.0"
-          }
-        },
         "micromatch": {
-          "version": "4.0.4",
-          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.4.tgz",
-          "integrity": "sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==",
+          "version": "4.0.5",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
+          "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
           "dev": true,
           "requires": {
-            "braces": "^3.0.1",
-            "picomatch": "^2.2.3"
-          },
-          "dependencies": {
-            "picomatch": {
-              "version": "2.2.3",
-              "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.3.tgz",
-              "integrity": "sha512-KpELjfwcCDUb9PeigTs2mBJzXUPzAuP2oPcA989He8Rte0+YUAjw1JVedDhuTKPkHjSYzMN3npC9luThGYEKdg==",
-              "dev": true
-            }
+            "braces": "^3.0.2",
+            "picomatch": "^2.3.1"
           }
         },
         "ms": {
@@ -32006,50 +31437,33 @@
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true
         },
-        "postcss": {
-          "version": "7.0.36",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.36.tgz",
-          "integrity": "sha512-BebJSIUMwJHRH0HAQoxN4u1CN86glsrwsW0q7T+/m44eXOUAxSNdHRkNZPYz5vVUbg17hFgOQDE7fZk7li3pZw==",
-          "dev": true,
-          "requires": {
-            "chalk": "^2.4.2",
-            "source-map": "^0.6.1",
-            "supports-color": "^6.1.0"
-          },
-          "dependencies": {
-            "chalk": {
-              "version": "2.4.2",
-              "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-              "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-              "dev": true,
-              "requires": {
-                "ansi-styles": "^3.2.1",
-                "escape-string-regexp": "^1.0.5",
-                "supports-color": "^5.3.0"
-              },
-              "dependencies": {
-                "supports-color": {
-                  "version": "5.5.0",
-                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-                  "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-                  "dev": true,
-                  "requires": {
-                    "has-flag": "^3.0.0"
-                  }
-                }
-              }
-            }
-          }
+        "picomatch": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+          "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+          "dev": true
         },
         "postcss-selector-parser": {
-          "version": "6.0.5",
-          "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.5.tgz",
-          "integrity": "sha512-aFYPoYmXbZ1V6HZaSvat08M97A8HqO6Pjz+PiNpw/DhuRrC72XWAdp3hL6wusDCN31sSmcZyMGa2hZEuX+Xfhg==",
+          "version": "6.0.10",
+          "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.10.tgz",
+          "integrity": "sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==",
           "dev": true,
           "requires": {
             "cssesc": "^3.0.0",
             "util-deprecate": "^1.0.2"
           }
+        },
+        "postcss-value-parser": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+          "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+          "dev": true
+        },
+        "signal-exit": {
+          "version": "3.0.7",
+          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+          "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+          "dev": true
         },
         "slash": {
           "version": "3.0.0",
@@ -32057,39 +31471,24 @@
           "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
           "dev": true
         },
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true
-        },
         "string-width": {
-          "version": "4.2.2",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
-          "integrity": "sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==",
+          "version": "4.2.3",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+          "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
           "dev": true,
           "requires": {
             "emoji-regex": "^8.0.0",
             "is-fullwidth-code-point": "^3.0.0",
-            "strip-ansi": "^6.0.0"
+            "strip-ansi": "^6.0.1"
           }
         },
         "strip-ansi": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+          "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
           "dev": true,
           "requires": {
-            "ansi-regex": "^5.0.0"
-          }
-        },
-        "supports-color": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^3.0.0"
+            "ansi-regex": "^5.0.1"
           }
         },
         "to-regex-range": {
@@ -32100,41 +31499,92 @@
           "requires": {
             "is-number": "^7.0.0"
           }
+        },
+        "write-file-atomic": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-4.0.1.tgz",
+          "integrity": "sha512-nSKUxgAbyioruk6hU87QzVbY279oYT6uiwgDoujth2ju4mJ+TZau7SQBhtbTmUyuNYTuXnSyRn66FV0+eCgcrQ==",
+          "dev": true,
+          "requires": {
+            "imurmurhash": "^0.1.4",
+            "signal-exit": "^3.0.7"
+          }
         }
       }
     },
     "stylelint-config-prettier": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/stylelint-config-prettier/-/stylelint-config-prettier-8.0.2.tgz",
-      "integrity": "sha512-TN1l93iVTXpF9NJstlvP7nOu9zY2k+mN0NSFQ/VEGz15ZIP9ohdDZTtCWHs5LjctAhSAzaILULGbgiM0ItId3A==",
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/stylelint-config-prettier/-/stylelint-config-prettier-9.0.3.tgz",
+      "integrity": "sha512-5n9gUDp/n5tTMCq1GLqSpA30w2sqWITSSEiAWQlpxkKGAUbjcemQ0nbkRvRUa0B1LgD3+hCvdL7B1eTxy1QHJg==",
       "dev": true
     },
-    "stylelint-config-recommended": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-5.0.0.tgz",
-      "integrity": "sha512-c8aubuARSu5A3vEHLBeOSJt1udOdS+1iue7BmJDTSXoCBmfEQmmWX+59vYIj3NQdJBY6a/QRv1ozVFpaB9jaqA==",
-      "dev": true
-    },
-    "stylelint-config-standard": {
-      "version": "22.0.0",
-      "resolved": "https://registry.npmjs.org/stylelint-config-standard/-/stylelint-config-standard-22.0.0.tgz",
-      "integrity": "sha512-uQVNi87SHjqTm8+4NIP5NMAyY/arXrBgimaaT7skvRfE9u3JKXRK9KBkbr4pVmeciuCcs64kAdjlxfq6Rur7Hw==",
+    "stylelint-config-recommended-scss": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/stylelint-config-recommended-scss/-/stylelint-config-recommended-scss-6.0.0.tgz",
+      "integrity": "sha512-6QOe2/OzXV2AP5FE12A7+qtKdZik7Saf42SMMl84ksVBBPpTdrV+9HaCbPYiRMiwELY9hXCVdH4wlJ+YJb5eig==",
       "dev": true,
       "requires": {
-        "stylelint-config-recommended": "^5.0.0"
+        "postcss-scss": "^4.0.2",
+        "stylelint-config-recommended": "^7.0.0",
+        "stylelint-scss": "^4.0.0"
+      },
+      "dependencies": {
+        "postcss-selector-parser": {
+          "version": "6.0.10",
+          "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.10.tgz",
+          "integrity": "sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==",
+          "dev": true,
+          "requires": {
+            "cssesc": "^3.0.0",
+            "util-deprecate": "^1.0.2"
+          }
+        },
+        "stylelint-config-recommended": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-7.0.0.tgz",
+          "integrity": "sha512-yGn84Bf/q41J4luis1AZ95gj0EQwRX8lWmGmBwkwBNSkpGSpl66XcPTulxGa/Z91aPoNGuIGBmFkcM1MejMo9Q==",
+          "dev": true
+        },
+        "stylelint-scss": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/stylelint-scss/-/stylelint-scss-4.2.0.tgz",
+          "integrity": "sha512-HHHMVKJJ5RM9pPIbgJ/XA67h9H0407G68Rm69H4fzFbFkyDMcTV1Byep3qdze5+fJ3c0U7mJrbj6S0Fg072uZA==",
+          "dev": true,
+          "requires": {
+            "lodash": "^4.17.21",
+            "postcss-media-query-parser": "^0.2.3",
+            "postcss-resolve-nested-selector": "^0.1.1",
+            "postcss-selector-parser": "^6.0.6",
+            "postcss-value-parser": "^4.1.0"
+          }
+        }
       }
     },
-    "stylelint-scss": {
-      "version": "3.21.0",
-      "resolved": "https://registry.npmjs.org/stylelint-scss/-/stylelint-scss-3.21.0.tgz",
-      "integrity": "sha512-CMI2wSHL+XVlNExpauy/+DbUcB/oUZLARDtMIXkpV/5yd8nthzylYd1cdHeDMJVBXeYHldsnebUX6MoV5zPW4A==",
+    "stylelint-config-standard-scss": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/stylelint-config-standard-scss/-/stylelint-config-standard-scss-4.0.0.tgz",
+      "integrity": "sha512-xizu8PTEyB6zYXBiVg6VtvUYn9m57x+6ZtaOdaxsfpbe5eagLPGNlbYnKfm/CfN69ArUpnwR6LjgsTHzlGbtXQ==",
       "dev": true,
       "requires": {
-        "lodash": "^4.17.15",
-        "postcss-media-query-parser": "^0.2.3",
-        "postcss-resolve-nested-selector": "^0.1.1",
-        "postcss-selector-parser": "^6.0.2",
-        "postcss-value-parser": "^4.1.0"
+        "stylelint-config-recommended-scss": "^6.0.0",
+        "stylelint-config-standard": "^25.0.0"
+      },
+      "dependencies": {
+        "stylelint-config-recommended": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-7.0.0.tgz",
+          "integrity": "sha512-yGn84Bf/q41J4luis1AZ95gj0EQwRX8lWmGmBwkwBNSkpGSpl66XcPTulxGa/Z91aPoNGuIGBmFkcM1MejMo9Q==",
+          "dev": true
+        },
+        "stylelint-config-standard": {
+          "version": "25.0.0",
+          "resolved": "https://registry.npmjs.org/stylelint-config-standard/-/stylelint-config-standard-25.0.0.tgz",
+          "integrity": "sha512-21HnP3VSpaT1wFjFvv9VjvOGDtAviv47uTp3uFmzcN+3Lt+RYRv6oAplLaV51Kf792JSxJ6svCJh/G18E9VnCA==",
+          "dev": true,
+          "requires": {
+            "stylelint-config-recommended": "^7.0.0"
+          }
+        }
       }
     },
     "stylelint-selector-bem-pattern": {
@@ -32147,84 +31597,6 @@
         "postcss": "^8.3.6",
         "postcss-bem-linter": "^3.3.0",
         "stylelint": ">=13.13.1"
-      },
-      "dependencies": {
-        "colorette": {
-          "version": "1.2.2",
-          "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.2.2.tgz",
-          "integrity": "sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w==",
-          "dev": true
-        },
-        "postcss": {
-          "version": "8.3.6",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.3.6.tgz",
-          "integrity": "sha512-wG1cc/JhRgdqB6WHEuyLTedf3KIRuD0hG6ldkFEZNCjRxiC+3i6kkWUUbiJQayP28iwG35cEmAbe98585BYV0A==",
-          "dev": true,
-          "requires": {
-            "colorette": "^1.2.2",
-            "nanoid": "^3.1.23",
-            "source-map-js": "^0.6.2"
-          }
-        }
-      }
-    },
-    "sugarss": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/sugarss/-/sugarss-2.0.0.tgz",
-      "integrity": "sha512-WfxjozUk0UVA4jm+U1d736AUpzSrNsQcIbyOkoE364GrtWmIrFdk5lksEupgWMD4VaT/0kVx1dobpiDumSgmJQ==",
-      "dev": true,
-      "requires": {
-        "postcss": "^7.0.2"
-      },
-      "dependencies": {
-        "chalk": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
-          },
-          "dependencies": {
-            "supports-color": {
-              "version": "5.5.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-              "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-              "dev": true,
-              "requires": {
-                "has-flag": "^3.0.0"
-              }
-            }
-          }
-        },
-        "postcss": {
-          "version": "7.0.36",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.36.tgz",
-          "integrity": "sha512-BebJSIUMwJHRH0HAQoxN4u1CN86glsrwsW0q7T+/m44eXOUAxSNdHRkNZPYz5vVUbg17hFgOQDE7fZk7li3pZw==",
-          "dev": true,
-          "requires": {
-            "chalk": "^2.4.2",
-            "source-map": "^0.6.1",
-            "supports-color": "^6.1.0"
-          }
-        },
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true
-        },
-        "supports-color": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^3.0.0"
-          }
-        }
       }
     },
     "supports-color": {
@@ -32271,7 +31643,7 @@
     "svg-tags": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/svg-tags/-/svg-tags-1.0.0.tgz",
-      "integrity": "sha1-WPcc7jvVGbWdSyqEO2x95krAR2Q=",
+      "integrity": "sha512-ovssysQTa+luh7A5Weu3Rta6FJlFBBbInjOh722LIt6klpU2/HtdUbszju/G4devcvk8PGt7FCLv5wftu3THUA==",
       "dev": true
     },
     "svgo": {
@@ -32344,24 +31716,22 @@
       }
     },
     "table": {
-      "version": "6.6.0",
-      "resolved": "https://registry.npmjs.org/table/-/table-6.6.0.tgz",
-      "integrity": "sha512-iZMtp5tUvcnAdtHpZTWLPF0M7AgiQsURR2DwmxnJwSy8I3+cY+ozzVvYha3BOLG2TB+L0CqjIz+91htuj6yCXg==",
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/table/-/table-6.8.0.tgz",
+      "integrity": "sha512-s/fitrbVeEyHKFa7mFdkuQMWlH1Wgw/yEXMt5xACT4ZpzWFluehAxRtUUQKPuWhaLAWhFcVx6w3oC8VKaUfPGA==",
       "dev": true,
       "requires": {
         "ajv": "^8.0.1",
-        "lodash.clonedeep": "^4.5.0",
-        "lodash.flatten": "^4.4.0",
         "lodash.truncate": "^4.4.2",
         "slice-ansi": "^4.0.0",
-        "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.0"
+        "string-width": "^4.2.3",
+        "strip-ansi": "^6.0.1"
       },
       "dependencies": {
         "ajv": {
-          "version": "8.1.0",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.1.0.tgz",
-          "integrity": "sha512-B/Sk2Ix7A36fs/ZkuGLIR86EdjbgR6fsAcbx9lOP/QBSXujDNbVmIS/U4Itz5k8fPFDeVZl/zQ/gJW4Jrq6XjQ==",
+          "version": "8.11.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
+          "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
           "dev": true,
           "requires": {
             "fast-deep-equal": "^3.1.1",
@@ -32371,9 +31741,9 @@
           }
         },
         "ansi-regex": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
           "dev": true
         },
         "emoji-regex": {
@@ -32395,23 +31765,23 @@
           "dev": true
         },
         "string-width": {
-          "version": "4.2.2",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
-          "integrity": "sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==",
+          "version": "4.2.3",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+          "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
           "dev": true,
           "requires": {
             "emoji-regex": "^8.0.0",
             "is-fullwidth-code-point": "^3.0.0",
-            "strip-ansi": "^6.0.0"
+            "strip-ansi": "^6.0.1"
           }
         },
         "strip-ansi": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+          "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
           "dev": true,
           "requires": {
-            "ansi-regex": "^5.0.0"
+            "ansi-regex": "^5.0.1"
           }
         }
       }
@@ -33235,15 +32605,6 @@
       "resolved": "https://registry.npmjs.org/unist-builder/-/unist-builder-2.0.3.tgz",
       "integrity": "sha512-f98yt5pnlMWlzP539tPc4grGMsFaQQlP/vM396b00jngsiINumNmsY8rkXjfoi1c6QaM8nQ3vaGDuoKWbe/1Uw==",
       "dev": true
-    },
-    "unist-util-find-all-after": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/unist-util-find-all-after/-/unist-util-find-all-after-3.0.2.tgz",
-      "integrity": "sha512-xaTC/AGZ0rIM2gM28YVRAFPIZpzbpDtU3dRmp7EXlNVA8ziQc4hY3H7BHXM1J49nEmiqc3svnqMReW+PGqbZKQ==",
-      "dev": true,
-      "requires": {
-        "unist-util-is": "^4.0.0"
-      }
     },
     "unist-util-generated": {
       "version": "1.1.6",

--- a/package.json
+++ b/package.json
@@ -80,10 +80,9 @@
     "semver": "^7.3.5",
     "simple-git": "^3.4.0",
     "size-limit": "^6.0.4",
-    "stylelint": "^13.13.1",
-    "stylelint-config-prettier": "^8.0.2",
-    "stylelint-config-standard": "^22.0.0",
-    "stylelint-scss": "^3.19.0",
+    "stylelint": "^14.9.1",
+    "stylelint-config-prettier": "^9.0.3",
+    "stylelint-config-standard-scss": "^4.0.0",
     "stylelint-selector-bem-pattern": "^2.1.0",
     "typescript": "^4.5.5",
     "url-polyfill": "^1.1.12"

--- a/scss/1-settings/_colour-language.scss
+++ b/scss/1-settings/_colour-language.scss
@@ -24,7 +24,6 @@ $cads-language__secondary-button-hover-colour: $cads-language__hover-background-
 $cads-language__tertiary-button-dark-hover-background-colour: palette.$cads-palette__heritage-blue-dark !default;
 $cads-language__tertiary-button-dark-hover-colour: $cads-language__brand-primary-contrast !default;
 $cads-language__tertiary-button-dark-hover-border-colour: $cads-language__brand-primary-contrast !default;
-
 $cads-language__button-shadow-colour: palette.$cads-palette__teal-dark !default;
 $cads-language__warning-colour: palette.$cads-palette__red !default;
 $cads-language__success-colour: palette.$cads-palette__green !default;
@@ -42,7 +41,6 @@ $cads-header__link-visited-colour: $cads-language__link-visited-colour !default;
 $cads-header__link-active-colour: $cads-language__link-active-colour !default;
 $cads-header__link-focus-highlight-colour: palette.$cads-palette__black !default;
 $cads-header__link-focus-colour: $cads-language__focus-colour !default;
-
 $cads-header__sign-out-background-colour: $cads-language__brand-primary-contrast !default;
 $cads-header__sign-out-colour: $cads-language__primary-button-colour !default;
 $cads-header__sign-out-border-colour: $cads-language__primary-button-colour !default;

--- a/scss/1-settings/_grid.scss
+++ b/scss/1-settings/_grid.scss
@@ -1,7 +1,6 @@
 @use '../1-settings/spacing-sizing' as spacing;
 
 $cads-grid-columns: 12 !default;
-
 $cads-grid-breakpoint-gutters: (
   // 16px
   sm: spacing.$cads-spacing-4,
@@ -10,7 +9,6 @@ $cads-grid-breakpoint-gutters: (
   // 32px
   lg: spacing.$cads-spacing-7
 ) !default;
-
 $cads-nav-breakpoint-gutters: (
   // 0px
   sm: spacing.$cads-spacing-2,
@@ -19,7 +17,6 @@ $cads-nav-breakpoint-gutters: (
   // 16px
   lg: spacing.$cads-spacing-6
 ) !default;
-
 $cads-container-max-widths: (
   lg: spacing.$cads-max-content-size,
 ) !default;

--- a/scss/1-settings/_spacing-sizing.scss
+++ b/scss/1-settings/_spacing-sizing.scss
@@ -1,5 +1,4 @@
 $cads-max-content-size: 1090px;
-
 $cads-spacing-1: 0.25rem; // 4px
 $cads-spacing-2: 0.5rem; // 8px
 $cads-spacing-3: 0.75rem; // 12px

--- a/scss/2-tools/_breakpoints.scss
+++ b/scss/2-tools/_breakpoints.scss
@@ -1,3 +1,6 @@
+@use 'sass:list';
+@use 'sass:map';
+
 @use '../1-settings/breakpoints' as breakpoint-settings;
 
 // Name of the next breakpoint (null for the last one)
@@ -6,7 +9,7 @@
   $breakpoints: breakpoint-settings.$cads-breakpoints,
   $breakpoint-names: map-keys(breakpoint-settings.$cads-breakpoints)
 ) {
-  $n: index($breakpoint-names, $name);
+  $n: list.index($breakpoint-names, $name);
 
   @return if(
     $n < length($breakpoint-names),
@@ -20,7 +23,7 @@
   $name,
   $breakpoints: breakpoint-settings.$cads-breakpoints
 ) {
-  $min: map-get($breakpoints, $name);
+  $min: map.get($breakpoints, $name);
 
   @return if($min != 0, $min, null);
 }

--- a/scss/2-tools/_interactive-elements.scss
+++ b/scss/2-tools/_interactive-elements.scss
@@ -1,6 +1,7 @@
 @mixin cads-interactive-focus() {
   outline: none;
   border-color: $cads-language__focus-border-colour;
+
   // We need to use box-shadow instead of outline as outline does not have a radius
   box-shadow: 0 0 0 2px $cads-language__focus-colour;
 }
@@ -12,7 +13,7 @@
   outline: none;
 
   &:focus {
-    @include cads-interactive-focus();
+    @include cads-interactive-focus;
   }
 }
 
@@ -49,6 +50,6 @@
 
   &:active,
   &:focus {
-    @include cads-nav-link-focus();
+    @include cads-nav-link-focus;
   }
 }

--- a/scss/3-generics/_fonts.scss
+++ b/scss/3-generics/_fonts.scss
@@ -33,7 +33,7 @@
 // ============================================================================
 
 @font-face {
-  font-family: 'cads';
+  font-family: cads;
   src: url('../../assets/fonts/cads.eot?d7dccfce9cf3c38908cc8e38fb40341b?#iefix')
       format('embedded-opentype'),
     url('../../assets/fonts/cads.woff?d7dccfce9cf3c38908cc8e38fb40341b')
@@ -48,7 +48,7 @@
 }
 
 @mixin cads-icon {
-  font-family: 'cads' !important;
+  font-family: cads !important;
   speak: none;
   font-style: normal;
   font-weight: normal;
@@ -68,48 +68,63 @@
 .cads-icon_arrow-right::before {
   content: '\0041';
 }
+
 .cads-icon_checkmark::before {
   content: '\0042';
 }
+
 .cads-icon_exclamation-circle::before {
   content: '\0043';
 }
+
 .cads-icon_arrow-left::before {
   content: '\0044';
 }
+
 .cads-icon_external-link::before {
   content: '\0045';
 }
+
 .cads-icon_file::before {
   content: '\0046';
 }
+
 .cads-icon_minus::before {
   content: '\0047';
 }
+
 .cads-icon_plus::before {
   content: '\0048';
 }
+
 .cads-icon_print::before {
   content: '\0049';
 }
+
 .cads-icon_redo::before {
   content: '\004a';
 }
+
 .cads-icon_search::before {
   content: '\004b';
 }
+
 .cads-icon_delete::before {
   content: '\004c';
 }
+
 .cads-icon_email::before {
   content: '\004d';
 }
+
 .cads-icon_references::before {
   content: '\004e';
 }
+
 .cads-icon_undo::before {
   content: '\004f';
 }
+
 // Close icon is + icon rotated
 .cads-icon_close::before {
   content: '\0048';

--- a/scss/4-elements/_buttons.scss
+++ b/scss/4-elements/_buttons.scss
@@ -10,7 +10,7 @@ $button-shadow-size: 4px;
 @mixin cads-button-defaults() {
   @include cads-transition-animation(background);
 
-  -webkit-appearance: none;
+  appearance: none;
   box-sizing: border-box;
   width: auto;
   text-align: center;
@@ -36,7 +36,7 @@ $button-shadow-size: 4px;
 .cads-button__primary,
 .cads-button__secondary,
 .cads-button__tertiary {
-  @include cads-button-defaults();
+  @include cads-button-defaults;
 
   border-radius: $cads-border-radius;
   border: solid $cads-border-width-medium $cads-language__primary-button-colour;

--- a/scss/4-elements/_links.scss
+++ b/scss/4-elements/_links.scss
@@ -47,7 +47,7 @@ a,
 
 // Reset button styles when styled like a link
 %cads-linkbutton-base {
-  -webkit-appearance: none;
+  appearance: none;
   border: none;
   background: transparent;
   padding: 0;
@@ -55,7 +55,7 @@ a,
   line-height: normal;
 
   &:focus {
-    margin-bottom: -2px; //account for bottom border
+    margin-bottom: -2px; // account for bottom border
   }
 }
 

--- a/scss/4-elements/_lists.scss
+++ b/scss/4-elements/_lists.scss
@@ -40,7 +40,7 @@
 }
 
 %cads-list-unordered-inline {
-  @include cads-reset-list-style();
+  @include cads-reset-list-style;
 
   margin-bottom: $cads-spacing-5;
 
@@ -51,7 +51,7 @@
 }
 
 %cads-list-no-bullet {
-  @include cads-reset-list-style();
+  @include cads-reset-list-style;
 
   margin-bottom: $cads-spacing-5;
 

--- a/scss/4-elements/_tables.scss
+++ b/scss/4-elements/_tables.scss
@@ -70,8 +70,7 @@
 
     td {
       display: flex;
-      flex-direction: row;
-      flex-wrap: nowrap;
+      flex-flow: row nowrap;
       align-content: stretch;
       border: none;
     }

--- a/scss/4-elements/_typography.scss
+++ b/scss/4-elements/_typography.scss
@@ -55,14 +55,14 @@
 }
 
 %cads-paragraph {
-  @include cads-typographic-scale-text();
+  @include cads-typographic-scale-text;
 
   font-weight: $cads-font-weight__regular;
   margin: 0 0 $cads-spacing-5 0;
 }
 
 %cads-paragraph-small {
-  @include cads-typographic-scale-text-small();
+  @include cads-typographic-scale-text-small;
 
   font-weight: $cads-font-weight__regular;
   margin: 0 0 $cads-spacing-5 0;

--- a/scss/5-objects/_grid.scss
+++ b/scss/5-objects/_grid.scss
@@ -1,3 +1,4 @@
+@use 'sass:map';
 @use 'sass:math';
 
 /* @use must be first, which conflicts with the import position rule */
@@ -22,7 +23,7 @@
   margin-left: auto;
 
   @each $breakpoint in map-keys($cads-breakpoints) {
-    $gutter: map-get($cads-grid-breakpoint-gutters, $breakpoint);
+    $gutter: map.get($cads-grid-breakpoint-gutters, $breakpoint);
 
     @include cads-media-breakpoint-up($breakpoint) {
       padding-right: $gutter;
@@ -42,7 +43,7 @@
   flex-wrap: wrap;
 
   @each $breakpoint in map-keys($cads-breakpoints) {
-    $gutter: map-get($cads-grid-breakpoint-gutters, $breakpoint);
+    $gutter: map.get($cads-grid-breakpoint-gutters, $breakpoint);
 
     @include cads-media-breakpoint-up($breakpoint) {
       margin-right: math.div($gutter, -2);
@@ -61,7 +62,7 @@
 // Generate the correct number of grid classes
 @each $breakpoint in map-keys($cads-breakpoints) {
   $infix: cads-breakpoint-infix($breakpoint);
-  $gutter: map-get($cads-grid-breakpoint-gutters, $breakpoint);
+  $gutter: map.get($cads-grid-breakpoint-gutters, $breakpoint);
 
   %grid-gutters {
     @include cads-media-breakpoint-up($breakpoint) {
@@ -100,9 +101,10 @@
 
     @for $i from 1 through $cads-grid-columns {
       .cads-grid-col#{$infix}-#{$i} {
-        flex: 0 0 percentage(math.div($i, $cads-grid-columns));
+        flex: 0 0 math.percentage(math.div($i, $cads-grid-columns));
+
         // Ensure content within each column does not blow out the width of the column
-        max-width: percentage(math.div($i, $cads-grid-columns));
+        max-width: math.percentage(math.div($i, $cads-grid-columns));
       }
     }
   }

--- a/scss/5-objects/_prose.scss
+++ b/scss/5-objects/_prose.scss
@@ -64,7 +64,7 @@
     // https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/rel#attr-external
     a:not([href^="#{prose-config.$cads-internal-link-domain}"]):not([href^="/"]):not([href^="#"]):not([href^="mailto:"]):not([href^="tel:"])::after {
       @media not print {
-        @include cads-hyperlink--external-icon();
+        @include cads-hyperlink--external-icon;
       }
     }
   }

--- a/scss/6-components/_badges.scss
+++ b/scss/6-components/_badges.scss
@@ -4,7 +4,7 @@
 
 /** @define badge */
 .cads-badge {
-  @include cads-typographic-scale-text-small();
+  @include cads-typographic-scale-text-small;
 
   line-height: 0.875rem;
   font-weight: $cads-font-weight__bold;

--- a/scss/6-components/_breadcrumbs.scss
+++ b/scss/6-components/_breadcrumbs.scss
@@ -1,3 +1,5 @@
+@use 'sass:map';
+
 // can't extend a placeholder across selectors (media query) so use a mixin instead.
 @mixin cads-breadcrumb-arrow {
   @include cads-icon;
@@ -69,6 +71,7 @@
 
       &:nth-last-child(2) {
         margin-left: 0;
+
         a {
           display: inline;
         }
@@ -97,7 +100,7 @@
     border-bottom: none;
 
     @each $breakpoint in map-keys($cads-breakpoints) {
-      $gutter: map-get($cads-grid-breakpoint-gutters, $breakpoint);
+      $gutter: map.get($cads-grid-breakpoint-gutters, $breakpoint);
 
       @include cads-media-breakpoint-up($breakpoint) {
         padding-left: $gutter;

--- a/scss/6-components/_callout.scss
+++ b/scss/6-components/_callout.scss
@@ -26,6 +26,7 @@
   & & {
     // For when callouts are inside callouts
     margin: $cads-spacing-4 0;
+
     // Nested callouts sit flush right
     margin-right: -$cads-spacing-4;
 

--- a/scss/6-components/_footer.scss
+++ b/scss/6-components/_footer.scss
@@ -4,7 +4,7 @@
 
 /** @define footer; weak */
 .cads-footer {
-  @include cads-typographic-scale-text-small();
+  @include cads-typographic-scale-text-small;
 
   background-color: $cads-footer__background-colour;
   padding: $cads-spacing-4 0;
@@ -15,8 +15,9 @@
     color: $cads-footer__text-colour;
     margin: 0 0 $cads-spacing-2 0;
   }
+
   .cads-footer__feedback {
-    @include cads-typographic-scale-text-small();
+    @include cads-typographic-scale-text-small;
 
     width: 100%;
     text-align: center;
@@ -36,6 +37,7 @@
 
     svg {
       height: 14px;
+
       // Optical alignment
       vertical-align: middle;
       position: relative;
@@ -53,6 +55,7 @@
 
     svg {
       height: 14px;
+
       // Optical alignment
       vertical-align: middle;
       position: relative;
@@ -85,11 +88,11 @@
 
   .cads-footer__links .cads-footer__link {
     // @TODO: cads-list-no-bullet contains font-sizes, should it inherit?
-    @include cads-typographic-scale-text-small();
+    @include cads-typographic-scale-text-small;
   }
 
   .cads-footer__company-info {
-    @include cads-restrict-content-width();
+    @include cads-restrict-content-width;
 
     color: $cads-footer__text-colour;
     padding-top: $cads-spacing-5;

--- a/scss/6-components/_header.scss
+++ b/scss/6-components/_header.scss
@@ -39,7 +39,7 @@
   }
 
   &__search-reveal {
-    @include cads-button-defaults();
+    @include cads-button-defaults;
 
     display: none; // Hide by default
     width: $cads-interactive-target-size;
@@ -190,6 +190,7 @@
       display: block;
     }
   }
+
   .cads-header__links {
     @include cads-media-breakpoint-only(sm) {
       display: block;

--- a/scss/6-components/_icons.scss
+++ b/scss/6-components/_icons.scss
@@ -5,7 +5,7 @@
 
 svg {
   &.cads-icon {
-    fill: currentColor;
+    fill: currentcolor;
   }
 
   &.cads-icon--small {

--- a/scss/6-components/_navigation.scss
+++ b/scss/6-components/_navigation.scss
@@ -1,3 +1,5 @@
+@use 'sass:map';
+
 @import 'navigation_greedy-nav';
 
 /** @define navigation */
@@ -38,10 +40,10 @@
   background-color: $cads-language__brand-primary;
 
   .cads-navigation {
-    @include cads-restrict-content-width();
+    @include cads-restrict-content-width;
 
     @each $breakpoint in map-keys($cads-breakpoints) {
-      $gutter: map-get($cads-nav-breakpoint-gutters, $breakpoint);
+      $gutter: map.get($cads-nav-breakpoint-gutters, $breakpoint);
 
       @include cads-media-breakpoint-up($breakpoint) {
         padding-left: $gutter;
@@ -61,6 +63,7 @@
       content: '';
       border-top: $cads-border-width-small solid $cads-palette__white;
       position: relative;
+
       // take focus border into account
       left: cads-rem-to-px($cads-spacing-4) + $cads-border-width-medium;
       width: calc(

--- a/scss/6-components/_on-this-page.scss
+++ b/scss/6-components/_on-this-page.scss
@@ -44,6 +44,7 @@
       columns: 2;
     }
   }
+
   .cads-on-this-page__list-item {
     @include cads-media-breakpoint-up(md) {
       // the two column layout extends the inline bottom border of a focused link

--- a/scss/6-components/_pagination.scss
+++ b/scss/6-components/_pagination.scss
@@ -11,16 +11,18 @@
 
 /** @define paging */
 .cads-paging {
-  @include cads-reset-list-style();
+  @include cads-reset-list-style;
 
   display: flex;
   flex-wrap: wrap;
 }
+
 .cads-paging__item {
   margin-right: $cads-spacing-4;
 }
+
 .cads-paging__button {
-  @include cads-button-defaults();
+  @include cads-button-defaults;
 
   color: $cads-language__link-colour;
   border: solid $cads-border-width-small $cads-language__border-colour;
@@ -31,7 +33,7 @@
   margin-bottom: $cads-spacing-2;
 
   &:focus {
-    @include cads-paging-focus();
+    @include cads-paging-focus;
   }
 
   &:hover,
@@ -48,7 +50,7 @@
     border-color: $cads-language__primary-button-colour;
 
     &:focus {
-      @include cads-paging-focus();
+      @include cads-paging-focus;
     }
 
     &:hover {

--- a/scss/6-components/_search.scss
+++ b/scss/6-components/_search.scss
@@ -27,7 +27,7 @@
   }
 
   &__button {
-    @include cads-button-defaults();
+    @include cads-button-defaults;
 
     margin-bottom: 0;
     padding: (cads-rem-to-px($cads-spacing-3) - 2px) $cads-spacing-3;
@@ -67,7 +67,7 @@
     }
 
     .cads-search__button-label {
-      @include cads-visually-hidden();
+      @include cads-visually-hidden;
     }
   }
 }

--- a/scss/6-components/_skip-links.scss
+++ b/scss/6-components/_skip-links.scss
@@ -3,7 +3,7 @@
   width: 100%;
 
   &__link {
-    @include cads-visually-hidden();
+    @include cads-visually-hidden;
 
     &:focus {
       clip: auto;

--- a/scss/6-components/_targeted-content.scss
+++ b/scss/6-components/_targeted-content.scss
@@ -73,14 +73,14 @@
     }
 
     &:focus {
-      @include cads-interactive-focus();
+      @include cads-interactive-focus;
     }
   }
 
   .cads-targeted-content__icon {
     height: 1em;
     margin-left: 0.5em;
-    fill: currentColor;
+    fill: currentcolor;
     flex: 0 0 1em;
   }
 
@@ -112,6 +112,7 @@
 
     &__content {
       display: block;
+
       hr,
       button {
         display: none;

--- a/scss/6-components/forms/checkboxes.scss
+++ b/scss/6-components/forms/checkboxes.scss
@@ -11,8 +11,8 @@
       left: 15px;
       width: 10px;
       height: 17px;
-      border-right: $cads-border-width-large solid currentColor;
-      border-bottom: $cads-border-width-large solid currentColor;
+      border-right: $cads-border-width-large solid currentcolor;
+      border-bottom: $cads-border-width-large solid currentcolor;
       opacity: 0;
       transform: rotateZ(45deg);
     }

--- a/scss/6-components/forms/fields.scss
+++ b/scss/6-components/forms/fields.scss
@@ -7,8 +7,7 @@
 /** @define form-field */
 .cads-form-field {
   display: flex;
-  flex-wrap: nowrap;
-  flex-direction: row;
+  flex-flow: row nowrap;
   align-items: stretch;
   font-size: 1.125rem;
   line-height: 1.5rem;
@@ -18,21 +17,26 @@
     font-size: 1rem;
   }
 }
+
 .cads-form-field__content {
   width: 100%;
 }
+
 .cads-form-field__label {
   @extend %cads-h4;
 
   display: block;
   margin-bottom: $cads-spacing-3;
 }
+
 .cads-form-field__label--with-heading {
   margin-bottom: 0;
 }
+
 .cads-form-field__heading {
   @extend %cads-h1;
 }
+
 .cads-form-field__optional {
   color: $cads-language__secondary-text-colour;
   font-weight: normal;
@@ -45,23 +49,28 @@
     content: ')';
   }
 }
+
 .cads-form-field__hint {
   display: block;
   margin: 0 0 $cads-spacing-3 0;
   color: $cads-language__secondary-text-colour;
 }
+
 .cads-form-field__label + .cads-form-field__hint {
   // Reduces visual spacing between label + hint when there is a hint
   margin-top: -$cads-spacing-2;
 }
+
 .cads-form-field__error-marker {
   display: none;
 }
+
 .cads-form-field__error-message {
   display: none;
   color: $cads-language__warning-colour;
   margin: 0 0 $cads-spacing-3 0;
 }
+
 //
 // Modifier: has-error
 //

--- a/scss/6-components/forms/form-groups.scss
+++ b/scss/6-components/forms/form-groups.scss
@@ -1,4 +1,5 @@
 @use 'sass:math';
+
 // ============================================================================
 // Forms: Form groups
 // Styles for groups of checkable items, like checkboxes and radio buttons
@@ -49,9 +50,11 @@ $cads-checkable-size: 40px;
   display: inline-block;
   vertical-align: middle;
   margin-bottom: 0;
+
   // optically align labels with controls
   padding: cads-rem(7px) $cads-spacing-4 $cads-spacing-2;
   cursor: pointer;
+
   // remove 300ms pause on mobile
   touch-action: manipulation;
 
@@ -83,11 +86,12 @@ $cads-checkable-size: 40px;
 .cads-form-group__input:focus + .cads-form-group__label {
   &::before {
     border-color: $cads-language__focus-border-colour;
+
     // We need to use box-shadow instead of outline as outline does not have a radius
     box-shadow: 0 0 0 $cads-border-width-medium $cads-language__focus-colour;
   }
 
   &::after {
-    color: currentColor;
+    color: currentcolor;
   }
 }

--- a/scss/6-components/forms/inputs.scss
+++ b/scss/6-components/forms/inputs.scss
@@ -6,10 +6,11 @@
 
 /** @define input */
 .cads-input {
-  @include cads-interactive-element();
+  @include cads-interactive-element;
 
   color: inherit;
   width: 100%;
+
   // prevent elements with size attributes overflowing on mobile
   max-width: 100%;
   height: $cads-interactive-target-size;

--- a/scss/6-components/forms/radios.scss
+++ b/scss/6-components/forms/radios.scss
@@ -25,13 +25,14 @@ $cads-small-radios-size: 24px;
       left: $cads-spacing-2;
       width: 0;
       height: 0;
-      border: $cads-spacing-3 solid currentColor;
+      border: $cads-spacing-3 solid currentcolor;
       border-radius: 50%;
       opacity: 0;
-      background: currentColor;
+      background: currentcolor;
     }
   }
 }
+
 //
 // Modifier: inline
 //

--- a/scss/6-components/forms/text-area.scss
+++ b/scss/6-components/forms/text-area.scss
@@ -4,7 +4,7 @@
 
 /** @define textarea */
 .cads-textarea {
-  @include cads-interactive-element();
+  @include cads-interactive-element;
 
   color: inherit;
   display: block;
@@ -12,7 +12,8 @@
   min-height: 40px;
   padding: $cads-spacing-2;
   border-radius: 0;
-  -webkit-appearance: none;
+  appearance: none;
+
   // Limit resizing to vertical
   resize: vertical;
   line-height: 1.625rem;

--- a/scss/7-utilities/_sizing.scss
+++ b/scss/7-utilities/_sizing.scss
@@ -1,5 +1,5 @@
 @use '../2-tools/spacing-sizing' as sizing-tools;
 
 .cads-max-content-width {
-  @include sizing-tools.cads-restrict-content-width();
+  @include sizing-tools.cads-restrict-content-width;
 }

--- a/stylelint.config.js
+++ b/stylelint.config.js
@@ -1,6 +1,6 @@
 module.exports = {
-  extends: ['stylelint-config-standard', 'stylelint-config-prettier'],
-  plugins: ['stylelint-scss', 'stylelint-selector-bem-pattern'],
+  extends: ['stylelint-config-standard-scss', 'stylelint-config-prettier'],
+  plugins: ['stylelint-selector-bem-pattern'],
   ignoreFiles: ['**/_normalize.scss', '**/_cads-iconfont.scss'],
   rules: {
     // Disallow named colours, for colours we use sass variables
@@ -9,10 +9,13 @@ module.exports = {
     // Set a reasonable limit on how many compound selectors we can have
     'selector-max-compound-selectors': 4,
 
-    // Vendor prefixes are handled by autoprefixer (or are no longer needed)
-    // So require that no-vendor prefixes are used.
-    'selector-no-vendor-prefix': true,
-    'value-no-vendor-prefix': true,
+    // Disable unwanted or conflicting selector patterns
+    'selector-class-pattern': null,
+    'selector-id-pattern': null,
+
+    // Prefer legacy colour function notation
+    'color-function-notation': 'legacy',
+    'alpha-value-notation': 'number',
 
     // We provide a cads-transition-animation mixin for handling
     // transitions along with a prefers-reduced-motion fallback,
@@ -32,6 +35,9 @@ module.exports = {
     'at-rule-disallowed-list': ['debug'],
     'scss/at-rule-no-unknown': true,
 
+    // Disable unwanted scss rules
+    'scss/comment-no-empty': null,
+
     // Require that @function and @mixin rules are prefixed with cads-
     'scss/at-function-pattern': '^cads-+([a-z0-9-]+[a-z0-9]+)?$',
     'scss/at-mixin-pattern': '^cads-+([a-z0-9-]+[a-z0-9]+)?$',
@@ -45,6 +51,13 @@ module.exports = {
     // These should be enabled as errors once current warnings have been fixed.
     'selector-max-id': [0, { severity: 'warning' }],
     'scss/at-extend-no-missing-placeholder': [true, { severity: 'warning' }],
+
+    // Disable kebab-case preference for variable names
+    // Current design system variables names use a more complex format
+    // which will eventually be simplified
+    // See https://github.com/citizensadvice/design-system/pull/1863
+    'scss/dollar-variable-pattern': null,
+    'scss/percent-placeholder-pattern': null,
 
     // Configure BEM pattern
     // Note: requires components to have an explicit @define comment


### PR DESCRIPTION
Restructures stylelint dependencies and to use stylelint-config-standard-scss in favour of manually configuring scss syntax as recommended in the docs. This automatically handles the new customSyntax requirements from the new
stylelint version and reduces the number of direct packages we manage.

Updates rules to reflect the new config and any new rules in stylelint v14. Removes any rules that are defined by newer versions of the standard config.