### PR TITLE
Run Backstop tests in test mode again

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -118,9 +118,7 @@ jobs:
   demo-app-backstop:
     runs-on: ubuntu-20.04
     env:
-      RAILS_ENV: production
-      RAILS_SERVE_STATIC_FILES: true
-      SECRET_KEY_BASE: ${{ secrets.SECRET_KEY_BASE }}
+      RAILS_ENV: test
       CYPRESS_INSTALL_BINARY: 0
     steps:
       - uses: actions/checkout@v3

--- a/demo/config/environments/test.rb
+++ b/demo/config/environments/test.rb
@@ -14,10 +14,10 @@ Rails.application.configure do
 
   config.cache_classes = false
 
-  # Do not eager load code on boot. This avoids loading your whole application
-  # just for the purpose of running a single test. If you are using a tool that
-  # preloads Rails for running tests, you may have to set it to true.
-  config.eager_load = false
+  # Eager loading loads your whole application. When running a single test locally,
+  # this probably isn't necessary. It's a good idea to do in a continuous integration
+  # system, or in some way before deploying your code.
+  config.eager_load = ENV["CI"].present?
 
   # Configure public file server for tests with Cache-Control for performance.
   config.public_file_server.enabled = true


### PR DESCRIPTION
In https://github.com/citizensadvice/design-system/pull/2210 we made some changes to improve the reliability of the Backstop tests.

One of those changes was to run the app in production mode. It turns out that this:

a) isn't necessary, the real fix was waiting on a specific component URL before running the tests and
b) whilst main branch builds work fine for normal pull requests they fail for dependabot changes because it doesn't have access to the secret used for SECRET_KEY_BASE.

As it's not actually necessary to run in production mode let's swap back to test mode but with eager-loading enabled in CI which should do the job without breaking on dependabot changes.