### PR TITLE
Docs tidy up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 **Bugfixes**
 
 - Footer: Fix borders when using minimal footer
+- Greedy nav: use theme colour for the background, not the brand colour
 
 ## <sub>v5.4.1-alpha.0</sub>
 

--- a/design-system-docs/src/_layouts/basic.erb
+++ b/design-system-docs/src/_layouts/basic.erb
@@ -9,9 +9,12 @@ layout: default
   ]
 )) %>
 
-<%= render "notice_banner" %>
-
 <main id="cads-main-content" class="cads-grid-container">
+  <div class="cads-grid-row">
+    <div class="cads-grid-col-md-9">
+      <%= render "notice_banner" %>
+    </div>
+  </div>
   <div class="cads-grid-row">
     <div class="cads-grid-col-md-8">
       <div class="cads-page-content">

--- a/design-system-docs/src/_layouts/component.erb
+++ b/design-system-docs/src/_layouts/component.erb
@@ -10,9 +10,12 @@ layout: default
   ]
 )) %>
 
-<%= render "notice_banner" %>
-
 <main id="cads-main-content" class="cads-grid-container">
+  <div class="cads-grid-row">
+    <div class="cads-grid-col-md-9">
+      <%= render "notice_banner" %>
+    </div>
+  </div>
   <div class="cads-grid-row">
     <div class="cads-grid-col-md-8">
       <div class="cads-page-content">

--- a/design-system-docs/src/_layouts/default.erb
+++ b/design-system-docs/src/_layouts/default.erb
@@ -5,11 +5,14 @@
     <%= seo %>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="robots" content="noindex, nofollow">
+    <link href="<%= webpack_path("fonts/open-sans-v26-latin-700.woff2") %>" rel="preload" as="font" type="font/woff2" crossorigin="true" />
+    <link href="<%= webpack_path("fonts/open-sans-v26-latin-regular.woff2") %>" rel="preload" as="font" type="font/woff2" crossorigin="true" />
+    <link href="<%= webpack_path("fonts/cads.woff") %>" rel="preload" as="font" type="font/woff" crossorigin="true" />
+    <link rel="stylesheet" href="<%= webpack_path "theme.css" %>" />
+    <style><%= Rouge::Theme.find('cads-theme').render(scope: '.highlight') %></style>
     <script type="application/javascript">
       document.querySelector('html').classList.remove('no-js');
     </script>
-    <link rel="stylesheet" href="<%= webpack_path "theme.css" %>" />
-    <style><%= Rouge::Theme.find('cads-theme').render(scope: '.highlight') %></style>
   </head>
   <body class="site">
     <%= render Shared::AppHeader.new %>

--- a/design-system-docs/src/_layouts/default.erb
+++ b/design-system-docs/src/_layouts/default.erb
@@ -5,6 +5,7 @@
     <%= seo %>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="robots" content="noindex, nofollow">
+    <meta name="format-detection" content="telephone=no">
     <link href="<%= webpack_path("fonts/open-sans-v26-latin-700.woff2") %>" rel="preload" as="font" type="font/woff2" crossorigin="true" />
     <link href="<%= webpack_path("fonts/open-sans-v26-latin-regular.woff2") %>" rel="preload" as="font" type="font/woff2" crossorigin="true" />
     <link href="<%= webpack_path("fonts/cads.woff") %>" rel="preload" as="font" type="font/woff" crossorigin="true" />

--- a/design-system-docs/src/_layouts/foundations.erb
+++ b/design-system-docs/src/_layouts/foundations.erb
@@ -1,6 +1,7 @@
 ---
 layout: default
 ---
+
 <%= render(CitizensAdviceComponents::Breadcrumbs.new(
   links: [
     { title: "Home", url: "/"},
@@ -9,9 +10,12 @@ layout: default
   ]
 )) %>
 
-<%= render "notice_banner" %>
-
 <main id="cads-main-content" class="cads-grid-container">
+  <div class="cads-grid-row">
+    <div class="cads-grid-col-md-9">
+      <%= render "notice_banner" %>
+    </div>
+  </div>
   <div class="cads-grid-row">
     <div class="cads-grid-col-md-8">
       <div class="cads-page-content">

--- a/design-system-docs/src/_pages/components.erb
+++ b/design-system-docs/src/_pages/components.erb
@@ -10,9 +10,12 @@ layout: default
   ]
 )) %>
 
-<%= render "notice_banner" %>
-
 <main id="cads-main-content" class="cads-grid-container">
+  <div class="cads-grid-row">
+    <div class="cads-grid-col-md-9">
+      <%= render "notice_banner" %>
+    </div>
+  </div>
   <div class="cads-grid-row">
     <div class="cads-grid-col-md-8 cads-page-content">
       <h1 class="cads-page-title"><%= resource.data.title %></h1>

--- a/design-system-docs/src/_pages/foundations.erb
+++ b/design-system-docs/src/_pages/foundations.erb
@@ -10,9 +10,12 @@ layout: default
   ]
 )) %>
 
-<%= render "notice_banner" %>
-
 <main id="cads-main-content" class="cads-grid-container cads-page-content">
+  <div class="cads-grid-row">
+    <div class="cads-grid-col-md-9">
+      <%= render "notice_banner" %>
+    </div>
+  </div>
   <div class="cads-grid-row">
     <div class="cads-grid-col-md-8">
       <h1 class="cads-page-title"><%= resource.data.title %></h1>

--- a/design-system-docs/src/_partials/_notice_banner.erb
+++ b/design-system-docs/src/_partials/_notice_banner.erb
@@ -1,12 +1,6 @@
-<div class="cads-grid-container">
-  <div class="cads-grid-row">
-    <div class="cads-grid-col-md-9">
-      <%= render CitizensAdviceComponents::NoticeBanner.new(label: "Alpha") do %>
-        <p>
-          You've stumbled across our new documentation site.
-          <a href="https://citizensadvice.github.io/design-system/">Go to the live documentation</a>.
-        </p>
-      <% end %>
-    </div>
-  </div>
-</div>
+<%= render CitizensAdviceComponents::NoticeBanner.new(label: "Alpha") do %>
+  <p>
+    You've stumbled across our new documentation site.
+    <a href="https://citizensadvice.github.io/design-system/">Go to the live documentation</a>.
+  </p>
+<% end %>

--- a/scss/6-components/_navigation_greedy-nav.scss
+++ b/scss/6-components/_navigation_greedy-nav.scss
@@ -15,7 +15,7 @@
     z-index: 1000;
     position: absolute;
     visibility: hidden;
-    background-color: $cads-language__brand-primary;
+    background-color: $cads-language__nav-background-colour;
     border-top: $cads-border-width-small solid $cads-palette__white;
     right: 0;
     width: 100vw;
@@ -88,7 +88,7 @@
 
     height: 100%;
     font-weight: bold;
-    background-color: $cads-language__brand-primary;
+    background-color: $cads-language__nav-background-colour;
     border-left: $cads-border-width-small solid $cads-language__border-colour;
 
     @include cads-media-breakpoint-up(md) {


### PR DESCRIPTION
Small bits of tidy up after migrating most of the component docs:

- Greedy nav: Use theme colour
- Preload fonts in docs website
- Disable telephone format detection
- Fix accessibility warning with notice banner outside main landmark
