### PR TITLE
Migrate on this page component docs

### DIFF
--- a/design-system-docs/frontend/javascript/index.js
+++ b/design-system-docs/frontend/javascript/index.js
@@ -7,12 +7,14 @@ import initHeader from '../../../lib/header';
 import greedyNav from '../../../lib/greedy-nav/index';
 import initTargetedContent from '../../../lib/targeted-content';
 import initDisclosure from '../../../lib/disclosure/disclosure';
+import initOnThisPage from '../../../lib/on-this-page/on-this-page';
 
 try {
   initHeader();
   greedyNav.init();
   initTargetedContent();
   initDisclosure();
+  initOnThisPage();
 } catch (error) {
   document.querySelector('html').classList.add('no-js');
   throw error;

--- a/design-system-docs/frontend/javascript/theme.js
+++ b/design-system-docs/frontend/javascript/theme.js
@@ -8,6 +8,7 @@ import initHeader from '../../../lib/header';
 import greedyNav from '../../../lib/greedy-nav/index';
 import initTargetedContent from '../../../lib/targeted-content';
 import initDisclosure from '../../../lib/disclosure/disclosure';
+import initOnThisPage from '../../../lib/on-this-page/on-this-page';
 import initCodeCopy from './code-copy';
 import initExamples from './examples';
 
@@ -16,6 +17,7 @@ try {
   greedyNav.init();
   initTargetedContent();
   initDisclosure();
+  initOnThisPage();
   initCodeCopy();
   initExamples();
 } catch (error) {

--- a/design-system-docs/src/_component_docs/on-this-page.md
+++ b/design-system-docs/src/_component_docs/on-this-page.md
@@ -1,0 +1,38 @@
+---
+title: On this page
+---
+
+## Examples
+
+### Default
+
+<%= render(Shared::ComponentExample.new(:on_this_page, :default)) %>
+
+### With nested links
+
+<%= render(Shared::ComponentExample.new(:on_this_page, :with_nested_links)) %>
+
+## JavaScript behaviour
+
+On this page requires some additional JavaScript behaviour which can be initialised with:
+
+```js
+import initOnThisPage from '@citizensadvice/design-system/lib/on-this-page/on-this-page';
+initOnThisPage();
+```
+
+## Using with Rails
+
+If you are using the `citizens_advice_components` gem, you can call the component from within a template using:
+
+<%= render(Shared::ComponentExampleSource.new(:on_this_page, :default)) %>
+
+### Component arguments
+
+<%= render Shared::ArgumentsTable.new(:on_this_page) %>
+
+### Links slot
+
+The on this page component accepts a required `links` slot. Links are an array of the following options:
+
+<%= render Shared::ArgumentsTable.new(:on_this_page_links_slot) %>

--- a/design-system-docs/src/_component_examples/_on_this_page/_defaults.yml
+++ b/design-system-docs/src/_component_examples/_on_this_page/_defaults.yml
@@ -1,0 +1,1 @@
+category: on_this_page

--- a/design-system-docs/src/_component_examples/_on_this_page/default.erb
+++ b/design-system-docs/src/_component_examples/_on_this_page/default.erb
@@ -1,0 +1,12 @@
+---
+title: default
+---
+
+<%= render CitizensAdviceComponents::OnThisPage.new do |c|
+  c.links([
+    { label: "Link 1", id: "link-1" },
+    { label: "Link 2", id: "link-2" },
+    { label: "Link 3", id: "link-3" },
+    { label: "Link 4", id: "link-4" }
+  ])
+end %>

--- a/design-system-docs/src/_component_examples/_on_this_page/with_nested_links.erb
+++ b/design-system-docs/src/_component_examples/_on_this_page/with_nested_links.erb
@@ -1,0 +1,18 @@
+---
+title: with nested links
+---
+
+<%= render CitizensAdviceComponents::OnThisPage.new(show_nested_links: true) do |c|
+  c.links([
+    { label: "Link 1", id: "link-1" },
+    { label: "Link 2", id: "link-2", children: [
+      { label: "Link 2.1", id: "link-2-1" },
+      { label: "Link 2.2", id: "link-2-2" }
+    ] },
+    { label: "Link 3", id: "link-3" },
+    { label: "Link 4", id: "link-4", children: [
+      { label: "Link 4.1", id: "link-4-1" }
+    ] },
+    { label: "Link 5", id: "link-5" }
+  ])
+end %>

--- a/design-system-docs/src/_data/component_arguments.yml
+++ b/design-system-docs/src/_data/component_arguments.yml
@@ -97,3 +97,13 @@ tables:
     description: 'Required, nested array of row contents'
   - argument: caption
     description: 'Optional, <code>&lt;caption&gt;</code> text'
+on_this_page:
+  - argument: show_nested_links
+    description: Optional, will display nested links if there are any. Defaults to false
+on_this_page_links_slot:
+  - argument: id
+    description: Required, used for linking content on the page, and for accessibility purposes
+  - argument: label
+    description: Required, the label of the link
+  - argument: id
+    description: Optional, array for nested links


### PR DESCRIPTION
Migrate on this page component docs. Split the component arguments out into two tables to better reflect the fact some are top-level the rest are for a slot.