### PR TITLE
Introduce the concept of scoped prose styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 #### _Aug. 24, 2022_
 
 **New**
+- 📃 Add a new `cads-prose-direct-descendants` class which scopes prose styles to direct descendants using the `>` child combinator selector
 - 🔓 Disclosure: Add optional `id` and `additional_attributes`
 
 **Bugfixes**

--- a/design-system-docs/src/_foundations/typography.md
+++ b/design-system-docs/src/_foundations/typography.md
@@ -85,10 +85,10 @@ If you need to apply these styles to heading elements that you cannot add a clas
 </main>
 ```
 
-If you need to apply these styles to heading elements that you cannot add a class to but want more tightly scoped styles than the default `.cads-prose` class you can add a `.cads-prose-scoped` class instead. This is useful when you are embedding lots of rich components within a prose block and you want to more narrowly scope the effects of the cascade.
+If you need to apply these styles to heading elements that you cannot add a class to but want more tightly scoped styles than the default `.cads-prose` class you can add a `.cads-prose-direct-descendants` class instead which will target direct descendants only using the `>` child combinator selector. This is useful when you are embedding lots of rich components within a prose block and you want to more narrowly scope the effects of the cascade.
 
 ```html
-<main class="cads-prose-scoped">
+<main class="cads-prose-direct-descendants">
   <h1>Your options if you're in the UK illegally</h1>
   <h2>Get immigration advice</h2>
   <h3>If you're a British citizen</h3>

--- a/design-system-docs/src/_foundations/typography.md
+++ b/design-system-docs/src/_foundations/typography.md
@@ -85,6 +85,25 @@ If you need to apply these styles to heading elements that you cannot add a clas
 </main>
 ```
 
+If you need to apply these styles to heading elements that you cannot add a class to but want more tightly scoped styles than the default `.cads-prose` class you can add a `.cads-prose-scoped` class instead. This is useful when you are embedding lots of rich components within a prose block and you want to more narrowly scope the effects of the cascade.
+
+```html
+<main class="cads-prose-scoped">
+  <h1>Your options if you're in the UK illegally</h1>
+  <h2>Get immigration advice</h2>
+  <h3>If you're a British citizen</h3>
+  <p>
+    Your family members who are citizens of countries outside the EU, EEA or
+    Switzerland might be able to apply to the EU Settlement Scheme if one of the
+    following applies
+  </p>
+
+  <div class="my-special-component">
+    <p>Prose styles are not applied here</p>
+  </div>
+</main>
+```
+
 ### Adjacent Heading Mixin
 
 To ensure that headings have the correct margins applied inside the `.cads-prose` element, a mixin has been used that will add the correct margin. This is automatically applied to the relevant elements that appear in a `.cads-prose` wrapper.

--- a/design-system-docs/src/_layouts/component.erb
+++ b/design-system-docs/src/_layouts/component.erb
@@ -22,7 +22,7 @@ layout: default
           <%= render(Shared::OnThisPage.new(content)) %>
         <% end %>
 
-        <div class="cads-prose-scoped">
+        <div class="cads-prose-direct-descendants">
           <%= content %>
         </div>
       </div>

--- a/design-system-docs/src/_layouts/component.erb
+++ b/design-system-docs/src/_layouts/component.erb
@@ -22,7 +22,7 @@ layout: default
           <%= render(Shared::OnThisPage.new(content)) %>
         <% end %>
 
-        <div class="cads-prose">
+        <div class="cads-prose-scoped">
           <%= content %>
         </div>
       </div>

--- a/scss/5-objects/_prose.scss
+++ b/scss/5-objects/_prose.scss
@@ -71,7 +71,7 @@
  * without using a mixin or extending a raw class name.
  */
 %cads-prose {
-  @include cads-prose();
+  @include cads-prose;
 }
 
 /**

--- a/scss/5-objects/_prose.scss
+++ b/scss/5-objects/_prose.scss
@@ -1,6 +1,6 @@
 @use '../1-settings/prose' as prose-config;
 
-%cads-prose {
+@mixin cads-prose() {
   h1 {
     @extend %cads-h1;
   }
@@ -47,10 +47,6 @@
     margin: 0 0 $cads-spacing-5 0;
     max-width: 100%;
   }
-}
-
-.cads-prose {
-  @extend %cads-prose;
 
   .cads-list-no-bullet {
     @extend %cads-list-no-bullet;
@@ -67,6 +63,39 @@
         @include cads-hyperlink--external-icon;
       }
     }
+  }
+}
+
+/**
+ * Prose placeholder, allows components to extend prose styles
+ * without using a mixin or extending a raw class name.
+ */
+%cads-prose {
+  @include cads-prose();
+}
+
+/**
+ * Prose styles (cascading)
+ *
+ * Apply this class to blocks of HTML that you want to give consistent typographic styles,
+ * typically this is applied to blocks of copy that come from a content management system
+ * or local file.
+ */
+.cads-prose {
+  @include cads-prose;
+}
+
+/**
+ * Prose styles (scoped)
+ *
+ * This applies the same styles as the default cads-prose class but scoped using
+ * a child combinator selector to only apply the styles to immediate children.
+ * This is useful when you are embedding lots of rich components within a prose
+ * block and you want to more narrowly scope the effects of the cascade.
+ */
+.cads-prose-scoped {
+  > {
+    @include cads-prose;
   }
 }
 

--- a/scss/5-objects/_prose.scss
+++ b/scss/5-objects/_prose.scss
@@ -86,14 +86,14 @@
 }
 
 /**
- * Prose styles (scoped)
+ * Prose styles (direct descendants)
  *
  * This applies the same styles as the default cads-prose class but scoped using
  * a child combinator selector to only apply the styles to immediate children.
  * This is useful when you are embedding lots of rich components within a prose
  * block and you want to more narrowly scope the effects of the cascade.
  */
-.cads-prose-scoped {
+.cads-prose-direct-descendants {
   > {
     @include cads-prose;
   }


### PR DESCRIPTION
Often we use the cads-prose class for content where we also embed lots of rich components inside. By default styles within cads-prose cascade down which can subtly affect any components inside. We often work around this in our styles by resetting styles if we are inside a cads-prose element.

I'm proposing that we introduce a new cads-prose-scoped class which uses a child combinator selector to only apply typographic styles to immediate children. Any components within a scoped prose block would not be effected as they would start a new context.

I think the way our standard cads-prose class behaves is a sensible default but it is useful to have an equivalent class that is more targeted for cases where we need a bit more control.

---

Notably using the child combinator in combination with an extend logs a warning that extending this kind of selector will be a warning Dart Sass 2.0.0. Using a mixin here has no major impact as our minifier already dedupes selectors (doing what extend does but automatically).