### PR TITLE
Navigation: Add background to colour language

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+**Bugfixes**
+
+- Navigation: Add background to colour language
+
 ## <sub>v5.4.0-alpha.0</sub>
 
 #### _Aug. 3, 2022_

--- a/scss/1-settings/_colour-language.scss
+++ b/scss/1-settings/_colour-language.scss
@@ -29,6 +29,7 @@ $cads-language__warning-colour: palette.$cads-palette__red !default;
 $cads-language__success-colour: palette.$cads-palette__green !default;
 
 // Navigation colours
+$cads-language__nav-background-colour: $cads-language__brand-primary !default;
 $cads-language__nav-hover-background-colour: palette.$cads-palette__heritage-blue-dark !default;
 $cads-language__nav-hover-border-colour: palette.$cads-palette__heritage-blue-dark !default;
 

--- a/scss/6-components/_navigation.scss
+++ b/scss/6-components/_navigation.scss
@@ -6,7 +6,7 @@
 .cads-navigation {
   display: flex;
   justify-content: space-between;
-  background-color: $cads-language__brand-primary;
+  background-color: $cads-language__nav-background-colour;
   width: 100%;
   padding: 0;
   margin-bottom: 0;
@@ -37,7 +37,7 @@
 
 /* stylelint-disable  plugin/selector-bem-pattern */
 .cads-navigation-full-width-wrapper {
-  background-color: $cads-language__brand-primary;
+  background-color: $cads-language__nav-background-colour;
 
   .cads-navigation {
     @include cads-restrict-content-width;


### PR DESCRIPTION
Extracted from https://github.com/citizensadvice/design-system/pull/2251

Currently the colour of the navigation is controlled by the primary brand colour. This is a problem if you need to control the colour of the navigation without changing the brand colour as is the case in https://github.com/citizensadvice/design-system/pull/2251

Update the navigation styles to use a dedicated variable for the navigation background colour.

@marianayovcheva Just an FYI that we'll probably need to reconcile things whenever we pick https://github.com/citizensadvice/design-system/pull/1863 back up again