### PR TITLE
Migrate more component docs pages

### DIFF
--- a/design-system-docs/frontend/javascript/examples.js
+++ b/design-system-docs/frontend/javascript/examples.js
@@ -1,15 +1,19 @@
 export default function initExamples() {
   const plusMinus = document.querySelector('.js-plus-minus-example');
 
-  plusMinus.addEventListener('click', function () {
-    const icon = document.querySelector('.cads-icon--plus-minus');
-    icon.classList.toggle('show-minus');
-  });
+  if (plusMinus) {
+    plusMinus.addEventListener('click', function () {
+      const icon = document.querySelector('.cads-icon--plus-minus');
+      icon.classList.toggle('show-minus');
+    });
+  }
 
   const upDown = document.querySelector('.js-up-down-example');
 
-  upDown.addEventListener('click', function () {
-    const icon = document.querySelector('.cads-icon--arrow-up-down');
-    icon.classList.toggle('show-up');
-  });
+  if (upDown) {
+    upDown.addEventListener('click', function () {
+      const icon = document.querySelector('.cads-icon--arrow-up-down');
+      icon.classList.toggle('show-up');
+    });
+  }
 }

--- a/design-system-docs/frontend/styles/_code.scss
+++ b/design-system-docs/frontend/styles/_code.scss
@@ -21,21 +21,12 @@ pre code {
   background-color: $cads-palette__white;
 }
 
-.highlight {
+pre.highlight {
   margin-bottom: $cads-spacing-6;
   border: $cads-border-width-small $cads-language__border-colour solid;
   padding: $cads-spacing-4;
 
-  &--with-button {
-    margin: 0;
-  }
-
   button {
     font-family: $cads-font-family;
-  }
-
-  > .highlight {
-    border: none;
-    padding: 0;
   }
 }

--- a/design-system-docs/frontend/styles/_examples.scss
+++ b/design-system-docs/frontend/styles/_examples.scss
@@ -30,4 +30,8 @@
   .cads-disclosure__toggle {
     @include cads-typographic-scale-text-small();
   }
+
+  pre.highlight {
+    margin-bottom: 0;
+  }
 }

--- a/design-system-docs/src/_component_docs/notice-banner.md
+++ b/design-system-docs/src/_component_docs/notice-banner.md
@@ -1,0 +1,15 @@
+---
+title: Notice banner
+---
+
+<%= render(Shared::ComponentExample.new(:notice_banner, :default)) %>
+
+## Using with Rails
+
+If you are using the `citizens_advice_components` gem, you can call the component from within a template using:
+
+<%= render(Shared::ComponentExampleSource.new(:notice_banner, :default)) %>
+
+### View Component Options
+
+<%= render Shared::ArgumentsTable.new(:notice_banner) %>

--- a/design-system-docs/src/_component_docs/page-review.md
+++ b/design-system-docs/src/_component_docs/page-review.md
@@ -1,0 +1,15 @@
+---
+title: Page review
+---
+
+<%= render(Shared::ComponentExample.new(:page_review, :default)) %>
+
+## Using with Rails
+
+If you are using the `citizens_advice_components` gem, you can call the component from within a template using:
+
+<%= render(Shared::ComponentExampleSource.new(:page_review, :default)) %>
+
+### View Component Options
+
+<%= render Shared::ArgumentsTable.new(:page_review) %>

--- a/design-system-docs/src/_component_docs/pagination.md
+++ b/design-system-docs/src/_component_docs/pagination.md
@@ -1,0 +1,21 @@
+---
+title: Pagination
+---
+
+<%= render(Shared::ComponentExample.new(:pagination, :default)) %>
+
+## Accessibility requirements
+
+- Pagination is wrapped in a `<nav>` with `role="navigation"` and an appropriate `aria-label` e.g. `aria-label="Pagination navigation"`. You may wish to customise this based on the context it is used in, e.g. "Search pagination"
+- Each link has an appropriate `aria-label` e.g. "Go to first page", or "Go to page 3".
+- The current page has an `aria-label` of `aria-label="Current page, page 5"` with `aria-current="page"`
+
+## Using with Rails
+
+If you are using the `citizens_advice_components` gem, you can call the component from within a template using:
+
+<%= render(Shared::ComponentExampleSource.new(:pagination, :default)) %>
+
+### View Component Options
+
+<%= render Shared::ArgumentsTable.new(:pagination) %>

--- a/design-system-docs/src/_component_docs/success-message.md
+++ b/design-system-docs/src/_component_docs/success-message.md
@@ -1,0 +1,15 @@
+---
+title: Success message
+---
+
+<%= render(Shared::ComponentExample.new(:success_message, :default)) %>
+
+## Using with Rails
+
+If you are using the `citizens_advice_components` gem, you can call the component from within a template using:
+
+<%= render(Shared::ComponentExampleSource.new(:success_message, :default)) %>
+
+### View Component Options
+
+<%= render Shared::ArgumentsTable.new(:success_message) %>

--- a/design-system-docs/src/_component_examples/_notice_banner/_defaults.yml
+++ b/design-system-docs/src/_component_examples/_notice_banner/_defaults.yml
@@ -1,0 +1,1 @@
+category: notice_banner

--- a/design-system-docs/src/_component_examples/_notice_banner/default.erb
+++ b/design-system-docs/src/_component_examples/_notice_banner/default.erb
@@ -1,0 +1,6 @@
+---
+title: Default
+---
+<%= render(CitizensAdviceComponents::NoticeBanner.new(label: "Notice banner title")) do %>
+  <p>Example notice banner content</p>
+<% end %>

--- a/design-system-docs/src/_component_examples/_page_review/_defaults.yml
+++ b/design-system-docs/src/_component_examples/_page_review/_defaults.yml
@@ -1,0 +1,1 @@
+category: page_review

--- a/design-system-docs/src/_component_examples/_page_review/default.erb
+++ b/design-system-docs/src/_component_examples/_page_review/default.erb
@@ -1,0 +1,6 @@
+---
+title: Default
+---
+<%= render(CitizensAdviceComponents::PageReview.new(
+  page_review_date: Date.new(2020, 9, 21)
+)) %>

--- a/design-system-docs/src/_component_examples/_pagination/_defaults.yml
+++ b/design-system-docs/src/_component_examples/_pagination/_defaults.yml
@@ -1,0 +1,1 @@
+category: pagination

--- a/design-system-docs/src/_component_examples/_pagination/default.erb
+++ b/design-system-docs/src/_component_examples/_pagination/default.erb
@@ -1,0 +1,8 @@
+---
+title: Default
+---
+<%= render CitizensAdviceComponents::Pagination.new(
+  current_params: { "q" => "debt and money" },
+  num_pages: 100,
+  current_page: 5
+) %>

--- a/design-system-docs/src/_component_examples/_success_message/_defaults.yml
+++ b/design-system-docs/src/_component_examples/_success_message/_defaults.yml
@@ -1,0 +1,1 @@
+category: success_message

--- a/design-system-docs/src/_component_examples/_success_message/default.erb
+++ b/design-system-docs/src/_component_examples/_success_message/default.erb
@@ -1,0 +1,4 @@
+---
+title: Default
+---
+<%= render(CitizensAdviceComponents::SuccessMessage.new(message: "Thank you for your feedback")) %>

--- a/design-system-docs/src/_data/component_arguments.yml
+++ b/design-system-docs/src/_data/component_arguments.yml
@@ -20,6 +20,15 @@ notice_banner:
     description: Required, string
   - argument: "content (block)"
     description: Required, content block
+pagination:
+  - argument: num_pages
+    description: Total number of pages of pagination to generate
+  - argument: current_page
+    description: The current page number
+  - argument: current_params
+    description: Current request query parameters
+  - argument: param_name
+    description: Optional. Pagination param name, defaults to page
 page_review:
   - argument: page_review_date
     description: Required, date object for last reviewed date

--- a/design-system-docs/src/_data/component_arguments.yml
+++ b/design-system-docs/src/_data/component_arguments.yml
@@ -15,6 +15,11 @@ asset_hyperlink:
     description: Required, description of the asset
   - argument: size
     description: Required, size in bytes
+notice_banner:
+  - argument: label
+    description: Required, string
+  - argument: "content (block)"
+    description: Required, content block
 targeted_content:
   - argument: id
     description: Required, unique ID

--- a/design-system-docs/src/_data/component_arguments.yml
+++ b/design-system-docs/src/_data/component_arguments.yml
@@ -18,7 +18,7 @@ asset_hyperlink:
 notice_banner:
   - argument: label
     description: Required, string
-  - argument: "content (block)"
+  - argument: 'content (block)'
     description: Required, content block
 pagination:
   - argument: num_pages
@@ -33,7 +33,7 @@ page_review:
   - argument: page_review_date
     description: Required, date object for last reviewed date
   - argument: date_format
-    description: "Optional, custom date format passed to <code>I18n.l</code>. Defaults to <code>%d %B %Y</code>"
+    description: 'Optional, custom date format passed to <code>I18n.l</code>. Defaults to <code>%d %B %Y</code>'
 success_message:
   - argument: message
     description: Required. Message string

--- a/design-system-docs/src/_data/component_arguments.yml
+++ b/design-system-docs/src/_data/component_arguments.yml
@@ -20,6 +20,9 @@ notice_banner:
     description: Required, string
   - argument: "content (block)"
     description: Required, content block
+success_message:
+  - argument: message
+    description: Required. Message string
 targeted_content:
   - argument: id
     description: Required, unique ID

--- a/design-system-docs/src/_data/component_arguments.yml
+++ b/design-system-docs/src/_data/component_arguments.yml
@@ -20,6 +20,11 @@ notice_banner:
     description: Required, string
   - argument: "content (block)"
     description: Required, content block
+page_review:
+  - argument: page_review_date
+    description: Required, date object for last reviewed date
+  - argument: date_format
+    description: "Optional, custom date format passed to <code>I18n.l</code>. Defaults to <code>%d %B %Y</code>"
 success_message:
   - argument: message
     description: Required. Message string

--- a/engine/app/components/citizens_advice_components/notice_banner.html.erb
+++ b/engine/app/components/citizens_advice_components/notice_banner.html.erb
@@ -1,0 +1,4 @@
+<div class="cads-notice-banner">
+  <span class="cads-notice-banner__title"><%= label %></span>
+  <%= content %>
+</div>

--- a/engine/app/components/citizens_advice_components/notice_banner.html.haml
+++ b/engine/app/components/citizens_advice_components/notice_banner.html.haml
@@ -1,3 +1,0 @@
-.cads-notice-banner
-  %span.cads-notice-banner__title= label
-  = content


### PR DESCRIPTION
Using the new ComponentExampleSource component from https://github.com/citizensadvice/design-system/pull/2304 this PR migrates over a few of the simpler component docs pages.

1. Notice banner (converts component to ERB in the process)
2. Success message
3. Page review
4. Pagination