### PR TITLE
Publish docs on main build

### DIFF
--- a/.github/workflows/docs-workflow-main.yml
+++ b/.github/workflows/docs-workflow-main.yml
@@ -1,0 +1,46 @@
+name: Design System Docs (main)
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  publish:
+    name: Publish release to Netlify
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version-file: .nvmrc
+
+      # We link the @citizensadvice/design-system package
+      # from the root but we only build the lib/ directory
+      # when we publish to npm, so we need to build it first.
+      - uses: bahmutov/npm-install@v1
+      - run: npm run build
+
+      # Setup docs site
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '2.7.4'
+          bundler-cache: true
+          working-directory: design-system-docs
+
+      # Yarn install
+      - uses: bahmutov/npm-install@v1
+        with:
+          working-directory: design-system-docs
+
+      - run: ./bin/bridgetown deploy
+        working-directory: design-system-docs
+
+      - name: Deploy production to Netlify
+        uses: South-Paw/action-netlify-deploy@v1.2.1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          netlify-auth-token: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+          netlify-site-id: ${{ secrets.NETLIFY_SITE_ID }}
+          build-dir: ./design-system-docs/output
+          config-path: ./netlify.toml

--- a/.github/workflows/docs-workflow-main.yml
+++ b/.github/workflows/docs-workflow-main.yml
@@ -9,6 +9,7 @@ jobs:
   publish:
     name: Publish release to Netlify
     runs-on: ubuntu-latest
+    if: github.actor != 'dependabot[bot]'
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3


### PR DESCRIPTION
Currently our docs build workflow only publishes drafts and on release versions.

Whilst we are still working on the foundations of the new docs website it would be nice to have a continuously deployed version of the latest changes. Added a new workflow that publishes on main builds which we can remove later if we want to stick to release-only builds.