### PR TITLE
Add new ComponentExampleSource component

### DIFF
--- a/design-system-docs/frontend/styles/_code.scss
+++ b/design-system-docs/frontend/styles/_code.scss
@@ -26,13 +26,10 @@ pre code {
   border: $cads-border-width-small $cads-language__border-colour solid;
   padding: $cads-spacing-4;
 
-  &--with-button {
-    margin: 0;
-  }
-
   button {
     font-family: $cads-font-family;
   }
+
   > .highlight {
     border: none;
     padding: 0;

--- a/design-system-docs/frontend/styles/_code.scss
+++ b/design-system-docs/frontend/styles/_code.scss
@@ -26,6 +26,10 @@ pre code {
   border: $cads-border-width-small $cads-language__border-colour solid;
   padding: $cads-spacing-4;
 
+  &--with-button {
+    margin: 0;
+  }
+
   button {
     font-family: $cads-font-family;
   }

--- a/design-system-docs/src/_component_docs/asset-hyperlink.md
+++ b/design-system-docs/src/_component_docs/asset-hyperlink.md
@@ -8,16 +8,7 @@ title: Asset hyperlink
 
 If you are using the `citizens_advice_components` gem, you can call the component from within a template using:
 
-```rb
-<%%= render(
-  CitizensAdviceComponents::AssetHyperlink.new(
-    href: "https://example.com",
-    description: "Test PDF",
-    size: 6_444_516
-  )
-  end
-%>
-```
+<%= render(Shared::ComponentExampleSource.new(:asset_hyperlink, :default)) %>
 
 ### View Component Options
 

--- a/design-system-docs/src/_component_docs/breadcrumbs.md
+++ b/design-system-docs/src/_component_docs/breadcrumbs.md
@@ -72,25 +72,7 @@ If you do not want the last crumb to indicate the current page (for screen reade
 
 If you are using the `citizens_advice_components` gem, you can call the component from within a template using:
 
-```rb
-= render(
-  CitizensAdviceComponents::Breadcrumbs.new(
-    type: :collapse,
-    links: [
-      {
-        title: "Home",
-        url: "/"
-      },
-      {
-        title: "Immigration",
-        url: "/immigration"
-      },
-      {
-        title: "Staying in the UK"
-      }
-    ])
-)
-```
+<%= render(Shared::ComponentExampleSource.new(:breadcrumbs, :default)) %>
 
 ### View Component Options
 

--- a/design-system-docs/src/_component_docs/button.md
+++ b/design-system-docs/src/_component_docs/button.md
@@ -58,10 +58,7 @@ Do not use anchor tags with an empty href when you want a button `<a href=â€#â€
 
 If you are using the `citizens_advice_components` gem, you can call the component from within a template using:
 
-```haml
-= render CitizensAdviceComponents::Button.new(variant: :primary, attributes: { "data-testid": "example" }) do
-  Primary button
-```
+<%= render(Shared::ComponentExampleSource.new(:button, :primary)) %>
 
 ### View component options
 

--- a/design-system-docs/src/_component_docs/button.md
+++ b/design-system-docs/src/_component_docs/button.md
@@ -71,20 +71,5 @@ If you are using the `citizens_advice_components` gem, you can call the componen
 
 The button component accepts an `icon_left` or `icon_right` slot for buttons with icons.
 
-```rb
-<%%= render CitizensAdviceComponents::Button.new do |c|
-  Next
-  - c.icon_right do
-    = render CitizensAdviceComponents::Icons::ArrowRight.new
-  end
-end %>
-```
+<%= render(Shared::ComponentExampleSource.new(:button, :previous_next)) %>
 
-```rb
-<%%= render CitizensAdviceComponents::Button.new(variant: :secondary) do |c|
-  Previous
-  - c.icon_left do
-    = render CitizensAdviceComponents::Icons::ArrowLeft.new
-  end
-end %>
-```

--- a/design-system-docs/src/_component_docs/button.md
+++ b/design-system-docs/src/_component_docs/button.md
@@ -72,4 +72,3 @@ If you are using the `citizens_advice_components` gem, you can call the componen
 The button component accepts an `icon_left` or `icon_right` slot for buttons with icons.
 
 <%= render(Shared::ComponentExampleSource.new(:button, :previous_next)) %>
-

--- a/design-system-docs/src/_component_docs/radio-group.md
+++ b/design-system-docs/src/_component_docs/radio-group.md
@@ -61,20 +61,7 @@ If you are using the `citizens_advice_components` gem, you can call the componen
 
 The radio buttons themselves can be defined using a simple hash, and passed into the `RadioGroup` component like this:
 
-```rb
-- my_radio_buttons = [
-  { label: "Option 1", value: "1", checked: true },
-  { label: "Option 2", value: "2" },
-  { label: "Option 3", value: "3", "data-testid": "my-test-id" }
-]
-
-= render CitizensAdviceComponents::RadioGroup.new(
-    label: "Example radio buttons",
-    name: "radio-buttons"
-  ) do |c|
-    c.inputs(my_radio_buttons)
-  end
-```
+<%= render(Shared::ComponentExampleSource.new(:radio_group, :default)) %>
 
 ### Additional attributes (View component only)
 

--- a/design-system-docs/src/_component_docs/targeted-content.md
+++ b/design-system-docs/src/_component_docs/targeted-content.md
@@ -50,15 +50,7 @@ If JavaScript either fails or is disabled in the users browser the fallback is t
 
 If you are using the `citizens_advice_components` gem you call the component from within a template using:
 
-```rb
-<%%= render(CitizensAdviceComponents::TargetedContent.new(
-  title: "Your title",
-  id: "targeted-content-example-id")
-  )) do
-    Your content
-  end
-%>
-```
+<%= render(Shared::ComponentExampleSource.new(:targeted_content, :default)) %>
 
 ### Component arguments
 

--- a/design-system-docs/src/_component_examples/_radio_group/default.erb
+++ b/design-system-docs/src/_component_examples/_radio_group/default.erb
@@ -6,7 +6,7 @@ title: Default
   name: "radio-buttons"
 ) do |c|
   c.inputs([
-             { label: "Option 1", value: "1" },
-             { label: "Option 2", value: "2" }
-           ])
+    { label: "Option 1", value: "1" },
+    { label: "Option 2", value: "2" }
+  ])
 end %>

--- a/design-system-docs/src/_component_examples/_radio_group/error.erb
+++ b/design-system-docs/src/_component_examples/_radio_group/error.erb
@@ -1,7 +1,7 @@
 ---
 title: With error summary
 ---
-<%=  render CitizensAdviceComponents::RadioGroup.new(
+<%= render CitizensAdviceComponents::RadioGroup.new(
   legend: "Example radio group",
   name: "radio-buttons-error",
   options: {
@@ -9,7 +9,7 @@ title: With error summary
   }
 ) do |c|
   c.inputs([
-             { label: "Option 1", value: "1" },
-             { label: "Option 2", value: "2" }
-           ])
+    { label: "Option 1", value: "1" },
+    { label: "Option 2", value: "2" }
+  ])
 end %>

--- a/design-system-docs/src/_component_examples/_targeted_content/default.erb
+++ b/design-system-docs/src/_component_examples/_targeted_content/default.erb
@@ -3,8 +3,8 @@ title: Default
 ---
 <%= render(CitizensAdviceComponents::TargetedContent.new(
   title: "If you are a citizen of a country outside the EU, EEA or Switzerland",
-  id: "targeted-content-123")
-) do %>
+  id: "targeted-content-123"
+)) do %>
   <p>You should apply to the EU Settlement Scheme if both:</p>
   <ul>
     <li>you’re in the UK by 31 December 2020</li>

--- a/design-system-docs/src/_components/shared/component_example.erb
+++ b/design-system-docs/src/_components/shared/component_example.erb
@@ -5,21 +5,27 @@
     </a>
   </div>
   <div class="component-example__preview">
-    <% if iframe? %>
-      <iframe class="component-example__iframe js-component-example-iframe" title="<%= example.data.title.downcase %> example" src="<%= example.relative_url %>" frameborder="0" loading="lazy"></iframe>
+    <% if example.iframe? %>
+      <iframe
+        class="component-example__iframe js-component-example-iframe"
+        title="<%= example.title.downcase %> example"
+        src="<%= example.relative_url %>"
+        frameborder="0"
+        loading="lazy"
+      ></iframe>
     <% else %>
       <%= example.content %>
     <% end %>
   </div>
   <div class="component-example__source">
-    <% if show_html? %>
-      <%= render(CitizensAdviceComponents::Disclosure.new(closed_summary: "HTML code", id: "html-code-#{example_code_id}")) do %>
-        <pre class="highlight"><code><%= raw highlighted_html %></code></pre>
+    <% if example.show_html? %>
+      <%= render(CitizensAdviceComponents::Disclosure.new(closed_summary: "HTML code", id: "html-code-#{example.id}")) do %>
+        <pre class="highlight"><code><%= raw example.highlighted_html %></code></pre>
       <% end %>
     <% end %>
-    <% if show_source? %>
-      <%= render(CitizensAdviceComponents::Disclosure.new(closed_summary: "ERB code", id: "erb-code-#{example_code_id}")) do %>
-        <pre class="highlight"><code><%= raw highlighted_source %></code></pre>
+    <% if example.show_source? %>
+      <%= render(CitizensAdviceComponents::Disclosure.new(closed_summary: "ERB code", id: "erb-code-#{example.id}")) do %>
+        <pre class="highlight"><code><%= raw example.highlighted_source %></code></pre>
       <% end %>
     <% end %>
   </div>

--- a/design-system-docs/src/_components/shared/component_example.rb
+++ b/design-system-docs/src/_components/shared/component_example.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "htmlbeautifier"
-
 module Shared
   class ComponentExample < ViewComponent::Base
     include Bridgetown::ViewComponentHelpers
@@ -15,56 +13,15 @@ module Shared
     end
 
     def render?
-      find_example.present?
+      example.present?
     end
 
     def example
-      example_resource = find_example
-      # Make sure that rendered output is processed
-      example_resource.transformer.process!
-      example_resource
-    end
-
-    def find_example
-      @site.collections.component_examples.resources.find do |resource|
-        resource.data.categories.include?(@category.to_s) &&
-          resource.data.slug == @slug.to_s
-      end
-    end
-
-    def iframe?
-      example.data[:iframe].present?
-    end
-
-    def show_html?
-      example.data[:show_html].present?
-    end
-
-    def show_source?
-      example.data[:show_source].present?
-    end
-
-    def highlighted_source
-      # @FIXME: There's probably some helper method to do this for us
-      lexer = Rouge::Lexers::ERB.new
-      formatter.format(lexer.lex(example.untransformed_content))
-    end
-
-    def highlighted_html
-      lexer = Rouge::Lexers::HTML.new
-      formatter.format(lexer.lex(beautified_content))
-    end
-
-    def beautified_content
-      ::HtmlBeautifier.beautify(example.content)
-    end
-
-    def formatter
-      Rouge::Formatters::HTML.new
-    end
-
-    def example_code_id
-      example.data.title.downcase.parameterize
+      @example ||= ComponentExamplePresenter.find_example(
+        site: @site,
+        category: @category,
+        slug: @slug
+      )
     end
   end
 end

--- a/design-system-docs/src/_components/shared/component_example_presenter.rb
+++ b/design-system-docs/src/_components/shared/component_example_presenter.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+require "htmlbeautifier"
+
+module Shared
+  class ComponentExamplePresenter
+    def self.find_example(site:, category:, slug:)
+      example = site.collections.component_examples.resources.find do |resource|
+        resource.data.categories.include?(category.to_s) &&
+          resource.data.slug == slug.to_s
+      end
+      new(example) if example.present?
+    end
+
+    attr_reader :example
+
+    def initialize(raw_example)
+      @example = raw_example
+      # Make sure that rendered output is processed
+      @example.transformer.process!
+    end
+
+    def data
+      example.data
+    end
+
+    def content
+      example.content
+    end
+
+    def relative_url
+      example.relative_url
+    end
+
+    def title
+      data[:title]
+    end
+
+    def id
+      title.downcase.parameterize
+    end
+
+    def iframe?
+      data[:iframe].present?
+    end
+
+    def show_html?
+      data[:show_html].present?
+    end
+
+    def show_source?
+      data[:show_source].present?
+    end
+
+    def highlighted_source
+      lexer = Rouge::Lexers::ERB.new
+      formatter.format(lexer.lex(example.untransformed_content))
+    end
+
+    def highlighted_html
+      lexer = Rouge::Lexers::HTML.new
+      beautified_content = ::HtmlBeautifier.beautify(example.content)
+      formatter.format(lexer.lex(beautified_content))
+    end
+
+    private
+
+    def formatter
+      Rouge::Formatters::HTML.new
+    end
+  end
+end

--- a/design-system-docs/src/_components/shared/component_example_source.erb
+++ b/design-system-docs/src/_components/shared/component_example_source.erb
@@ -1,1 +1,1 @@
-<pre class="highlight"><code><%= raw highlighted_source %></code></pre>
+<pre class="highlight"><code><%= raw example.highlighted_source %></code></pre>

--- a/design-system-docs/src/_components/shared/component_example_source.erb
+++ b/design-system-docs/src/_components/shared/component_example_source.erb
@@ -1,0 +1,1 @@
+<pre class="highlight"><code><%= raw highlighted_source %></code></pre>

--- a/design-system-docs/src/_components/shared/component_example_source.rb
+++ b/design-system-docs/src/_components/shared/component_example_source.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+module Shared
+  class ComponentExampleSource < ViewComponent::Base
+    include Bridgetown::ViewComponentHelpers
+
+    def initialize(category, slug)
+      super
+
+      @category = category
+      @slug = slug
+      @site = Bridgetown::Current.site
+    end
+
+    def render?
+      find_example.present?
+    end
+
+    def example
+      example_resource = find_example
+      # Make sure that rendered output is processed
+      example_resource.transformer.process!
+      example_resource
+    end
+
+    def find_example
+      @site.collections.component_examples.resources.find do |resource|
+        resource.data.categories.include?(@category.to_s) &&
+          resource.data.slug == @slug.to_s
+      end
+    end
+
+    def highlighted_source
+      lexer = Rouge::Lexers::ERB.new
+      formatter.format(lexer.lex(example.untransformed_content))
+    end
+
+    def formatter
+      Rouge::Formatters::HTML.new
+    end
+  end
+end

--- a/design-system-docs/src/_components/shared/component_example_source.rb
+++ b/design-system-docs/src/_components/shared/component_example_source.rb
@@ -13,30 +13,15 @@ module Shared
     end
 
     def render?
-      find_example.present?
+      example.present?
     end
 
     def example
-      example_resource = find_example
-      # Make sure that rendered output is processed
-      example_resource.transformer.process!
-      example_resource
-    end
-
-    def find_example
-      @site.collections.component_examples.resources.find do |resource|
-        resource.data.categories.include?(@category.to_s) &&
-          resource.data.slug == @slug.to_s
-      end
-    end
-
-    def highlighted_source
-      lexer = Rouge::Lexers::ERB.new
-      formatter.format(lexer.lex(example.untransformed_content))
-    end
-
-    def formatter
-      Rouge::Formatters::HTML.new
+      @example ||= ComponentExamplePresenter.find_example(
+        site: @site,
+        category: @category,
+        slug: @slug
+      )
     end
   end
 end


### PR DESCRIPTION
1. **Adds a new ComponentExampleSource component**. Serves a similar purpose to ComponentExample but just renders the ERB source code. Useful for showing inline code samples that reuse our existing code samples.
2. **Share code sample code between components**. Both the source and full example components use the same underlying data. Provide a presenter-ish object which can also find an example based on the site, category, and slug. Provides a shared interface for accessing an example with pre-transformed and formatted source.

The upshot is you can call this from your component docs:

```
<%= render(Shared::ComponentExampleSource.new(:asset_hyperlink, :default)) %>
```

And it will render just the inline source for the provided example