### PR TITLE
Convert disclosure to ERB

### DIFF
--- a/engine/app/components/citizens_advice_components/disclosure.html.erb
+++ b/engine/app/components/citizens_advice_components/disclosure.html.erb
@@ -1,0 +1,10 @@
+<div class="cads-disclosure js-disclosure">
+  <%= tag.button(**button_attrs) do %>
+    <span class="cads-disclosure__summary js-disclosure-summary">
+      <%= closed_summary %>
+    </span>
+  <% end %>
+  <div class="cads-disclosure__details js-disclosure-details" id="<%= id %>">
+    <%= content %>
+  </div>
+</div>

--- a/engine/app/components/citizens_advice_components/disclosure.html.haml
+++ b/engine/app/components/citizens_advice_components/disclosure.html.haml
@@ -1,6 +1,0 @@
-.cads-disclosure.js-disclosure
-  %button{ button_attrs }
-    %span.cads-disclosure__summary.js-disclosure-summary
-      = closed_summary
-  .cads-disclosure__details.js-disclosure-details{ id: disclosure_details_id }
-    = content

--- a/engine/app/components/citizens_advice_components/disclosure.rb
+++ b/engine/app/components/citizens_advice_components/disclosure.rb
@@ -2,7 +2,7 @@
 
 module CitizensAdviceComponents
   class Disclosure < Base
-    attr_reader :closed_summary
+    attr_reader :closed_summary, :open_summary
 
     def initialize(closed_summary:, open_summary: nil, additional_attributes: nil, id: nil)
       super
@@ -13,38 +13,11 @@ module CitizensAdviceComponents
     end
 
     def render?
-      @closed_summary.present? && content.present?
+      closed_summary.present? && content.present?
     end
 
-    def disclosure_details_id
-      @id.presence || "#{@closed_summary.parameterize}-disclosure-details"
-    end
-
-    def base_button_attrs
-      {
-        type: "button",
-        class: %w[cads-disclosure__toggle cads-icon_plus cads-linkbutton js-disclosure-toggle],
-        aria: { expanded: "false", controls: disclosure_details_id },
-        data: button_data_attrs
-      }
-    end
-
-    def button_data_attrs
-      {
-        toggle_target_id: disclosure_details_id,
-        label_when_hiding: generate_label("Show this section", @closed_summary),
-        label_when_showing: generate_label("Hide this section", @open_summary),
-        open_summary: @open_summary,
-        closed_summary: @closed_summary
-      }
-    end
-
-    def generate_label(prepend_text, summary)
-      if @open_summary.eql? @closed_summary
-        "#{prepend_text}, #{summary}"
-      else
-        summary
-      end
+    def id
+      @id.presence || "#{closed_summary.parameterize}-disclosure-details"
     end
 
     def button_attrs
@@ -52,6 +25,28 @@ module CitizensAdviceComponents
         base_button_attrs.merge @additional_attributes
       else
         base_button_attrs
+      end
+    end
+
+    def base_button_attrs
+      {
+        type: "button",
+        class: %w[cads-disclosure__toggle cads-icon_plus cads-linkbutton js-disclosure-toggle],
+        "aria-expanded": "false",
+        "aria-controls": id,
+        "data-toggle-target-id": id,
+        "data-label-when-hiding": generate_label("Show this section", closed_summary),
+        "data-label-when-showing": generate_label("Hide this section", open_summary),
+        "data-open-summary": open_summary,
+        "data-closed-summary": closed_summary
+      }
+    end
+
+    def generate_label(prepend_text, summary)
+      if open_summary.eql? closed_summary
+        "#{prepend_text}, #{summary}"
+      else
+        summary
       end
     end
   end

--- a/styleguide/examples/disclosure/example.html
+++ b/styleguide/examples/disclosure/example.html
@@ -1,14 +1,14 @@
 <div class="cads-disclosure js-disclosure">
   <button
-    aria-controls="view-disclosure-details"
-    aria-expanded="false"
+    type="button"
     class="cads-disclosure__toggle cads-icon_plus cads-linkbutton js-disclosure-toggle"
-    data-closed-summary="View"
+    aria-expanded="false"
+    aria-controls="view-disclosure-details"
+    data-toggle-target-id="view-disclosure-details"
     data-label-when-hiding="View"
     data-label-when-showing="Hide"
     data-open-summary="Hide"
-    data-toggle-target-id="view-disclosure-details"
-    type="button"
+    data-closed-summary="View"
   >
     <span class="cads-disclosure__summary js-disclosure-summary"> View </span>
   </button>

--- a/styleguide/examples/disclosure/with_additional_attributes.html
+++ b/styleguide/examples/disclosure/with_additional_attributes.html
@@ -1,17 +1,17 @@
 <div class="cads-disclosure js-disclosure">
   <button
-    aria-controls="view-disclosure-details"
-    aria-expanded="false"
+    type="button"
     class="cads-disclosure__toggle cads-icon_plus cads-linkbutton js-disclosure-toggle"
-    data-closed-summary="View"
+    aria-expanded="false"
+    aria-controls="view-disclosure-details"
+    data-toggle-target-id="view-disclosure-details"
     data-label-when-hiding="View"
     data-label-when-showing="Hide"
     data-open-summary="Hide"
-    data-test-id="test"
-    data-toggle-target-id="view-disclosure-details"
+    data-closed-summary="View"
     data-tracking-id="show"
     id="additional-attributes"
-    type="button"
+    data-test-id="test"
   >
     <span class="cads-disclosure__summary js-disclosure-summary"> View </span>
   </button>

--- a/styleguide/examples/disclosure/with_optional_id.html
+++ b/styleguide/examples/disclosure/with_optional_id.html
@@ -1,14 +1,14 @@
 <div class="cads-disclosure js-disclosure">
   <button
-    aria-controls="disclosure-1"
-    aria-expanded="false"
+    type="button"
     class="cads-disclosure__toggle cads-icon_plus cads-linkbutton js-disclosure-toggle"
-    data-closed-summary="View"
+    aria-expanded="false"
+    aria-controls="disclosure-1"
+    data-toggle-target-id="disclosure-1"
     data-label-when-hiding="View"
     data-label-when-showing="Hide"
     data-open-summary="Hide"
-    data-toggle-target-id="disclosure-1"
-    type="button"
+    data-closed-summary="View"
   >
     <span class="cads-disclosure__summary js-disclosure-summary"> View </span>
   </button>
@@ -18,15 +18,15 @@
 </div>
 <div class="cads-disclosure js-disclosure">
   <button
-    aria-controls="disclosure-2"
-    aria-expanded="false"
+    type="button"
     class="cads-disclosure__toggle cads-icon_plus cads-linkbutton js-disclosure-toggle"
-    data-closed-summary="View"
+    aria-expanded="false"
+    aria-controls="disclosure-2"
+    data-toggle-target-id="disclosure-2"
     data-label-when-hiding="View"
     data-label-when-showing="Hide"
     data-open-summary="Hide"
-    data-toggle-target-id="disclosure-2"
-    type="button"
+    data-closed-summary="View"
   >
     <span class="cads-disclosure__summary js-disclosure-summary"> View </span>
   </button>

--- a/styleguide/examples/disclosure/without_open_summary.html
+++ b/styleguide/examples/disclosure/without_open_summary.html
@@ -1,14 +1,14 @@
 <div class="cads-disclosure js-disclosure">
   <button
-    aria-controls="filter-disclosure-details"
-    aria-expanded="false"
+    type="button"
     class="cads-disclosure__toggle cads-icon_plus cads-linkbutton js-disclosure-toggle"
-    data-closed-summary="Filter"
+    aria-expanded="false"
+    aria-controls="filter-disclosure-details"
+    data-toggle-target-id="filter-disclosure-details"
     data-label-when-hiding="Show this section, Filter"
     data-label-when-showing="Hide this section, Filter"
     data-open-summary="Filter"
-    data-toggle-target-id="filter-disclosure-details"
-    type="button"
+    data-closed-summary="Filter"
   >
     <span class="cads-disclosure__summary js-disclosure-summary"> Filter </span>
   </button>

--- a/styleguide/examples/sample_pages/content-sample.html
+++ b/styleguide/examples/sample_pages/content-sample.html
@@ -262,8 +262,8 @@
             data-close-label="Close"
           >
             <h2
-              id="h-targeted-content-123"
               class="cads-targeted-content__title js-cads-targeted-content__title"
+              id="h-targeted-content-123"
               data-testid="targeted-content-title"
             >
               <span class="cads-targeted-content__title-text">

--- a/styleguide/examples/targeted_content/adviser.html
+++ b/styleguide/examples/targeted_content/adviser.html
@@ -5,8 +5,8 @@
   data-close-label="Close"
 >
   <h2
-    id="h-targeted-content-adviser"
     class="cads-targeted-content__title js-cads-targeted-content__title"
+    id="h-targeted-content-adviser"
     data-testid="targeted-content-title"
   >
     <span class="cads-targeted-content__title-text">

--- a/styleguide/examples/targeted_content/anchor.html
+++ b/styleguide/examples/targeted_content/anchor.html
@@ -100,8 +100,8 @@
       data-close-label="Close"
     >
       <h2
-        id="h-targeted-content-234"
         class="cads-targeted-content__title js-cads-targeted-content__title"
+        id="h-targeted-content-234"
         data-testid="targeted-content-title"
       >
         <span class="cads-targeted-content__title-text">

--- a/styleguide/examples/targeted_content/default.html
+++ b/styleguide/examples/targeted_content/default.html
@@ -5,8 +5,8 @@
   data-close-label="Close"
 >
   <h2
-    id="h-targeted-content-123"
     class="cads-targeted-content__title js-cads-targeted-content__title"
+    id="h-targeted-content-123"
     data-testid="targeted-content-title"
   >
     <span class="cads-targeted-content__title-text">


### PR DESCRIPTION
Converts disclosure component to use an ERB template. Tidies up the component class in the process, mostly to flatten the button attributes.