### PR TITLE
Update release process docs

### DIFF
--- a/contributing/release-process.md
+++ b/contributing/release-process.md
@@ -1,8 +1,16 @@
 # Release process
 
-Releasing a new npm package version is a three step process.
+This document outlines the steps to release the design-system packages.
 
-## 1. Prepare the release
+## Pre-requisites
+
+**Note:** To perform a release you need:
+
+1. To be in the citizensadvice github org and have permissions to create releases for the design-system repo
+2. To be part of the citizensadvice npm org and have two-factor authentication enabled on your account.
+3. To be signed in to npm on your local machine. You can do this by running `npm login`. You will only need to do this once on the machine you want to release from.
+
+## Prepare the release
 
 ```sh
 npm run release
@@ -10,42 +18,35 @@ npm run release
 
 This prepares the release and puts it in a branch with the appropriate version name, which needs a pull request to be merged into main. Once that is merged you can then do the actual release.
 
-## 2. Publish to npm
+## Publish to npm
 
-**_Note:_**
+After the new version branch is merged, switch to `main`, pull the latest changes.
 
-To run this step you need to be part of the npm org and have 2FA enabled on your account.
+The npm publish command will build the package and publish to npm. A `prePublish` script will ensure you can only run npm publish from a `main` that is in a clean state.
 
-You also need an auth token in your `~/.npmrc` file. You can do this by running the following command:
+### If you are releasing an alpha or beta version
 
 ```sh
-npm login
+npm publish --tag latest
 ```
 
-You will only need to do this once on the machine you want to release from.
+This makes sure that the npm package is tagged with a pre-release dist-tag.
 
-After the new version branch is merged, switch to `main`, pull the latest changes and run:
+### If you releasing a main version
+
+For main releases you can run:
 
 ```sh
 npm publish
 ```
 
-Followed by
+## Create a release in GitHub
 
-```
-git push origin v{your_version_here}
-```
+Once the npm package has been published you need to make a release in GitHub.
 
-To publish the release tag to GitHub.
-
-A `prePublish` script will ensure you can only run npm publish from a `main` that is in a clean state. It will build the package and publish to npm.
-
-## 3. Update the release tag in GitHub
-
-Once the release tag has been push to GitHub in step 2, you must:
-
-- go to the design-system repository in GitHub
-- navigate to the 'Releases' section
-- update the release you pushed to be the latest release
-- copy the contents of the changelog comments for the relase into the release notes section
-- publish the release
+1. Go to the ['Releases' section of the design-system repository in GitHub](https://github.com/citizensadvice/design-system/releases)
+2. Choose "Draft a new release"
+3. Enter your new tag name, e.g. `v5.4.1-alpha.0` and choose to create a new tag
+4. Copy the contents of the changelog for the release into the release notes section
+5. If you are publishing and alpha or beta version check "This is a pre-release"
+6. Publish the release


### PR DESCRIPTION
Updates the release process docs after doing my first alpha release in a while to:

1. More clearly spell out the prerequisites to publish
2. Vary the instructions based on if the release is a pre-release to encourage running npm publish with --tag latest as the dist-tag
3. Reflect the fact that the release script now uses `--no-git-tag-version` (see https://github.com/citizensadvice/design-system/pull/1818) so we need to create the tag as part of the GitHub release