### PR TITLE
fix: removed unreleased line from changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,6 @@
 
 #### _Aug. 3, 2022_
 
-## Unreleased
-
 **Bugfixes**
 
 - 🔗 Header: Renamed skip to content link


### PR DESCRIPTION
Removing 'unreleased' line from changelong after a pre-release