### PR TITLE
Migrate search component docs

### DIFF
--- a/design-system-docs/src/_component_docs/search.md
+++ b/design-system-docs/src/_component_docs/search.md
@@ -1,0 +1,23 @@
+---
+title: Search
+---
+
+## Examples
+
+### Default
+
+<%= render(Shared::ComponentExample.new(:search, :default)) %>
+
+### With value
+
+<%= render(Shared::ComponentExample.new(:search, :with_value)) %>
+
+## Using with Rails
+
+If you are using the `citizens_advice_components` gem, you can call the component from within a template using:
+
+<%= render(Shared::ComponentExampleSource.new(:search, :default)) %>
+
+### Component arguments
+
+<%= render Shared::ArgumentsTable.new(:search) %>

--- a/design-system-docs/src/_component_examples/_search/_defaults.yml
+++ b/design-system-docs/src/_component_examples/_search/_defaults.yml
@@ -1,0 +1,1 @@
+category: search

--- a/design-system-docs/src/_component_examples/_search/default.erb
+++ b/design-system-docs/src/_component_examples/_search/default.erb
@@ -1,0 +1,5 @@
+---
+title: default
+---
+
+<%= render CitizensAdviceComponents::Search.new %>

--- a/design-system-docs/src/_component_examples/_search/with_value.erb
+++ b/design-system-docs/src/_component_examples/_search/with_value.erb
@@ -1,0 +1,5 @@
+---
+title: with value
+---
+
+<%= render CitizensAdviceComponents::Search.new(value: "Current search term") %>

--- a/design-system-docs/src/_data/component_arguments.yml
+++ b/design-system-docs/src/_data/component_arguments.yml
@@ -85,3 +85,8 @@ callout:
     description: Optional type. One of :standard, :example, :important, or :adviser. Defaults to :standard.
   - argument: label
     description: Optional, title used as aria-label
+search:
+  - argument: value
+    description: Optional, current value
+  - argument: param_name
+    description: 'Optional. Pagination param name, defaults to <code>page</code>'


### PR DESCRIPTION
Not to toot my own 🎺 but the new docs generator makes this process _so_ much quicker.