### PR TITLE
Fix label being assigned as checkbox attribute in Ruby 3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 **New**
 
+- Fix label being assigned as checkbox attribute in Ruby 3+
 - SCSS: Allows nav link colours to be customised using dedicated language variables.
 - Engine: Haml is no longer a dependency of the Rails engine. All component templates now use ERB internally. This doesn't affect the ability to use Haml in app code. If you were unintentionally relying on `haml-rails` being present in your app you will need to add it to your project Gemfile. 
 

--- a/engine/.rubocop.yml
+++ b/engine/.rubocop.yml
@@ -6,6 +6,14 @@ inherit_gem:
 require:
   - rubocop-rspec
 
+# Calls to super in subclasses of ViewComponent::Base aren't needed
+# by default and can change the behaviour of **kwargs so we
+# exclude component classes from this rule
+# https://github.com/ViewComponent/view_component/discussions/1545
+Lint/MissingSuper:
+  Exclude:
+    - 'app/components/**/*'
+
 Metrics/MethodLength:
   CountAsOne: ['array', 'hash']
 

--- a/engine/app/components/citizens_advice_components/checkable/base.rb
+++ b/engine/app/components/citizens_advice_components/checkable/base.rb
@@ -6,7 +6,6 @@ module CitizensAdviceComponents
       attr_reader :label
 
       def initialize(label:, value:, checked: false, **additional_attributes)
-        super
         @label = label
         @value = value
         @checked = fetch_or_fallback_boolean(checked, fallback: false)

--- a/engine/spec/components/citizens_advice_components/checkbox_single_spec.rb
+++ b/engine/spec/components/citizens_advice_components/checkbox_single_spec.rb
@@ -33,6 +33,10 @@ RSpec.describe CitizensAdviceComponents::CheckboxSingle, type: :component do
     expect(component.css("input[value=1] + label").text.strip).to eq "Option 1"
   end
 
+  it "does not pass label through to input" do
+    expect(component.css("input[label]")).to be_empty
+  end
+
   it "associates the labels with the inputs correctly" do
     expect(component.css("input[id='my-checkbox-0'] + label").attribute("for").value).to eq "my-checkbox-0"
   end


### PR DESCRIPTION
When running against ruby 3 and passing extra options to a checkbox via `c.checkbox(label: "Label", value: "value", extra: "example")` the previous `**additional_attributes` keyword args would include the named label which we don't want.

This is down to the `super` call in the initialise method. Calls to super in subclasses of `ViewComponent::Base` aren't needed by default and can change the behaviour of `**kwargs` so we exclude component classes from this rule.