### PR TITLE
Feat: adding 'On this page' section to foundations

### DIFF
--- a/design-system-docs/src/_foundations/_defaults.yml
+++ b/design-system-docs/src/_foundations/_defaults.yml
@@ -1,1 +1,2 @@
 layout: foundations
+show_on_this_page: true

--- a/design-system-docs/src/_layouts/foundations.erb
+++ b/design-system-docs/src/_layouts/foundations.erb
@@ -14,6 +14,11 @@ layout: default
     <div class="cads-grid-col-md-8">
       <div class="cads-page-content">
         <h1 class="cads-page-title"><%= resource.data.title %></h1>
+
+        <% if resource.data.show_on_this_page.present? %>
+          <%= render(Shared::OnThisPage.new(content)) %>
+        <% end %>
+
         <div class="cads-prose">
           <%= content %>
         </div>


### PR DESCRIPTION
Originated from https://github.com/citizensadvice/design-system/pull/2157 where we discussed adding 'On this page' section to the foundations pages. 