### PR TITLE
Convert asset hyperlink to ERB

### DIFF
--- a/engine/app/components/citizens_advice_components/asset_hyperlink.html.erb
+++ b/engine/app/components/citizens_advice_components/asset_hyperlink.html.erb
@@ -1,0 +1,4 @@
+<a href="<%= href %>">
+  <%= description %>
+  <span class="cads-asset-type"><%= icon %> <%= size %></span>
+</a>

--- a/engine/app/components/citizens_advice_components/asset_hyperlink.html.haml
+++ b/engine/app/components/citizens_advice_components/asset_hyperlink.html.haml
@@ -1,5 +1,0 @@
-%a{ href: href }
-  = description
-  %span.cads-asset-type<
-    = render CitizensAdviceComponents::Icons::File.new
-    \ #{number_to_human_size(size)}

--- a/engine/app/components/citizens_advice_components/asset_hyperlink.rb
+++ b/engine/app/components/citizens_advice_components/asset_hyperlink.rb
@@ -2,13 +2,21 @@
 
 module CitizensAdviceComponents
   class AssetHyperlink < Base
-    attr_reader :href, :description, :size
+    attr_reader :href, :description
 
     def initialize(href:, description:, size:)
       super
       @href = href
       @description = description
       @size = size
+    end
+
+    def size
+      number_to_human_size(@size)
+    end
+
+    def icon
+      render CitizensAdviceComponents::Icons::File.new
     end
   end
 end


### PR DESCRIPTION
Convert asset hyperlink to ERB. Removes some of the awkward HAML-escaping needed for this component and pushes more of the detail into the component class.