### PR TITLE
Ref 427 DAC_Pseudo_content_02

### DIFF
--- a/engine/app/components/citizens_advice_components/form_group.html.haml
+++ b/engine/app/components/citizens_advice_components/form_group.html.haml
@@ -8,7 +8,7 @@
       - else
         = legend
       - if optional?
-        %span.cads-form-field__optional= t("citizens_advice_components.input.optional")
+        %span.cads-form-field__optional= "(#{t("citizens_advice_components.input.optional")})"
     - if hint?
       %p.cads-form-field__hint= hint
     - if error?

--- a/engine/app/components/citizens_advice_components/input.html.haml
+++ b/engine/app/components/citizens_advice_components/input.html.haml
@@ -2,7 +2,7 @@
   %label.cads-form-field__label{id: label_id, for: input_id }
     = label
     - if optional?
-      %span.cads-form-field__optional= t(".optional")
+      %span.cads-form-field__optional= "(#{t(".optional")})"
   - if hint?
     %p.cads-form-field__hint= hint
   - if error?

--- a/engine/spec/components/citizens_advice_components/checkbox_group_spec.rb
+++ b/engine/spec/components/citizens_advice_components/checkbox_group_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe CitizensAdviceComponents::CheckboxGroup, type: :component do
 
     it "renders a required input" do
       without_fetch_or_fallback_raises do
-        expect(component.text.strip).not_to include "optional"
+        expect(component.text.strip).not_to include "(optional)"
       end
     end
   end
@@ -94,7 +94,7 @@ RSpec.describe CitizensAdviceComponents::CheckboxGroup, type: :component do
     end
 
     it "marks the field as optional" do
-      expect(component.text.strip).to include "optional"
+      expect(component.text.strip).to include "(optional)"
     end
 
     context "when in Cymraeg" do
@@ -103,7 +103,7 @@ RSpec.describe CitizensAdviceComponents::CheckboxGroup, type: :component do
       end
 
       it "renders optional in Welsh" do
-        expect(component.text).to include "dewisol"
+        expect(component.text).to include "(dewisol)"
       end
     end
   end

--- a/engine/spec/components/citizens_advice_components/input_spec.rb
+++ b/engine/spec/components/citizens_advice_components/input_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe CitizensAdviceComponents::Input, type: :component do
     let(:options) { { optional: true } }
 
     it "adds optional to the label" do
-      expect(component.text).to include("optional")
+      expect(component.text).to include("(optional)")
     end
 
     it "does not add required to the input" do

--- a/scss/6-components/forms/fields.scss
+++ b/scss/6-components/forms/fields.scss
@@ -36,15 +36,8 @@
 .cads-form-field__optional {
   color: $cads-language__secondary-text-colour;
   font-weight: normal;
-
-  &::before {
-    content: ' (';
-  }
-
-  &::after {
-    content: ')';
-  }
 }
+
 .cads-form-field__hint {
   display: block;
   margin: 0 0 $cads-spacing-3 0;

--- a/styleguide/examples/checkbox_group/optional.html
+++ b/styleguide/examples/checkbox_group/optional.html
@@ -5,7 +5,7 @@
   >
     <legend class="cads-form-field__label">
       Example radio group
-      <span class="cads-form-field__optional">optional</span>
+      <span class="cads-form-field__optional">(optional)</span>
     </legend>
     <div class="cads-form-group__item">
       <input

--- a/styleguide/examples/input/optional.html
+++ b/styleguide/examples/input/optional.html
@@ -7,7 +7,7 @@
       id="example-input-optional-label"
     >
       Example input
-      <span class="cads-form-field__optional">optional</span>
+      <span class="cads-form-field__optional">(optional)</span>
     </label>
     <input
       class="cads-input"

--- a/styleguide/examples/radio_group/optional.html
+++ b/styleguide/examples/radio_group/optional.html
@@ -5,7 +5,7 @@
   >
     <legend class="cads-form-field__label">
       Example radio group
-      <span class="cads-form-field__optional">optional</span>
+      <span class="cads-form-field__optional">(optional)</span>
     </legend>
     <div class="cads-form-group__item">
       <input

--- a/styleguide/examples/text_input/optional.html
+++ b/styleguide/examples/text_input/optional.html
@@ -7,7 +7,7 @@
       id="example-input-optional-label"
     >
       Example input
-      <span class="cads-form-field__optional">optional</span>
+      <span class="cads-form-field__optional">(optional)</span>
     </label>
     <input
       class="cads-input"

--- a/styleguide/examples/textarea/optional.html
+++ b/styleguide/examples/textarea/optional.html
@@ -7,7 +7,7 @@
       id="example-input-optional-label"
     >
       Example input
-      <span class="cads-form-field__optional">optional</span>
+      <span class="cads-form-field__optional">(optional)</span>
     </label>
     <textarea
       class="cads-textarea"


### PR DESCRIPTION
https://citizensadvice.atlassian.net/browse/REF-427

This ticket addresses an issue raised in the referrals accessibility report. The fix was made to the referrals codebase, but this ticket fixes the issue in the design system components and styleguide so it is no repeated elsewhere. 

It will be a breaking change for anyone who was relying on the classname `cads-form-field__optional` to add the brackets around the word 'optional'. It shouldn't be a breaking change for anyone using the rails components.

[DAC Accessibility Report WCAG 2.1 Citizens Advice referrals tool 16 03 2022 - FINAL .pdf](https://github.com/citizensadvice/design-system/files/9182911/DAC.Accessibility.Report.WCAG.2.1.Citizens.Advice.referrals.tool.16.03.2022.-.FINAL.pdf)

