### PR TITLE
Demonstrate output buffer bug

### DIFF
--- a/design-system-docs/src/_component_docs/output-buffer-bug.erb
+++ b/design-system-docs/src/_component_docs/output-buffer-bug.erb
@@ -1,0 +1,10 @@
+---
+title: Output buffer bug
+---
+
+<%= render CitizensAdviceComponents::Button.new(variant: :secondary) do |c| %>
+  Example button
+  <%- c.icon_right do %>
+    <%= render CitizensAdviceComponents::Icons::ArrowRight.new %>
+  <% end %>
+<% end %>

--- a/design-system-docs/src/_component_docs/output-buffer-bug.erb
+++ b/design-system-docs/src/_component_docs/output-buffer-bug.erb
@@ -8,3 +8,12 @@ title: Output buffer bug
     <%= render CitizensAdviceComponents::Icons::ArrowRight.new %>
   <% end %>
 <% end %>
+
+<%= render CitizensAdviceComponents::TextInput.new(
+  name: "example-input-with-hint",
+  label: "Example input with hint",
+  type: :text,
+  options: {
+    hint: "This is the hint for the input"
+  }
+) %>


### PR DESCRIPTION
As shown in https://github.com/citizensadvice/design-system/pull/2179 there is an issue rendering components in bridgetown where blocks are used.

This causes an output buffer issue where the contents of the block is also rendered on the page.

This only seems to happen with haml templates not erb templates. It's possibly a bridgetown bug but more likely down to the fact we are having to approximate haml support in our builder by having to patch in a new template handler.

<img width="713" alt="image" src="https://user-images.githubusercontent.com/123386/180737471-add200aa-cd4e-4653-900d-2c001d1f68cb.png">

<img width="710" alt="image" src="https://user-images.githubusercontent.com/123386/180761647-6bcecbeb-8702-4897-9571-4975b7bd3fb6.png">

This pull request acts as a reduced test case to demonstrate the issue. I'll raise a pull request based on this showing how switching to ERB bypasses any underlying issues.