### PR TITLE
Migrate navigation component docs

### DIFF
--- a/design-system-docs/src/_component_docs/header.md
+++ b/design-system-docs/src/_component_docs/header.md
@@ -2,7 +2,26 @@
 title: Header
 ---
 
+## Examples
+
+### Standalone
+
 <%= render(Shared::ComponentExample.new(:header, :default)) %>
+
+### With navigation
+
+<%= render(Shared::ComponentExample.new(:header, :with_navigation)) %>
+
+The header is intended to be used alongside the navigation, although it works standalone, see the [navigation component docs](/components/navigation) for details on how to use the navigation component.
+
+## JavaScript behaviour
+
+If you plan to use this component you will need to initialise the following JavaScript:
+
+```js
+import initHeader from '@citizensadvice/design-system/lib/header';
+initHeader();
+```
 
 ## Using with Rails
 
@@ -111,12 +130,3 @@ Or by passing a custom block to render your own HTML:
 **Note:** If you use the custom block format you control the HTML rendered so you'll also need to handle styling yourself.
 
 However, there are some basic `form` and `button` styles you can use to render a simple 'Sign out' button included in the design-system styles and shown in the example above.
-
-## JavaScript behaviour
-
-If you plan to use this component you will need to initialise the following JavaScript:
-
-```js
-import initHeader from '@citizensadvice/design-system/lib/header';
-initHeader();
-```

--- a/design-system-docs/src/_component_docs/navigation.md
+++ b/design-system-docs/src/_component_docs/navigation.md
@@ -1,0 +1,30 @@
+---
+title: Navigation
+---
+
+<%= render(Shared::ComponentExample.new(:navigation, :default)) %>
+
+The navigation is intended to be used alongside the header, although it works standalone, see the [header component docs](/components/header) for details on how to use the header component.
+
+## JavaScript behaviour
+
+The global navigation uses a "greedy" navigation pattern to allow as many links to be visible as possible. As the width of the viewport is restricted, navigation links fall into a collapsible section.
+
+On mobile devices, any links that appear in the `.js-cads-copy-into-nav` element in the header are copied into the collapsible more section too.
+
+If you plan to use this component you will need to initialise the following JavaScript:
+
+```js
+import greedyNav from '@citizensadvice/design-system/lib/greedy-nav';
+greedyNav.init();
+```
+
+## Using with Rails
+
+If you are using the `citizens_advice_components` gem, you can call the component from within a template using:
+
+<%= render(Shared::ComponentExampleSource.new(:navigation, :default)) %>
+
+### Component arguments
+
+<%= render Shared::ArgumentsTable.new(:navigation) %>

--- a/design-system-docs/src/_component_examples/_header/with_navigation.erb
+++ b/design-system-docs/src/_component_examples/_header/with_navigation.erb
@@ -1,0 +1,34 @@
+---
+title: with navigation
+---
+
+<%= render CitizensAdviceComponents::Header.new do |c|
+  c.logo(title: "Citizens Advice homepage", url: "/")
+  c.skip_links([
+    { title: "Skip to navigation", url: "#cads-navigation" },
+    { title: "Skip to main content", url: "#cads-main-content" },
+    { title: "Skip to footer", url: "#cads-footer" }
+  ])
+  c.header_links([
+    { title: "Public site", url: "#", current_site: true },
+    { title: "AdviserNet", url: "#" },
+    { title: "Intranet", url: "#" },
+    { title: "Cymraeg", url: "#" }
+  ])
+  c.search_form(search_action_url: "/search")
+  c.account_link(title: "Sign in", url: "/sign-in")
+end %>
+<%= render CitizensAdviceComponents::Navigation.new(
+  links: [
+    { url: "/benefits/", title: "Benefits" },
+    { url: "/work/", title: "Work" },
+    { url: "/debt-and-money/", title: "Debt and money" },
+    { url: "/consumer/", title: "Consumer" },
+    { url: "/housing/", title: "Housing" },
+    { url: "/family/", title: "Family" },
+    { url: "/law-and-courts/", title: "Law and courts" },
+    { url: "/immigration/", title: "Immigration" },
+    { url: "/health/", title: "Health" },
+    { url: "/more", title: "More from us" }
+  ]
+) %>

--- a/design-system-docs/src/_component_examples/_navigation/_defaults.yml
+++ b/design-system-docs/src/_component_examples/_navigation/_defaults.yml
@@ -1,0 +1,2 @@
+category: navigation
+iframe: true

--- a/design-system-docs/src/_component_examples/_navigation/default.erb
+++ b/design-system-docs/src/_component_examples/_navigation/default.erb
@@ -1,0 +1,18 @@
+---
+title: default
+---
+
+<%= render CitizensAdviceComponents::Navigation.new(
+  links: [
+    { url: "/benefits/", title: "Benefits" },
+    { url: "/work/", title: "Work" },
+    { url: "/debt-and-money/", title: "Debt and money" },
+    { url: "/consumer/", title: "Consumer" },
+    { url: "/housing/", title: "Housing" },
+    { url: "/family/", title: "Family" },
+    { url: "/law-and-courts/", title: "Law and courts" },
+    { url: "/immigration/", title: "Immigration" },
+    { url: "/health/", title: "Health" },
+    { url: "/more", title: "More from us" }
+  ]
+) %>

--- a/design-system-docs/src/_data/component_arguments.yml
+++ b/design-system-docs/src/_data/component_arguments.yml
@@ -107,3 +107,10 @@ on_this_page_links_slot:
     description: Required, the label of the link
   - argument: id
     description: Optional, array for nested links
+navigation:
+  - argument: links
+    description: 'Required, an array of hashes, each with the following:'
+  - argument: 'link[:url]'
+    description: '→ Required, url for the link'
+  - argument: 'link[:title]'
+    description: '→ Required, title for the link'


### PR DESCRIPTION
Migrates the navigation component docs with a couple of amends:

1. Adds a navigation example to the header docs. I debated merging these docs into a single page but instead cross-linked between the two
2. Added missing JavaScript documentation to the navigation page