### PR TITLE
Wrap form examples in a form context

### DIFF
--- a/design-system-docs/frontend/styles/standalone.scss
+++ b/design-system-docs/frontend/styles/standalone.scss
@@ -1,3 +1,14 @@
 // This file loads just the design system components for use in isolated iframes
 // We use this when we need a clean base with no theme overrides
 @import '../scss/lib';
+
+body {
+  margin: 1em;
+}
+
+// Unset default margin for specific examples
+body.component-example-header,
+body.component-example-breadcrumbs,
+body.component-example-navigation {
+  margin: 0;
+}

--- a/design-system-docs/src/_component_examples/_checkbox/_defaults.yml
+++ b/design-system-docs/src/_component_examples/_checkbox/_defaults.yml
@@ -1,1 +1,2 @@
 category: checkbox
+form: true

--- a/design-system-docs/src/_component_examples/_checkbox_group/_defaults.yml
+++ b/design-system-docs/src/_component_examples/_checkbox_group/_defaults.yml
@@ -1,1 +1,2 @@
 category: checkbox_group
+form: true

--- a/design-system-docs/src/_component_examples/_radio_group/_defaults.yml
+++ b/design-system-docs/src/_component_examples/_radio_group/_defaults.yml
@@ -1,1 +1,2 @@
 category: radio_group
+form: true

--- a/design-system-docs/src/_component_examples/_search/_defaults.yml
+++ b/design-system-docs/src/_component_examples/_search/_defaults.yml
@@ -1,1 +1,2 @@
 category: search
+form: true

--- a/design-system-docs/src/_component_examples/_text_input/_defaults.yml
+++ b/design-system-docs/src/_component_examples/_text_input/_defaults.yml
@@ -1,1 +1,2 @@
 category: text_input
+form: true

--- a/design-system-docs/src/_component_examples/_textarea/_defaults.yml
+++ b/design-system-docs/src/_component_examples/_textarea/_defaults.yml
@@ -1,1 +1,2 @@
 category: textarea
+form: true

--- a/design-system-docs/src/_components/shared/component_example.erb
+++ b/design-system-docs/src/_components/shared/component_example.erb
@@ -14,7 +14,15 @@
         loading="lazy"
       ></iframe>
     <% else %>
+      <%#
+        Wrap form components in a form contet.
+        A form context affects how screen readers behave,
+        we set novalidate as we do not rely on html validation
+        for our forms so we don't want this behaviour.
+      %>
+      <% if example.form? %><form action="" novalidate><% end %>
       <%= example.content %>
+      <% if example.form? %></form><% end %>
     <% end %>
   </div>
   <div class="component-example__source">

--- a/design-system-docs/src/_components/shared/component_example_presenter.rb
+++ b/design-system-docs/src/_components/shared/component_example_presenter.rb
@@ -40,6 +40,10 @@ module Shared
       title.downcase.parameterize
     end
 
+    def form?
+      data[:form].present?
+    end
+
     def iframe?
       data[:iframe].present?
     end

--- a/design-system-docs/src/_layouts/component_example.erb
+++ b/design-system-docs/src/_layouts/component_example.erb
@@ -11,7 +11,15 @@
     </script>
   </head>
   <body>
+    <%#
+      Wrap form components in a form contet.
+      A form context affects how screen readers behave,
+      we set novalidate as we do not rely on html validation
+      for our forms so we don't want this behaviour.
+    %>
+    <% if resource.data[:form].present? %><form action="" novalidate><% end %>
     <%= yield %>
+    <% if resource.data[:form].present? %></form><% end %>
     <script src="<%= webpack_path "standalone.js" %>" defer></script>
   </body>
 </html>

--- a/design-system-docs/src/_layouts/component_example.erb
+++ b/design-system-docs/src/_layouts/component_example.erb
@@ -10,7 +10,7 @@
       document.querySelector('html').classList.remove('no-js');
     </script>
   </head>
-  <body>
+  <body class="component-example-<%= resource.data.category %> component-example-<%= resource.data.category %>-<%= resource.data.slug %>">
     <%#
       Wrap form components in a form contet.
       A form context affects how screen readers behave,


### PR DESCRIPTION
Our form component examples weren't wrapped in a `<form>` element. A form context affects how screen readers behave. Rather than adding a form manually to every component I've added an option to the front-matter to optionally add the form in, also set novalidate as we do not rely on html validation for our forms so we don't want this behaviour.

Whilst I'm here makes a small change to the standalone component example styles to add a bit of padding to the body aside from global components (this is the same approach we use in the demo app)