### PR TITLE
Header: Only render right column when needed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+**Bugfixes**
+
+- Header: Don't render right column when only logo is present (engine only)
+
 ## <sub>v5.4.0-alpha.0</sub>
 
 #### _Aug. 3, 2022_

--- a/engine/app/components/citizens_advice_components/header.html.erb
+++ b/engine/app/components/citizens_advice_components/header.html.erb
@@ -25,42 +25,44 @@
           </button>
         <% end %>
       </div>
-      <div class="cads-grid-col-md-10 cads-header__search-row">
-        <ul class="cads-header__links js-cads-copy-into-nav">
-          <% header_links.each do |header_link| %>
-            <li class="cads-header__links-item"><%= header_link %></li>
-          <% end %>
-          <% if account_link.present? %>
-            <li class="cads-header__links-item"><%= account_link %></li>
-          <% end %>
-        </ul>
-        <% if search_form.present? %>
-          <div class="cads-header__search-form" id="header-search-form">
-            <%= form_tag(
-              search_form.search_action_url,
-              method: :get,
-              role: "search",
-              class: "cads-search cads-search--icon-only"
-            ) do %>
-              <%= search_field_tag(
-                search_form.search_param.to_sym, nil,
-                id: "search-query",
-                "aria-label": t("citizens_advice_components.search.input_aria_label"),
-                class: "cads-search__input cads-input",
-                autocomplete: "off"
-              ) %>
-              <button
-                type="submit"
-                title="<%= t("citizens_advice_components.search.submit_title") %>"
-                data-testid="search-button"
-                class="cads-search__button">
-                <%= render CitizensAdviceComponents::Icons::Search.new %>
-                <%= tag.span(t("citizens_advice_components.search.submit_label"), class: "cads-search__button-label") %>
-              </button>
+      <% if show_right_column? %>
+        <div class="cads-grid-col-md-10 cads-header__search-row">
+          <ul class="cads-header__links js-cads-copy-into-nav">
+            <% header_links.each do |header_link| %>
+              <li class="cads-header__links-item"><%= header_link %></li>
             <% end %>
-          </div>
-        <% end %>
-      </div>
+            <% if account_link.present? %>
+              <li class="cads-header__links-item"><%= account_link %></li>
+            <% end %>
+          </ul>
+          <% if search_form.present? %>
+            <div class="cads-header__search-form" id="header-search-form">
+              <%= form_tag(
+                search_form.search_action_url,
+                method: :get,
+                role: "search",
+                class: "cads-search cads-search--icon-only"
+              ) do %>
+                <%= search_field_tag(
+                  search_form.search_param.to_sym, nil,
+                  id: "search-query",
+                  "aria-label": t("citizens_advice_components.search.input_aria_label"),
+                  class: "cads-search__input cads-input",
+                  autocomplete: "off"
+                ) %>
+                <button
+                  type="submit"
+                  title="<%= t("citizens_advice_components.search.submit_title") %>"
+                  data-testid="search-button"
+                  class="cads-search__button">
+                  <%= render CitizensAdviceComponents::Icons::Search.new %>
+                  <%= tag.span(t("citizens_advice_components.search.submit_label"), class: "cads-search__button-label") %>
+                </button>
+              <% end %>
+            </div>
+          <% end %>
+        </div>
+      <% end %>
     </div>
   </div>
 </header>

--- a/engine/app/components/citizens_advice_components/header.rb
+++ b/engine/app/components/citizens_advice_components/header.rb
@@ -13,6 +13,10 @@ module CitizensAdviceComponents
       logo.present?
     end
 
+    def show_right_column?
+      header_links.any? || account_link.present? || search_form.present?
+    end
+
     def skip_links_to_show
       skip_links.presence || default_skip_links
     end

--- a/engine/spec/components/citizens_advice_components/header_spec.rb
+++ b/engine/spec/components/citizens_advice_components/header_spec.rb
@@ -2,43 +2,39 @@
 
 RSpec.describe CitizensAdviceComponents::Header, type: :component do
   describe "no slots" do
-    subject(:component) do
-      render_inline(described_class.new)
-    end
+    before { render_inline(described_class.new) }
 
     it "does not render without any slots" do
-      expect(component.at("header")).not_to be_present
+      expect(page).not_to have_selector "header"
     end
   end
 
   describe "logo slot" do
     context "with default logo" do
-      subject(:logo) { component.at(".cads-logo") }
-
-      let(:component) do
+      before do
         render_inline(described_class.new) do |c|
           c.logo(title: "Logo title", url: "/homepage")
         end
       end
 
-      it "has expected title" do
-        expect(logo.attr("title")).to eq "Logo title"
+      it "has logo link" do
+        expect(page).to have_link "Logo title", href: "/homepage"
       end
 
-      it "has expected href" do
-        expect(logo.attr("href")).to eq "/homepage"
+      it "does not show right column when only logo is present" do
+        expect(page).not_to have_selector ".cads-header__search-row"
       end
     end
 
     context "with custom block" do
-      subject(:component) do
+      before do
         render_inline(described_class.new) do |c|
           c.logo { "Custom logo HTML" }
         end
       end
 
       it "renders custom block" do
-        expect(component.text).to include "Custom logo HTML"
+        expect(page).to have_text "Custom logo HTML"
       end
     end
   end


### PR DESCRIPTION
Extracted from https://github.com/citizensadvice/design-system/pull/2251

Only applies to the Rails engine header component. When rendering the header with only the logo slot the markup for the secondary column is still output. Only render the extra markup when needed.

Best viewed with whitespace ignored: https://github.com/citizensadvice/design-system/pull/2275/files?w=1