### PR TITLE
Docs: Speed up yarn installs

### DIFF
--- a/design-system-docs/frontend/javascript/index.js
+++ b/design-system-docs/frontend/javascript/index.js
@@ -1,7 +1,7 @@
 import '../styles/index.scss';
 
-import initTargetedContent from '@citizensadvice/design-system/lib/targeted-content';
-import initDisclosure from '@citizensadvice/design-system/lib/disclosure/disclosure';
+import initTargetedContent from '../../../lib/targeted-content';
+import initDisclosure from '../../../lib/disclosure/disclosure';
 import initCodeCopy from './code-copy';
 
 try {

--- a/design-system-docs/frontend/styles/index.scss
+++ b/design-system-docs/frontend/styles/index.scss
@@ -1,4 +1,4 @@
-@import '~@citizensadvice/design-system/scss/lib';
+@import '../scss/lib';
 
 @import 'layout';
 @import 'code';

--- a/design-system-docs/package.json
+++ b/design-system-docs/package.json
@@ -8,7 +8,6 @@
     "update-colour-data": "npx sass-export --dependencies='../scss/1-settings/' ../scss/1-settings/_colour-language.scss -o src/_data/colour_language.json"
   },
   "devDependencies": {
-    "@citizensadvice/design-system": "file:..",
     "css-loader": "^4.3.0",
     "esbuild": "^0.14.49",
     "esbuild-loader": "^2.19.0",


### PR DESCRIPTION
Currently running `yarn install` in the docs package take a long time to resolve the design-system using the `file:` install method. I also tried using `link:` to install the package which should use a simple symlink. In both cases the install stalls for a long time, presumably because the mode module is at the root of the project so it's getting confused with some circular behaviour.

Either way linking using relative paths has exactly the same effect locally, we don't actually need to install the package. Switching to relative paths fixes any install issues.
