### PR TITLE
chore: updating changelog before pre-release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,11 @@
 ## Unreleased
-**Breaking changes**
-
-- 📋 Optional form fields: The class `$cads-form-field__optional` no longer generates brackets as part of the css. For instance, if you have something like this in your codebase: `<span class="cads-form-field__optional">optional</span>`, you'll want to change it to: `<span class="cads-form-field__optional">(optional)</span>`.
 
 **Bugfixes**
 
 - 🔗 Header: Renamed skip to content link
 - Inputs and targeted content: Change the focus contrast to meet the accessibility requirements
 - 🛑️ Error summary and message: Change text colour and weight to meet accessibility requirements
-- 📋 Optional form fields: Fix an issue identified in an accessibility report related to pseudo content. The class `$cads-form-field__optional` no longer generates brackets as part of the css.
+- 📋 Optional form fields: Fix an issue identified in an accessibility report related to pseudo content. The class `$cads-form-field__optional` no longer generates brackets as part of the css. For instance, if you have something like this in your codebase: `<span class="cads-form-field__optional">optional</span>`, you'll want to change it to: `<span class="cads-form-field__optional">(optional)</span>`.
 - 🎯 Targeted content: Fix missing label in name of close button
 - 📋 Form hints: Add aria-describedby to form input when a hint exists
 


### PR DESCRIPTION
Moved a breaking change to bugfix as it would potentially happen when not using Rails.
Unblocks pre-releasing design-system  v5.4