### PR TITLE
Rationalise colour names amends

### DIFF
--- a/scss/6-components/_footer.scss
+++ b/scss/6-components/_footer.scss
@@ -44,7 +44,7 @@ $cads-color-footer-link-active: cads-colors(
 .cads-footer {
   @include cads-typographic-scale-text-small;
 
-  background-color: $cads-footer__background-colour;
+  background-color: $cads-color-footer-background;
   padding: $cads-spacing-4 0;
 
   .cads-footer__section-title {

--- a/scss/6-components/_header.scss
+++ b/scss/6-components/_header.scss
@@ -51,13 +51,13 @@ $cads-color-header-sign-out-border: cads-colors(
     color: $cads-color-header-link;
     border-bottom: $cads-border-width-medium solid transparent;
 
+    &:visited {
+      color: $cads-color-header-link-visited;
+    }
+
     &:hover {
       color: $cads-color-header-link-hover;
       background-color: $cads-color-header-background-hover;
-    }
-
-    &:active {
-      color: $cads-color-header-link-active;
     }
 
     &:focus {
@@ -66,8 +66,8 @@ $cads-color-header-sign-out-border: cads-colors(
       border-bottom: 2px solid $cads-color-text;
     }
 
-    &:visited {
-      color: $cads-color-header-link-visited;
+    &:active {
+      color: $cads-color-header-link-active;
     }
   }
 
@@ -93,8 +93,7 @@ $cads-color-header-sign-out-border: cads-colors(
       vertical-align: middle;
     }
 
-    &:hover,
-    &:active {
+    &:hover {
       color: $cads-color-button-primary-hover;
       background-color: $cads-color-button-primary-hover;
     }
@@ -104,6 +103,11 @@ $cads-color-header-sign-out-border: cads-colors(
       color: $cads-color-text-focus;
       border-color: $cads-color-border-focus;
       background-color: $cads-color-focus;
+    }
+
+    &:active {
+      color: $cads-color-button-primary-hover;
+      background-color: $cads-color-button-primary-hover;
     }
   }
 


### PR DESCRIPTION
Had a go at using https://github.com/citizensadvice/design-system/pull/1863 to re-theme the intranet. It worked really well and allowed me to remove a bunch of previous override and configure fewer variables. Spotted two small details along the way:

1. The footer was still using an old colour variable name which broke when switching to the new variables
2. Link state ordering in the header caused some undesirable conflicts when theming. See the commit message in https://github.com/citizensadvice/design-system/commit/f5ecdee7d254102bfd31431c4a5c8272d06d90d0 for more detail