### PR TITLE
Docs design refinement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+**New**
+
+- SCSS: Allows nav link colours to be customised using dedicated language variables.
+
 ## v5.5.0-alpha.0
 
 ### 8 September 2022

--- a/design-system-docs/frontend/javascript/components/component-examples.js
+++ b/design-system-docs/frontend/javascript/components/component-examples.js
@@ -4,6 +4,6 @@ export default function initComponentExamples() {
   // Resize component iFrames using https://www.npmjs.com/package/iframe-resizer
   const els = document.querySelectorAll('.js-component-example-iframe');
   Array.from(els).forEach((iframe) => {
-    iframeResizer({ log: true }, iframe);
+    iframeResizer(iframe);
   });
 }

--- a/design-system-docs/frontend/styles/_examples.scss
+++ b/design-system-docs/frontend/styles/_examples.scss
@@ -5,17 +5,18 @@
 .component-example {
   border: 1px solid $cads-language__border-colour;
   margin-bottom: $cads-spacing-6;
-  padding: $cads-spacing-5;
+  padding: $cads-spacing-4;
 }
 
 .component-example__links {
-  text-align: right;
   @include cads-typographic-scale-text-small();
+
+  text-align: right;
+  margin-bottom: $cads-spacing-7;
 }
 .component-example__preview {
   border: none;
   border-width: 1px 0;
-  padding: $cads-spacing-4 0;
 }
 .component-example__iframe {
   display: block;
@@ -25,6 +26,18 @@
   overflow: auto;
 }
 .component-example__source {
+  margin-top: $cads-spacing-7;
+  padding-top: $cads-spacing-4;
+  border-top: $cads-border-width-small $cads-language__border-colour solid;
+
+  .cads-disclosure {
+    margin: 0 0 $cads-spacing-3 0;
+
+    &:last-of-type {
+      margin-bottom: 0;
+    }
+  }
+
   .cads-disclosure__toggle {
     @include cads-typographic-scale-text-small();
   }

--- a/design-system-docs/frontend/styles/_foundations.scss
+++ b/design-system-docs/frontend/styles/_foundations.scss
@@ -2,13 +2,6 @@
 // Foundations
 // ============================================================================
 
-// Grid examples
-
-.grid-example {
-  padding: $cads-spacing-4;
-  background-color: $cads-palette__light-grey;
-}
-
 // Icons
 
 .icon-grid {

--- a/design-system-docs/frontend/styles/_settings.scss
+++ b/design-system-docs/frontend/styles/_settings.scss
@@ -3,6 +3,7 @@
 // ============================================================================
 
 @import '../scss/1-settings/colour-palette';
+@import '../scss/1-settings/colour-language';
 
 $cads-enable-external-link-icon: false !default;
 
@@ -14,8 +15,9 @@ $cads-header__background-colour: $docs-palette__black;
 
 // Navigation colours
 $cads-language__nav-background-colour: $docs-palette__black-tint;
-$cads-language__nav-hover-background-colour: $cads-palette__dark-grey;
-$cads-language__nav-hover-border-colour: $cads-palette__dark-grey;
+$cads-language__nav-hover-background-colour: $cads-palette__mid-grey;
+$cads-language__nav-hover-border-colour: $cads-palette__mid-grey;
+$cads-language__nav-focus-colour: $cads-language__text-colour;
 
 // Footer colours
 $cads-footer__text-colour: $cads-palette__white;

--- a/design-system-docs/frontend/styles/standalone.scss
+++ b/design-system-docs/frontend/styles/standalone.scss
@@ -12,3 +12,9 @@ body.component-example-breadcrumbs,
 body.component-example-navigation {
   margin: 0;
 }
+
+// Grid examples
+.grid-example {
+  padding: $cads-spacing-4;
+  background-color: $cads-palette__light-grey;
+}

--- a/design-system-docs/src/_components/foundations/borders_table.rb
+++ b/design-system-docs/src/_components/foundations/borders_table.rb
@@ -4,6 +4,8 @@ module Foundations
   class BordersTable < ViewComponent::Base
     include Bridgetown::ViewComponentHelpers
 
+    Bridgetown::ViewComponentHelpers.allow_rails_helpers :tag
+
     def call
       render(
         CitizensAdviceComponents::Table.new(
@@ -11,17 +13,17 @@ module Foundations
           rows: [
             [
               "$cads-border-width-small",
-              "<div class='sizing-border' />",
+              tag.div(class: "sizing-border"),
               "1px"
             ],
             [
               "$cads-border-width-medium",
-              "<div class='sizing-border sizing-border--medium' />",
+              tag.div(class: "sizing-border sizing-border--medium"),
               "2px"
             ],
             [
               "$cads-border-width-large",
-              "<div class='sizing-border sizing-border--large' />",
+              tag.div(class: "sizing-border sizing-border--large"),
               "4px"
             ],
           ])

--- a/design-system-docs/src/_components/foundations/spacing_table.rb
+++ b/design-system-docs/src/_components/foundations/spacing_table.rb
@@ -4,47 +4,20 @@ module Foundations
   class SpacingTable < ViewComponent::Base
     include Bridgetown::ViewComponentHelpers
 
+    Bridgetown::ViewComponentHelpers.allow_rails_helpers :tag
+
     def call
       render(
         CitizensAdviceComponents::Table.new(
           header: %w[Variables Example Size],
-          rows: [
+          rows: %w[4px 8px 12px 16px 24px 32px 40px].each_with_index.map do |size, index|
             [
-              "$cads-spacing-1",
-              "<div class='spacing-block-1' />",
-              "4px"
-            ],
-            [
-              "$cads-spacing-2",
-              "<div class='spacing-block-2' />",
-              "8px"
-            ],
-            [
-              "$cads-spacing-3",
-              "<div class='spacing-block-3' />",
-              "12px"
-            ],
-            [
-              "$cads-spacing-4",
-              "<div class='spacing-block-4' />",
-              "16px"
-            ],
-            [
-              "$cads-spacing-5",
-              "<div class='spacing-block-5' />",
-              "24px"
-            ],
-            [
-              "$cads-spacing-6",
-              "<div class='spacing-block-6' />",
-              "32px"
-            ],
-            [
-              "$cads-spacing-7",
-              "<div class='spacing-block-7' />",
-              "40px"
-            ],
-          ])
+              "$cads-spacing-#{index + 1}",
+              tag.div(class: "spacing-block-#{index + 1}"),
+              size
+            ]
+          end
+        )
       )
     end
   end

--- a/scss/1-settings/_colour-language.scss
+++ b/scss/1-settings/_colour-language.scss
@@ -29,9 +29,13 @@ $cads-language__warning-colour: palette.$cads-palette__red !default;
 $cads-language__success-colour: palette.$cads-palette__green !default;
 
 // Navigation colours
+$cads-language__nav-colour: palette.$cads-palette__white !default;
 $cads-language__nav-background-colour: $cads-language__brand-primary !default;
 $cads-language__nav-hover-background-colour: palette.$cads-palette__heritage-blue-dark !default;
 $cads-language__nav-hover-border-colour: palette.$cads-palette__heritage-blue-dark !default;
+$cads-language__nav-focus-colour: $cads-language__link-colour !default;
+$cads-language__nav-focus-background-colour: palette.$cads-palette__white !default;
+$cads-language__nav-focus-border-colour: $cads-language__focus-colour !default;
 
 // Header colours
 $cads-header__background-colour: palette.$cads-palette__white !default;

--- a/scss/1-settings/_colour-language.scss
+++ b/scss/1-settings/_colour-language.scss
@@ -33,7 +33,7 @@ $cads-language__nav-colour: palette.$cads-palette__white !default;
 $cads-language__nav-background-colour: $cads-language__brand-primary !default;
 $cads-language__nav-hover-background-colour: palette.$cads-palette__heritage-blue-dark !default;
 $cads-language__nav-hover-border-colour: palette.$cads-palette__heritage-blue-dark !default;
-$cads-language__nav-focus-colour: $cads-language__link-colour !default;
+$cads-language__nav-focus-colour: palette.$cads-palette__heritage-blue !default;
 $cads-language__nav-focus-background-colour: palette.$cads-palette__white !default;
 $cads-language__nav-focus-border-colour: $cads-language__focus-colour !default;
 

--- a/scss/1-settings/_colour-language.scss
+++ b/scss/1-settings/_colour-language.scss
@@ -33,7 +33,7 @@ $cads-language__nav-colour: palette.$cads-palette__white !default;
 $cads-language__nav-background-colour: $cads-language__brand-primary !default;
 $cads-language__nav-hover-background-colour: palette.$cads-palette__heritage-blue-dark !default;
 $cads-language__nav-hover-border-colour: palette.$cads-palette__heritage-blue-dark !default;
-$cads-language__nav-focus-colour: palette.$cads-palette__heritage-blue !default;
+$cads-language__nav-focus-colour: $cads-language__brand-primary !default;
 $cads-language__nav-focus-background-colour: palette.$cads-palette__white !default;
 $cads-language__nav-focus-border-colour: $cads-language__focus-colour !default;
 

--- a/scss/2-tools/_interactive-elements.scss
+++ b/scss/2-tools/_interactive-elements.scss
@@ -19,15 +19,16 @@
 }
 
 @mixin cads-nav-link-focus() {
-  background-color: $cads-language__brand-primary-contrast;
-  color: $cads-language__brand-primary;
-  border: $cads-border-width-medium solid $cads-palette__yellow;
+  background-color: $cads-language__nav-focus-background-colour;
+  color: $cads-language__nav-focus-colour;
+  border: $cads-border-width-medium solid
+    $cads-language__nav-focus-border-colour;
   outline: none;
 }
 
 @mixin cads-nav-link() {
   font-size: $cads-font-size;
-  color: $cads-language__brand-primary-contrast;
+  color: $cads-language__nav-colour;
   padding: $cads-spacing-3 $cads-spacing-2;
   display: inline-block;
   text-decoration: none;


### PR DESCRIPTION
- Move example grid styles into standalone styles
- Fix spacing and sizing example tables
- Update component examples to match latest designs
- Disable iframeResizer logging
- Make nav link colours customisable
- Update docs header colours to match designs
