### PR TITLE
Convert targeted content to ERB

### DIFF
--- a/engine/app/components/citizens_advice_components/targeted_content.html.erb
+++ b/engine/app/components/citizens_advice_components/targeted_content.html.erb
@@ -1,0 +1,30 @@
+<%= tag.div(
+  class: [
+    "cads-targeted-content",
+    "js-cads-targeted-content",
+    ("cads-targeted-content--adviser" if adviser?),
+    ("cads-no-close" unless show_close_button?)
+  ].compact,
+  "data-descriptive-label-show": "#{t('.descriptive_label_show')}, #{title}",
+  "data-descriptive-label-hide": "#{t('.descriptive_label_hide')}, #{title}",
+  "data-close-label": t(".close_label")
+) do %>
+  <%= content_tag(
+    "h#{heading_level}".to_sym,
+    class: "cads-targeted-content__title js-cads-targeted-content__title",
+    id: "h-#{id}",
+    "data-testid": "targeted-content-title"
+  ) do %>
+    <span class="cads-targeted-content__title-text">
+      <% if adviser? %>
+        <span class="cads-targeted-content__badge">
+          <%= render(CitizensAdviceComponents::Badge.new(type: :adviser)) %>
+        </span>
+      <% end %>
+      <%= title %>
+    </span>
+  <% end %>
+  <div class="cads-targeted-content__content cads-prose js-cads-targeted-content__content" id="<%= "#{id}-content" %>">
+    <%= content %>
+  </div>
+<% end %>

--- a/engine/app/components/citizens_advice_components/targeted_content.html.haml
+++ b/engine/app/components/citizens_advice_components/targeted_content.html.haml
@@ -1,9 +1,0 @@
-.cads-targeted-content.js-cads-targeted-content{ attributes }
-  - haml_tag("h#{heading_level}", heading_attributes) do
-    %span.cads-targeted-content__title-text
-      - if adviser?
-        %span.cads-targeted-content__badge
-          = render(CitizensAdviceComponents::Badge.new(type: :adviser))
-      = title
-  .cads-targeted-content__content.cads-prose.js-cads-targeted-content__content{ id: "#{id}-content" }
-    = content

--- a/engine/app/components/citizens_advice_components/targeted_content.rb
+++ b/engine/app/components/citizens_advice_components/targeted_content.rb
@@ -35,28 +35,6 @@ module CitizensAdviceComponents
       @show_close_button
     end
 
-    def attributes
-      {
-        class: [
-          ("cads-targeted-content--adviser" if adviser?),
-          ("cads-no-close" unless show_close_button?)
-        ],
-        data: {
-          descriptive_label_show: "#{t('citizens_advice_components.targeted_content.descriptive_label_show')}, #{title}",
-          descriptive_label_hide: "#{t('citizens_advice_components.targeted_content.descriptive_label_hide')}, #{title}",
-          close_label: t("citizens_advice_components.targeted_content.close_label")
-        }
-      }
-    end
-
-    def heading_attributes
-      {
-        id: "h-#{id}",
-        class: %w[cads-targeted-content__title js-cads-targeted-content__title],
-        data: { testid: "targeted-content-title" }
-      }
-    end
-
     def render?
       content.present?
     end

--- a/styleguide/examples/sample_pages/content-sample.html
+++ b/styleguide/examples/sample_pages/content-sample.html
@@ -257,14 +257,14 @@
 
           <div
             class="cads-targeted-content js-cads-targeted-content"
-            data-close-label="Close"
-            data-descriptive-label-hide="close this section, If you are a citizen of a country outside the EU, EEA or Switzerland"
             data-descriptive-label-show="show this section, If you are a citizen of a country outside the EU, EEA or Switzerland"
+            data-descriptive-label-hide="close this section, If you are a citizen of a country outside the EU, EEA or Switzerland"
+            data-close-label="Close"
           >
             <h2
+              id="h-targeted-content-123"
               class="cads-targeted-content__title js-cads-targeted-content__title"
               data-testid="targeted-content-title"
-              id="h-targeted-content-123"
             >
               <span class="cads-targeted-content__title-text">
                 If you are a citizen of a country outside the EU, EEA or

--- a/styleguide/examples/targeted_content/adviser.html
+++ b/styleguide/examples/targeted_content/adviser.html
@@ -1,13 +1,13 @@
 <div
   class="cads-targeted-content js-cads-targeted-content cads-targeted-content--adviser"
-  data-close-label="Close"
-  data-descriptive-label-hide="close this section, Students or self-sufficient people"
   data-descriptive-label-show="show this section, Students or self-sufficient people"
+  data-descriptive-label-hide="close this section, Students or self-sufficient people"
+  data-close-label="Close"
 >
   <h2
+    id="h-targeted-content-adviser"
     class="cads-targeted-content__title js-cads-targeted-content__title"
     data-testid="targeted-content-title"
-    id="h-targeted-content-adviser"
   >
     <span class="cads-targeted-content__title-text">
       <span class="cads-targeted-content__badge">

--- a/styleguide/examples/targeted_content/anchor.html
+++ b/styleguide/examples/targeted_content/anchor.html
@@ -95,14 +95,14 @@
     </p>
     <div
       class="cads-targeted-content js-cads-targeted-content"
-      data-close-label="Close"
-      data-descriptive-label-hide="close this section, If you are a citizen of a country outside the EU, EEA or Switzerland"
       data-descriptive-label-show="show this section, If you are a citizen of a country outside the EU, EEA or Switzerland"
+      data-descriptive-label-hide="close this section, If you are a citizen of a country outside the EU, EEA or Switzerland"
+      data-close-label="Close"
     >
       <h2
+        id="h-targeted-content-234"
         class="cads-targeted-content__title js-cads-targeted-content__title"
         data-testid="targeted-content-title"
-        id="h-targeted-content-234"
       >
         <span class="cads-targeted-content__title-text">
           If you are a citizen of a country outside the EU, EEA or Switzerland

--- a/styleguide/examples/targeted_content/default.html
+++ b/styleguide/examples/targeted_content/default.html
@@ -1,13 +1,13 @@
 <div
   class="cads-targeted-content js-cads-targeted-content"
-  data-close-label="Close"
-  data-descriptive-label-hide="close this section, If you are a citizen of a country outside the EU, EEA or Switzerland"
   data-descriptive-label-show="show this section, If you are a citizen of a country outside the EU, EEA or Switzerland"
+  data-descriptive-label-hide="close this section, If you are a citizen of a country outside the EU, EEA or Switzerland"
+  data-close-label="Close"
 >
   <h2
+    id="h-targeted-content-123"
     class="cads-targeted-content__title js-cads-targeted-content__title"
     data-testid="targeted-content-title"
-    id="h-targeted-content-123"
   >
     <span class="cads-targeted-content__title-text">
       If you are a citizen of a country outside the EU, EEA or Switzerland


### PR DESCRIPTION
Convert targeted content to ERB. Made the choice to move the attributes into the template as ERB has far less of a problem with larger lists of attributes so it's clearer having them inline now.