### PR TITLE
Migrate table docs

### DIFF
--- a/design-system-docs/src/_component_docs/tables.md
+++ b/design-system-docs/src/_component_docs/tables.md
@@ -1,0 +1,15 @@
+---
+title: Tables
+---
+
+<%= render(Shared::ComponentExample.new(:tables, :default)) %>
+
+## Using with Rails
+
+If you are using the `citizens_advice_components` gem, you can call the component from within a template using:
+
+<%= render(Shared::ComponentExampleSource.new(:tables, :default)) %>
+
+### Component arguments
+
+<%= render Shared::ArgumentsTable.new(:tables) %>

--- a/design-system-docs/src/_component_examples/_tables/_defaults.yml
+++ b/design-system-docs/src/_component_examples/_tables/_defaults.yml
@@ -1,0 +1,1 @@
+category: tables

--- a/design-system-docs/src/_component_examples/_tables/default.erb
+++ b/design-system-docs/src/_component_examples/_tables/default.erb
@@ -1,0 +1,26 @@
+---
+title: default
+---
+
+<%= render(CitizensAdviceComponents::Table.new(
+  caption: "Post box collection times (Monday to Friday)",
+  header: [
+    "Your location",
+    "Post box collection times"
+  ],
+  rows: [
+    [
+      "City or town",
+      "9am to 6.30pm"
+    ], [
+      "Areas with lots of businesses - known as commercial",
+      "9am to 7.30pm"
+    ], [
+      "Very rural areas - for example, where there aren't many people",
+      "9am to 4pm"
+    ], [
+      "Rest of the UK",
+      "9am to 5.30pm"
+    ]
+  ]
+)) %>

--- a/design-system-docs/src/_data/component_arguments.yml
+++ b/design-system-docs/src/_data/component_arguments.yml
@@ -60,3 +60,10 @@ callout:
     description: Optional type. One of :standard, :example, :important, or :adviser. Defaults to :standard.
   - argument: label
     description: Optional, title used as aria-label
+tables:
+  - argument: header
+    description: 'Required, array of header label'
+  - argument: rows
+    description: 'Required, nested array of row contents'
+  - argument: caption
+    description: 'Optional, <code>&lt;caption&gt;</code> text'


### PR DESCRIPTION
Migrate table docs using the generator introduced in https://github.com/citizensadvice/design-system/pull/2303

Ended up dropping the extra examples from the docs:

1. The long table example is more of a stress test and is already included in our backstop tests which makes more sense
2. The no-caption option is not _really_ recommended—we ideally want you to always provide a caption for accessibility reasons—but is covered by the components arguments table as an optional argument.