### PR TITLE
Design system docs launch prep

### DIFF
--- a/design-system-docs/src/_component_docs/asset-hyperlink.md
+++ b/design-system-docs/src/_component_docs/asset-hyperlink.md
@@ -10,6 +10,6 @@ If you are using the `citizens_advice_components` gem, you can call the componen
 
 <%= render(Shared::ComponentExampleSource.new(:asset_hyperlink, :default)) %>
 
-### View Component Options
+### Component arguments
 
 <%= render Shared::ArgumentsTable.new(:asset_hyperlink) %>

--- a/design-system-docs/src/_component_docs/breadcrumbs.md
+++ b/design-system-docs/src/_component_docs/breadcrumbs.md
@@ -74,6 +74,6 @@ If you are using the `citizens_advice_components` gem, you can call the componen
 
 <%= render(Shared::ComponentExampleSource.new(:breadcrumbs, :default)) %>
 
-### View Component Options
+### Component arguments
 
 <%= render Shared::ArgumentsTable.new(:breadcrumbs) %>

--- a/design-system-docs/src/_component_docs/breadcrumbs.md
+++ b/design-system-docs/src/_component_docs/breadcrumbs.md
@@ -16,7 +16,7 @@ Do not use breadcrumbs on a website with a flat hierarchy or to show the journey
 
 ## How it works
 
-Breadcrumbs should be placed on the top left of each page and below "Global Navigation". They should start with a link to the home page and end with the current page title. Page titles of parent pages should be linked; the current should not have a link. Note that you will have to add the 'Home' link into the links you pass in.
+Breadcrumbs should be placed on the top left of each page and below the global navigation. They should start with a link to the home page and end with the current page title. Page titles of parent pages should be linked; the current should not have a link. Note that you will have to add the 'Home' link into the links you pass in.
 
 On the small breakpoint, breadcrumbs show the previous parent level as a link by default. You can explicity set this behaviour by passing in
 `collaspe` as the type.
@@ -62,7 +62,7 @@ When shown somewhere where they should not be full width, as in a search result,
 
 <%= render(Shared::ComponentExample.new(:breadcrumbs, :not_full_width)) %>
 
-### Not indicating the current Page
+### Not indicating the current page
 
 If you do not want the last crumb to indicate the current page (for screen readers etc), you can pass in `current_page: false`.
 

--- a/design-system-docs/src/_component_docs/button.md
+++ b/design-system-docs/src/_component_docs/button.md
@@ -16,7 +16,7 @@ Secondary button should be used for secondary calls to action. Typically there s
 
 <%= render(Shared::ComponentExample.new(:button, :secondary)) %>
 
-Tertiary buttons are used for turning something on or off instantly on a page – for example, References and “Expand all” action.
+Tertiary buttons are used for turning something on or off instantly on a page – for example, references and “Expand all” actions.
 
 <%= render(Shared::ComponentExample.new(:button, :tertiary)) %>
 

--- a/design-system-docs/src/_component_docs/button.md
+++ b/design-system-docs/src/_component_docs/button.md
@@ -60,7 +60,7 @@ If you are using the `citizens_advice_components` gem, you can call the componen
 
 <%= render(Shared::ComponentExampleSource.new(:button, :primary)) %>
 
-### View component options
+### Component arguments
 
 <%= render Shared::ArgumentsTable.new(:button) %>
 

--- a/design-system-docs/src/_component_docs/callout.md
+++ b/design-system-docs/src/_component_docs/callout.md
@@ -49,7 +49,7 @@ Before using a callout, make sure you really need it. Fewer callouts have more o
 
 Callouts should come with a title that explains the subject of the information when possible. This will give the users an idea of what the information is about.
 
-#### In the Content Platform Rails App
+#### In the Content Platform Rails app
 
 Note that there is code in the Content Platform app that ensure headings inside callouts are rendered with the correct heading level in order to comply with WCAG accessibility standards. This code will not demote a heading past an `h4` (ie no `h5` etc). No `h4` headings should be used in Contentful.
 

--- a/design-system-docs/src/_component_docs/error-summary.md
+++ b/design-system-docs/src/_component_docs/error-summary.md
@@ -9,7 +9,7 @@ Error summary and messages are used to highlight where users need to change info
 - entered the wrong username and/or password and can’t log in to AdviserNet
 - haven’t filled in all the required fields in a tool or form
 - haven’t entered a required character, like ‘@’ in an email address
-- They’re important because they help users quickly work out what they need to change to finish their task. - They also help you get the right information from them.
+- They’re important because they help users quickly work out what they need to change to finish their task. They also help you get the right information from them.
 
 The error summary contains a title and a list of errors. The list contains anchor page links that will take users to the answer or field they relate to. Always show an error summary when there is a validation error, even if there’s only one.
 

--- a/design-system-docs/src/_component_docs/notice-banner.md
+++ b/design-system-docs/src/_component_docs/notice-banner.md
@@ -10,6 +10,6 @@ If you are using the `citizens_advice_components` gem, you can call the componen
 
 <%= render(Shared::ComponentExampleSource.new(:notice_banner, :default)) %>
 
-### View Component Options
+### Component arguments
 
 <%= render Shared::ArgumentsTable.new(:notice_banner) %>

--- a/design-system-docs/src/_component_docs/page-review.md
+++ b/design-system-docs/src/_component_docs/page-review.md
@@ -10,6 +10,6 @@ If you are using the `citizens_advice_components` gem, you can call the componen
 
 <%= render(Shared::ComponentExampleSource.new(:page_review, :default)) %>
 
-### View Component Options
+### Component arguments
 
 <%= render Shared::ArgumentsTable.new(:page_review) %>

--- a/design-system-docs/src/_component_docs/pagination.md
+++ b/design-system-docs/src/_component_docs/pagination.md
@@ -16,6 +16,6 @@ If you are using the `citizens_advice_components` gem, you can call the componen
 
 <%= render(Shared::ComponentExampleSource.new(:pagination, :default)) %>
 
-### View Component Options
+### Component arguments
 
 <%= render Shared::ArgumentsTable.new(:pagination) %>

--- a/design-system-docs/src/_component_docs/radio-group.md
+++ b/design-system-docs/src/_component_docs/radio-group.md
@@ -75,6 +75,6 @@ Used for one question per page forms. Using similar approach to the one describe
 
 <%= render(Shared::ComponentExample.new(:radio_group, :legend_heading)) %>
 
-### View Component Options
+### Component arguments
 
 <%= render Shared::ArgumentsTable.new(:radio_group) %>

--- a/design-system-docs/src/_component_docs/success-message.md
+++ b/design-system-docs/src/_component_docs/success-message.md
@@ -10,6 +10,6 @@ If you are using the `citizens_advice_components` gem, you can call the componen
 
 <%= render(Shared::ComponentExampleSource.new(:success_message, :default)) %>
 
-### View Component Options
+### Component arguments
 
 <%= render Shared::ArgumentsTable.new(:success_message) %>

--- a/design-system-docs/src/_foundations/icons.md
+++ b/design-system-docs/src/_foundations/icons.md
@@ -130,7 +130,7 @@ render CitizensAdviceComponents::Icons::Email.new(size: :small)
 
 You can look the name in the [available icons grid](#available-icons) to see which component class to use for which icon.
 
-### View Component Options
+### Component arguments
 
 The constructor accepts the following arguments
 

--- a/design-system-docs/src/_foundations/icons.md
+++ b/design-system-docs/src/_foundations/icons.md
@@ -156,7 +156,7 @@ The default `fill` colour is `currentColor`. You can override this in your CSS u
 }
 ```
 
-### Combined Icons
+### Combined icons
 
 In some instances, you might need to combine icons into one SVG and use javascript and CSS to create a toggle-able combined icon. You can do this by:
 

--- a/design-system-docs/src/_foundations/typography.md
+++ b/design-system-docs/src/_foundations/typography.md
@@ -104,7 +104,7 @@ If you need to apply these styles to heading elements that you cannot add a clas
 </main>
 ```
 
-### Adjacent Heading Mixin
+### Adjacent heading mixin
 
 To ensure that headings have the correct margins applied inside the `.cads-prose` element, a mixin has been used that will add the correct margin. This is automatically applied to the relevant elements that appear in a `.cads-prose` wrapper.
 
@@ -144,7 +144,7 @@ Links are blue and underlined by default. Avoid opening links in a new tab, as i
 
 Read our guidance about using <a href ="?path=/docs/components-buttons--primary">buttons as links</a>.
 
-### External Links
+### External links
 
 When you link to a page external to your website add the `.cads-hyperlink--external` class to display an icon after the link.
 

--- a/design-system-docs/src/_pages/docs-roadmap.md
+++ b/design-system-docs/src/_pages/docs-roadmap.md
@@ -1,0 +1,15 @@
+---
+title: Documentation website roadmap
+layout: basic
+---
+
+This is an alpha release of the new design system documentation website that was released in October 2022.
+
+It was migrated from the previous Storybook documentation and now uses the design system directly. The documentation itself is otherwise the same as the previous version of the website.
+
+For future iterations we are working on:
+
+- Revised component documentation
+- Dedicated accessibility guidance
+- Expanded getting started guides
+- More detailed technical documentation

--- a/design-system-docs/src/_partials/_notice_banner.erb
+++ b/design-system-docs/src/_partials/_notice_banner.erb
@@ -3,8 +3,8 @@
     <div class="cads-grid-col-md-9">
       <%= render CitizensAdviceComponents::NoticeBanner.new(label: "Alpha") do %>
         <p>
-          You've stumbled across our new documentation site.
-          <a href="https://citizensadvice.github.io/design-system/">Go to the live documentation</a>.
+          This is an alpha release of our documentation site.
+          <a href="/docs-roadmap">View the roadmap</a>.
         </p>
       <% end %>
     </div>

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -136,23 +136,6 @@ prompt([
         const newChangelog = `${changelogEntry}\n\n${changelog}`;
         fs.writeFileSync(changelogPath, newChangelog, 'utf8');
 
-        // Rebuild the docs
-        if (newVersion.includes('alpha') === false) {
-          const docsBuildStatus = spawnSync('npm run docs:build', {
-            cwd: __dirname,
-            shell: true,
-          }).status;
-
-          if (docsBuildStatus === 0) {
-            log(chalk.green.dim(`${ok} Documentation build complete.`));
-          } else {
-            showError(
-              `${error} Documentation build failed, check the repo status.`,
-              true
-            );
-          }
-        }
-
         try {
           log(chalk.green.bold('Release prepared.'));
 

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -5,7 +5,7 @@ const path = require('path');
 const { prompt } = require('inquirer');
 const { execSync, spawnSync } = require('child_process');
 const semver = require('semver');
-const { checkRepoStatus, ok, error, showError } = require('./releaseHelpers');
+const { checkRepoStatus, ok, showError } = require('./releaseHelpers');
 
 const log = console.log; // eslint-disable-line
 const DO_NOT_RELEASE = 'Do not release';


### PR DESCRIPTION
A few last bits of prep before we launch the new docs website:

- Don't build storybook docs on release — We won't need this anymore and new docs builds are handled via CI
- Add minimal docs roadmap page, just enough to link to from the notice banner.
- Fix some wording and typos based on the documentation review