### PR TITLE
Add new cads-grid-col-width function

### DIFF
--- a/scss/2-tools/__tests__/grid.test.js
+++ b/scss/2-tools/__tests__/grid.test.js
@@ -1,0 +1,44 @@
+/* eslint-env jest */
+const sass = require('sass');
+
+describe('cads-grid-col-width', () => {
+  test.each([
+    [1, '8.3333333333%'],
+    [2, '16.6666666667%'],
+    [3, '25%'],
+    [4, '33.3333333333%'],
+    [5, '41.6666666667%'],
+    [6, '50%'],
+    [7, '58.3333333333%'],
+    [8, '66.6666666667%'],
+    [9, '75%'],
+    [10, '83.3333333333%'],
+    [11, '91.6666666667%'],
+    [12, '100%'],
+  ])('outputs width for %i columns', (cols, expected) => {
+    const data = `
+      @use 'scss/2-tools/grid';
+
+      .foo {
+        width: grid.cads-grid-col-width(${cols});
+      }
+    `;
+
+    const result = sass.renderSync({ data });
+    expect(result.css.toString()).toContain(`width: ${expected};`);
+  });
+
+  test('throws error when an invalid column count is provided', () => {
+    const data = `
+      @use 'scss/2-tools/grid';
+
+      .foo {
+        width: grid.cads-grid-col-width(13);
+      }
+    `;
+
+    expect(() => sass.renderSync({ data })).toThrow(
+      `Column count can't be greater than $cads-grid-columns`
+    );
+  });
+});

--- a/scss/2-tools/_grid.scss
+++ b/scss/2-tools/_grid.scss
@@ -1,0 +1,13 @@
+@use 'sass:math';
+
+// @use must be first, which conflicts with the import position rule
+// stylelint-disable no-invalid-position-at-import-rule
+@import '../1-settings/grid';
+
+@function cads-grid-col-width($cols) {
+  @if $cols > $cads-grid-columns {
+    @error "Column count can't be greater than $cads-grid-columns";
+  }
+
+  @return math.percentage(math.div($cols, $cads-grid-columns));
+}

--- a/scss/2-tools/tools-imports.scss
+++ b/scss/2-tools/tools-imports.scss
@@ -1,6 +1,7 @@
 @import './animation';
 @import './breakpoints';
 @import './spacing-sizing';
+@import './grid';
 @import './interactive-elements';
 @import './colours';
 @import './typography';

--- a/scss/5-objects/_grid.scss
+++ b/scss/5-objects/_grid.scss
@@ -7,6 +7,7 @@
 @import '../1-settings/spacing-sizing';
 @import '../1-settings/grid';
 @import '../2-tools/breakpoints';
+@import '../2-tools/grid';
 
 // ============================================================================
 // Grids
@@ -101,10 +102,10 @@
 
     @for $i from 1 through $cads-grid-columns {
       .cads-grid-col#{$infix}-#{$i} {
-        flex: 0 0 math.percentage(math.div($i, $cads-grid-columns));
+        flex: 0 0 cads-grid-col-width($i);
 
         // Ensure content within each column does not blow out the width of the column
-        max-width: math.percentage(math.div($i, $cads-grid-columns));
+        max-width: cads-grid-col-width($i);
       }
     }
   }


### PR DESCRIPTION
Adds a new cads-grid-col-width function which allows us to get the
percentage width for a given number of grid columns.

```scss
.my-component {
  max-width: cads-grid-col-width(6);
}
```

Throws an error if you request a column count greater than the maximum.