### PR TITLE
Migrate text input and textarea component docs

### DIFF
--- a/design-system-docs/src/_component_docs/text-input.md
+++ b/design-system-docs/src/_component_docs/text-input.md
@@ -1,0 +1,70 @@
+---
+title: Text input
+---
+
+Use this component when you want to collect textual or numerical data from a user that is not more than a single line.
+
+## Examples
+
+### Default
+
+<%= render(Shared::ComponentExample.new(:text_input, :default)) %>
+
+### With hint text
+
+Use hint text for help that’s relevant to the majority of users, based on the needs of your service.
+
+<%= render(Shared::ComponentExample.new(:text_input, :with_hint_text)) %>
+
+### Optional
+
+<%= render(Shared::ComponentExample.new(:text_input, :optional)) %>
+
+### Fixed widths
+
+Help users understand the purpose of the input by making the input size appropriate for the content it’s intended for.
+
+<%= render(Shared::ComponentExample.new(:text_input, :fixed_widths)) %>
+
+### With error message
+
+Error messages are used to highlight where users need to change information. They’re used together with an error summary
+
+<%= render(Shared::ComponentExample.new(:text_input, :with_error_message)) %>
+
+### With value
+
+<%= render(Shared::ComponentExample.new(:text_input, :with_value)) %>
+
+### With custom type
+
+<%= render(Shared::ComponentExample.new(:text_input, :with_custom_type)) %>
+
+## Implementation
+
+You must always have a `label` associated with the input element.
+
+Use the correct input `type` so the purpose of each input field can be determined.
+
+When collecting information about a user, use the `autocomplete` attribute to help users complete forms more quickly.
+
+[Read more about input purpose](https://www.w3.org/WAI/WCAG21/Understanding/identify-input-purpose.html) at WCAG 2.1.
+
+The following needs more research:
+
+- The effects of `type=number` and `inputmode=numeric` on assistive technologies?
+- Should we be able to group text inputs into fieldsets? Eg when capturing addresses?
+
+## Using with Rails
+
+If you are using the `citizens_advice_components` gem, you can call the component from within a template using:
+
+<%= render(Shared::ComponentExampleSource.new(:text_input, :all_options)) %>
+
+### Component arguments
+
+<%= render Shared::ArgumentsTable.new(:text_input) %>
+
+### Additional type values
+
+If you need access to inputs with additional type values, eg file or color, you can use the base `Input` view component instead. The interface is the same except you may not specify a width parameter.

--- a/design-system-docs/src/_component_docs/textarea.md
+++ b/design-system-docs/src/_component_docs/textarea.md
@@ -1,0 +1,35 @@
+---
+title: Textarea
+---
+
+## Examples
+
+### Default
+
+<%= render(Shared::ComponentExample.new(:textarea, :default)) %>
+
+### Optional
+
+<%= render(Shared::ComponentExample.new(:textarea, :optional)) %>
+
+### With hint
+
+<%= render(Shared::ComponentExample.new(:textarea, :with_hint)) %>
+
+### With error message
+
+<%= render(Shared::ComponentExample.new(:textarea, :with_error_message)) %>
+
+### With value
+
+<%= render(Shared::ComponentExample.new(:textarea, :with_value)) %>
+
+## Using with Rails
+
+If you are using the `citizens_advice_components` gem, you can call the component from within a template using:
+
+<%= render(Shared::ComponentExampleSource.new(:textarea, :all_options)) %>
+
+### Component arguments
+
+<%= render Shared::ArgumentsTable.new(:textarea) %>

--- a/design-system-docs/src/_component_examples/_text_input/_defaults.yml
+++ b/design-system-docs/src/_component_examples/_text_input/_defaults.yml
@@ -1,0 +1,1 @@
+category: text_input

--- a/design-system-docs/src/_component_examples/_text_input/all_options.erb
+++ b/design-system-docs/src/_component_examples/_text_input/all_options.erb
@@ -1,0 +1,19 @@
+---
+title: all options
+---
+
+<%= render(CitizensAdviceComponents::TextInput.new(
+  name: "my-input",
+  label: "My input",
+  type: :text,
+  width: :sixteen_chars,
+  options: {
+    hint: "Hint text",
+    error_message: "Error message",
+    optional: true,
+    value: "Input value",
+    additional_attributes: {
+      "data-test-id": "test"
+    }
+  }
+))%>

--- a/design-system-docs/src/_component_examples/_text_input/default.erb
+++ b/design-system-docs/src/_component_examples/_text_input/default.erb
@@ -1,0 +1,9 @@
+---
+title: default
+---
+
+<%= render(CitizensAdviceComponents::TextInput.new(
+  name: "example-input-basic",
+  label: "Example input",
+  type: :text
+))%>

--- a/design-system-docs/src/_component_examples/_text_input/fixed_widths.erb
+++ b/design-system-docs/src/_component_examples/_text_input/fixed_widths.erb
@@ -1,0 +1,31 @@
+---
+title: fixed widths
+---
+
+<%= render(CitizensAdviceComponents::TextInput.new(
+  width: :two_chars,
+  name: "example-input-fixed-width-two_chars",
+  label: "Example input", type: :text,
+  options: { hint: "This input is two_chars wide" }
+)) %>
+
+<%= render(CitizensAdviceComponents::TextInput.new(
+  width: :four_chars,
+  name: "example-input-fixed-width-four_chars",
+  label: "Example input", type: :text,
+  options: { hint: "This input is four_chars wide" }
+)) %>
+
+<%= render(CitizensAdviceComponents::TextInput.new(
+  width: :eight_chars,
+  name: "example-input-fixed-width-eight_chars",
+  label: "Example input", type: :text,
+  options: { hint: "This input is eight_chars wide" }
+)) %>
+
+<%= render(CitizensAdviceComponents::TextInput.new(
+  width: :sixteen_chars,
+  name: "example-input-fixed-width-sixteen_chars",
+  label: "Example input", type: :text,
+  options: { hint: "This input is sixteen_chars wide" }
+)) %>

--- a/design-system-docs/src/_component_examples/_text_input/optional.erb
+++ b/design-system-docs/src/_component_examples/_text_input/optional.erb
@@ -1,0 +1,12 @@
+---
+title: optional
+---
+
+<%= render(CitizensAdviceComponents::TextInput.new(
+  name: "example-input-optional",
+  label: "Example input",
+  type: :text,
+  options: {
+    optional: true
+  }
+))%>

--- a/design-system-docs/src/_component_examples/_text_input/with_custom_type.erb
+++ b/design-system-docs/src/_component_examples/_text_input/with_custom_type.erb
@@ -1,0 +1,13 @@
+---
+title: with custom type
+---
+
+<%= render(CitizensAdviceComponents::TextInput.new(
+  name: "example-input-password",
+  label: "Example input",
+  type: :password,
+  options: {
+    value: "It's a secret",
+    hint: "This input has type 'password'"
+  }
+))%>

--- a/design-system-docs/src/_component_examples/_text_input/with_error_message.erb
+++ b/design-system-docs/src/_component_examples/_text_input/with_error_message.erb
@@ -1,0 +1,12 @@
+---
+title: with error message
+---
+
+<%= render(CitizensAdviceComponents::TextInput.new(
+  name: "example-input-error",
+  label: "Email address",
+  type: :text,
+  options: {
+    error_message: "Enter a valid email address, like name@example.com"
+  }
+))%>

--- a/design-system-docs/src/_component_examples/_text_input/with_hint_text.erb
+++ b/design-system-docs/src/_component_examples/_text_input/with_hint_text.erb
@@ -1,0 +1,12 @@
+---
+title: with hint text
+---
+
+<%= render(CitizensAdviceComponents::TextInput.new(
+  name: "example-input-with-hint",
+  label: "Example input with hint",
+  type: :text,
+  options: {
+    hint: "This is the hint for the input"
+  }
+))%>

--- a/design-system-docs/src/_component_examples/_text_input/with_value.erb
+++ b/design-system-docs/src/_component_examples/_text_input/with_value.erb
@@ -1,0 +1,10 @@
+---
+title: with value
+---
+
+<%= render(CitizensAdviceComponents::TextInput.new(
+  name: "example-input-value",
+  label: "Example input",
+  type: :text,
+  options: { value: "Lorem ipsum" }
+))%>

--- a/design-system-docs/src/_component_examples/_textarea/_defaults.yml
+++ b/design-system-docs/src/_component_examples/_textarea/_defaults.yml
@@ -1,0 +1,1 @@
+category: textarea

--- a/design-system-docs/src/_component_examples/_textarea/all_options.erb
+++ b/design-system-docs/src/_component_examples/_textarea/all_options.erb
@@ -1,0 +1,18 @@
+---
+title: all options
+---
+
+<%= render(CitizensAdviceComponents::Textarea.new(
+  name: "my-textarea",
+  label: "My textarea",
+  rows: 12,
+  options: {
+    hint: "Hint text",
+    error_message: "Error message",
+    optional: true,
+    value: "Input value",
+    additional_attributes: {
+      "data-test-id": "test"
+    }
+  }
+))%>

--- a/design-system-docs/src/_component_examples/_textarea/default.erb
+++ b/design-system-docs/src/_component_examples/_textarea/default.erb
@@ -1,0 +1,8 @@
+---
+title: default
+---
+
+<%= render(CitizensAdviceComponents::Textarea.new(
+  name: "example-textarea-basic",
+  label: "Example textarea",
+))%>

--- a/design-system-docs/src/_component_examples/_textarea/optional.erb
+++ b/design-system-docs/src/_component_examples/_textarea/optional.erb
@@ -1,0 +1,11 @@
+---
+title: optional
+---
+
+<%= render(CitizensAdviceComponents::Textarea.new(
+  name: "example-textarea-optional",
+  label: "Example textarea",
+  options: {
+    optional: true
+  }
+))%>

--- a/design-system-docs/src/_component_examples/_textarea/with_error_message.erb
+++ b/design-system-docs/src/_component_examples/_textarea/with_error_message.erb
@@ -1,0 +1,11 @@
+---
+title: with error message
+---
+
+<%= render(CitizensAdviceComponents::Textarea.new(
+  name: "example-textarea-with-error-message",
+  label: "Example textarea",
+  options: {
+    error_message: "Example error message"
+  }
+))%>

--- a/design-system-docs/src/_component_examples/_textarea/with_hint.erb
+++ b/design-system-docs/src/_component_examples/_textarea/with_hint.erb
@@ -1,0 +1,11 @@
+---
+title: with hint
+---
+
+<%= render(CitizensAdviceComponents::Textarea.new(
+  name: "example-textarea-hint",
+  label: "Example textarea (with hint)",
+  options: {
+    hint: "Example hint text"
+  }
+))%>

--- a/design-system-docs/src/_component_examples/_textarea/with_value.erb
+++ b/design-system-docs/src/_component_examples/_textarea/with_value.erb
@@ -1,0 +1,11 @@
+---
+title: with value
+---
+
+<%= render(CitizensAdviceComponents::Textarea.new(
+  name: "example-textarea-with-value",
+  label: "Example textarea",
+  options: {
+    value: "Amet parturient platea augue natoque vitae sem parturient senectus nisi sit nascetur penatibus neque scelerisque rutrum nisl amet odio adipiscing.Ad consectetur quam taciti faucibus etiam parturient a sed."
+  }
+))%>

--- a/design-system-docs/src/_data/component_arguments.yml
+++ b/design-system-docs/src/_data/component_arguments.yml
@@ -161,3 +161,43 @@ disclosure:
     description: 'Optional, if not provided, the closed title will be used for generating the id of the disclosure details'
   - argument: additional_attributes
     description: 'Optional, a hash of additional attributes rendered onto the button, eg <code>{ "data-test-id": "my-test-id" }</code>'
+text_input:
+  - argument: name
+    description: Required, field name
+  - argument: label
+    description: Required, the text for the label associated with the input
+  - argument: type
+    description: 'Required, one of: <code>:email</code>, <code>:hidden</code>, <code>:number</code>, <code>:password</code>, <code>:search</code>, <code>:tel</code>, <code>:text</code>, <code>:url</code>'
+  - argument: width
+    description: 'Optional, one of: <code>:two_char</code>, <code>:four_char</code>, <code>:eight_char</code>, <code>:sixteen_char</code>'
+  - argument: options
+    description: 'Optional, a hash with one or more of the following values:'
+  - argument: 'options[:hint]'
+    description: '→ Optional, hint text for the input'
+  - argument: 'options[:error_message]'
+    description: '→ Optional, an error message for the input'
+  - argument: 'options[:optional]'
+    description: '→ Optional, boolean indicating the field is optional (i.e. not required)'
+  - argument: 'options[:value]'
+    description: '→ Optional, the value of the input'
+  - argument: 'options[:additional_attributes]'
+    description: 'Optional, a hash of additional attributes rendered onto the input, eg <code>{ autocomplete: "name" }</code>'
+textarea:
+  - argument: name
+    description: Required, field name
+  - argument: label
+    description: Required, the text for the label associated with the input
+  - argument: rows
+    description: 'Optional, the number of rows for the textarea. Defaults to 8'
+  - argument: options
+    description: 'Optional, a hash with one or more of the following values:'
+  - argument: 'options[:hint]'
+    description: '→ Optional, hint text for the input'
+  - argument: 'options[:error_message]'
+    description: '→ Optional, an error message for the input'
+  - argument: 'options[:optional]'
+    description: '→ Optional, boolean indicating the field is optional (i.e. not required)'
+  - argument: 'options[:value]'
+    description: '→ Optional, the value of the input'
+  - argument: 'options[:additional_attributes]'
+    description: 'Optional, a hash of additional attributes rendered onto the input, eg <code>{ autocomplete: "name" }</code>'


### PR DESCRIPTION
Migrate text input and textarea component docs to new website.

Renamed the "Input" docs to "Text input" to reflect that's the actual component name used here.