### PR TITLE
Clean up component specs

### DIFF
--- a/engine/.rubocop.yml
+++ b/engine/.rubocop.yml
@@ -26,16 +26,3 @@ Metrics/ClassLength:
 
 RSpec/ExampleLength:
   CountAsOne: ['array', 'hash']
-
-# @FIXME
-Rails/I18nLocaleAssignment:
-  Exclude:
-    - 'spec/components/citizens_advice_components/badge_spec.rb'
-    - 'spec/components/citizens_advice_components/checkbox_group_spec.rb'
-    - 'spec/components/citizens_advice_components/header_spec.rb'
-    - 'spec/components/citizens_advice_components/input_spec.rb'
-    - 'spec/components/citizens_advice_components/page_review_spec.rb'
-    - 'spec/components/citizens_advice_components/pagination_spec.rb'
-    - 'spec/components/citizens_advice_components/search_spec.rb'
-    - 'spec/components/citizens_advice_components/targeted_content_spec.rb'
-    - 'spec/spec_helper.rb'

--- a/engine/Gemfile
+++ b/engine/Gemfile
@@ -31,7 +31,6 @@ group :development, :test do
   gem "i18n-tasks"
   gem "rspec"
   gem "rspec-rails"
-  gem "rspec-snapshot", "~> 2.0"
   gem "rubocop-rails", require: false
   gem "rubocop-rspec", require: false
 end

--- a/engine/Gemfile.lock
+++ b/engine/Gemfile.lock
@@ -43,7 +43,6 @@ GEM
     addressable (2.8.1)
       public_suffix (>= 2.0.2, < 6.0)
     ast (2.4.2)
-    awesome_print (1.9.2)
     better_html (2.0.1)
       actionview (>= 6.0)
       activesupport (>= 6.0)
@@ -143,9 +142,6 @@ GEM
       rspec-expectations (~> 3.11)
       rspec-mocks (~> 3.11)
       rspec-support (~> 3.11)
-    rspec-snapshot (2.0.1)
-      awesome_print (> 1.0.0)
-      rspec (> 3.0.0)
     rspec-support (3.12.0)
     rubocop (1.30.1)
       parallel (~> 1.10)
@@ -194,7 +190,6 @@ DEPENDENCIES
   railties (~> 6.1)
   rspec
   rspec-rails
-  rspec-snapshot (~> 2.0)
   rubocop-rails
   rubocop-rspec
 

--- a/engine/spec/components/citizens_advice_components/badge_spec.rb
+++ b/engine/spec/components/citizens_advice_components/badge_spec.rb
@@ -1,70 +1,51 @@
 # frozen_string_literal: true
 
 RSpec.describe CitizensAdviceComponents::Badge, type: :component do
-  let(:component) do
-    described_class.new(type: type.presence)
-  end
+  subject { page }
 
-  let(:type) { nil }
-
-  it "does not render when type is missing" do
-    without_fetch_or_fallback_raises do
-      render_inline component
-      expect(page).to have_no_selector ".cads-badge"
+  context "when type is missing" do
+    before do
+      without_fetch_or_fallback_raises do
+        render_inline described_class.new(type: nil)
+      end
     end
+
+    it { is_expected.to have_no_selector ".cads-badge" }
   end
 
   context "when type is example" do
-    let(:type) { :example }
+    before { render_inline described_class.new(type: :example) }
 
-    it "has the correct label" do
-      render_inline component
-      expect(page).to have_selector ".cads-badge--example", text: "Example"
-    end
+    it { is_expected.to have_selector ".cads-badge--example", text: "Example" }
 
     context "when welsh language" do
-      before { I18n.locale = :cy }
+      around { |example| I18n.with_locale(:cy) { example.run } }
 
-      it "has translated label" do
-        render_inline component
-        expect(page).to have_text "Enghraifft"
-      end
+      it { is_expected.to have_text "Enghraifft" }
     end
   end
 
   context "when type is important" do
-    let(:type) { :important }
+    before { render_inline described_class.new(type: :important) }
 
-    it "has the correct label" do
-      render_inline component
-      expect(page).to have_selector ".cads-badge--important", text: "Important"
-    end
+    it { is_expected.to have_selector ".cads-badge--important", text: "Important" }
 
     context "when welsh language" do
-      before { I18n.locale = :cy }
+      around { |example| I18n.with_locale(:cy) { example.run } }
 
-      it "has translated label" do
-        render_inline component
-        expect(page).to have_text "Pwysig"
-      end
+      it { is_expected.to have_text "Pwysig" }
     end
   end
 
   context "when type is adviser" do
-    let(:type) { :adviser }
+    before { render_inline described_class.new(type: :adviser) }
 
-    it "has the correct label" do
-      render_inline component
-      expect(page).to have_selector ".cads-badge--adviser", text: "Adviser"
-    end
+    it { is_expected.to have_selector ".cads-badge--adviser", text: "Adviser" }
 
     context "when welsh language" do
-      before { I18n.locale = :cy }
+      around { |example| I18n.with_locale(:cy) { example.run } }
 
-      it "has translated label" do
-        render_inline component
-        expect(page).to have_text "Cynghorydd"
-      end
+      it { is_expected.to have_text "Cynghorydd" }
     end
   end
 end

--- a/engine/spec/components/citizens_advice_components/callout_spec.rb
+++ b/engine/spec/components/citizens_advice_components/callout_spec.rb
@@ -1,86 +1,70 @@
 # frozen_string_literal: true
 
 RSpec.describe CitizensAdviceComponents::Callout, type: :component do
-  subject(:component) do
-    render_inline(described_class.new(type: type.presence, title: title.presence)) do
-      "Example content"
+  subject { page }
+
+  context "with default arguments" do
+    before do
+      render_inline(described_class.new(type: :standard)) { "Example content" }
     end
-  end
 
-  let(:type) { :standard }
-  let(:title) { nil }
-
-  it "renders content block" do
-    expect(component.text).to include "Example content"
+    it { is_expected.to have_selector ".cads-callout", text: "Example content" }
   end
 
   context "when missing type" do
-    let(:type) { nil }
-
-    it "renders a standard callout" do
+    before do
       without_fetch_or_fallback_raises do
-        expect(component.at(".cads-callout--standard")).to be_present
+        render_inline(described_class.new) { "Example content" }
       end
     end
 
-    it "does not render a badge" do
-      without_fetch_or_fallback_raises do
-        expect(component.at(".cads-badge")).not_to be_present
-      end
-    end
+    it { is_expected.to have_selector ".cads-callout--standard" }
+    it { is_expected.to have_no_selector ".cads-badge" }
   end
 
   context "when type is example" do
-    let(:type) { :example }
-
-    it "renders an example callout" do
-      expect(component.at(".cads-callout--example")).to be_present
+    before do
+      render_inline(described_class.new(type: :example)) { "Example content" }
     end
 
-    it "has expected badge" do
-      expect(component.at(".cads-badge--example")).to be_present
-    end
+    it { is_expected.to have_selector ".cads-callout--example" }
+    it { is_expected.to have_selector ".cads-badge", text: "Example" }
   end
 
   context "when type is important" do
-    let(:type) { :important }
-
-    it "renders an important callout" do
-      expect(component.at(".cads-callout--important")).to be_present
+    before do
+      render_inline(described_class.new(type: :important)) { "Example content" }
     end
 
-    it "has expected badge" do
-      expect(component.at(".cads-badge--important")).to be_present
-    end
+    it { is_expected.to have_selector ".cads-callout--important" }
+    it { is_expected.to have_selector ".cads-badge--important", text: "Important" }
   end
 
   context "when type is adviser" do
-    let(:type) { :adviser }
-
-    it "renders an adviser callout" do
-      expect(component.at(".cads-callout--adviser")).to be_present
+    before do
+      render_inline(described_class.new(type: :adviser)) { "Example content" }
     end
 
-    it "has expected badge" do
-      expect(component.at(".cads-badge--adviser")).to be_present
-    end
+    it { is_expected.to have_selector ".cads-callout--adviser" }
+    it { is_expected.to have_selector ".cads-badge--adviser", text: "Adviser" }
   end
 
   context "when title is provided" do
-    let(:title) { "Descriptive title" }
-
-    it "Includes descriptive aria-label" do
-      expect(component.at("section").attr("aria-label")).to eq "Descriptive title"
+    before do
+      render_inline(described_class.new(
+                      type: :adviser,
+                      title: "Descriptive title"
+                    )) { "Example content" }
     end
+
+    it { is_expected.to have_selector "section[aria-label='Descriptive title']" }
   end
 
   context "when no content present" do
-    subject(:component) do
+    before do
       render_inline(described_class.new(type: :standard))
     end
 
-    it "does not render" do
-      expect(component.at("section")).not_to be_present
-    end
+    it { is_expected.to have_no_selector ".cads-callout" }
   end
 end

--- a/engine/spec/components/citizens_advice_components/checkbox_single_spec.rb
+++ b/engine/spec/components/citizens_advice_components/checkbox_single_spec.rb
@@ -1,87 +1,59 @@
 # frozen_string_literal: true
 
 RSpec.describe CitizensAdviceComponents::CheckboxSingle, type: :component do
-  subject(:component) do
-    render_inline described_class.new(
-      name: name.presence,
-      error_message: error_message.presence
-    ) do |c|
-      c.checkbox(**checkbox)
+  subject { page }
+
+  context "with default arguments" do
+    before do
+      render_inline described_class.new(
+        name: "my-checkbox"
+      ) do |c|
+        c.checkbox(label: "Option 1", value: "1")
+      end
+    end
+
+    it { is_expected.to have_field "Option 1", type: :checkbox, count: 1, checked: false }
+
+    it "does not pass label through to input" do
+      expect(page).to have_no_selector "input[label]"
     end
   end
 
-  let(:checkbox) do
-    { label: "Option 1", value: "1" }
-  end
-
-  let(:name) { "my-checkbox" }
-  let(:error_message) { nil }
-
-  it "renders a single checkbox" do
-    expect(component.css("input[type='checkbox']").length).to eq(1)
-  end
-
-  it "renders the labels for the checkbox" do
-    expect(component.text).to include("Option 1")
-  end
-
-  it "does not check any options by default" do
-    expect(component.css("input[checked]")).to be_empty
-  end
-
-  it "adds the values to the correct inputs" do
-    expect(component.css("input[value=1] + label").text.strip).to eq "Option 1"
-  end
-
-  it "does not pass label through to input" do
-    expect(component.css("input[label]")).to be_empty
-  end
-
-  it "associates the labels with the inputs correctly" do
-    expect(component.css("input[id='my-checkbox-0'] + label").attribute("for").value).to eq "my-checkbox-0"
-  end
-
-  context "when there are no checkboxes" do
-    subject(:component) do
-      render_inline described_class.new(name: "checkboxes")
+  context "when no checkbox is provided" do
+    before do
+      render_inline described_class.new(
+        name: "my-checkbox"
+      )
     end
 
-    it "does not render" do
-      expect(component.children).to be_empty
-    end
+    it { is_expected.to have_no_selector ".cads-checkbox-single" }
   end
 
   context "when there is an error message" do
-    let(:error_message) { "This is the error message" }
-
-    it "renders the error message" do
-      expect(component.text.strip).to include "This is the error message"
+    before do
+      render_inline described_class.new(
+        name: "my-checkbox",
+        error_message: "This is the error message"
+      ) do |c|
+        c.checkbox(label: "Option 1", value: "1")
+      end
     end
 
-    it "adds an aria-invalid attribute to the input" do
-      expect(component.css("input[aria-invalid]").length).to eq(1)
-    end
-
-    it "links the error message to the input" do
-      expect(component.css("input").attribute("aria-describedby").value).to eq("my-checkbox-error")
-    end
-
-    it "gives an id to the error message" do
-      expect(component.css("[id=my-checkbox-error]")).to be_present
-    end
+    it { is_expected.to have_selector "#my-checkbox-error", text: "This is the error message" }
+    it { is_expected.to have_selector "input[aria-invalid]", count: 1 }
+    it { is_expected.to have_selector "input[aria-describedby=my-checkbox-error]", count: 1 }
   end
 
-  context "when there are additional parameters on the radio buttons" do
-    let(:checkbox) do
-      { label: "Option 1", value: "1", "data-jackie": "weaver", "data-fruit": "bananas" }
+  context "when there are additional attributes provided" do
+    before do
+      render_inline described_class.new(
+        name: "my-checkbox",
+        error_message: "This is the error message"
+      ) do |c|
+        c.checkbox(label: "Option 1", value: "1", "data-additional": "example")
+      end
     end
 
-    it "adds data-jackie attribute" do
-      expect(component.css("input").attribute("data-jackie").value).to eq "weaver"
-    end
-
-    it "adds data-fruit attribute" do
-      expect(component.css("input").attribute("data-fruit").value).to eq "bananas"
-    end
+    it { is_expected.to have_selector "[data-additional=example]" }
   end
 end

--- a/engine/spec/components/citizens_advice_components/contact_details_spec.rb
+++ b/engine/spec/components/citizens_advice_components/contact_details_spec.rb
@@ -1,21 +1,17 @@
 # frozen_string_literal: true
 
 RSpec.describe CitizensAdviceComponents::ContactDetails, type: :component do
-  context "when content is present" do
-    subject(:component) { described_class.new.with_content("Example content") }
+  subject { page }
 
-    it "renders content block" do
-      render_inline component
-      expect(page).to have_selector ".cads-contact-details", text: "Example content"
-    end
+  context "when content is present" do
+    before { render_inline described_class.new.with_content("Example content") }
+
+    it { is_expected.to have_selector ".cads-contact-details", text: "Example content" }
   end
 
   context "when no content present" do
-    subject(:component) { described_class.new }
+    before { render_inline described_class.new }
 
-    it "does not render" do
-      render_inline component
-      expect(page).to have_no_selector ".cads-contact-details"
-    end
+    it { is_expected.to have_no_selector ".cads-contact-details" }
   end
 end

--- a/engine/spec/components/citizens_advice_components/disclosure_spec.rb
+++ b/engine/spec/components/citizens_advice_components/disclosure_spec.rb
@@ -1,97 +1,89 @@
 # frozen_string_literal: true
 
 RSpec.describe CitizensAdviceComponents::Disclosure, type: :component do
-  subject(:component) do
-    render_inline described_class.new(
-      closed_summary: closed_summary.presence,
-      open_summary: open_summary.presence
-    ).with_content(content.presence)
-  end
+  subject { page }
 
-  let(:closed_summary) { "View template letter" }
-  let(:open_summary) { "Hide template letter" }
-  let(:content) { "The disclosure content" }
+  context "with default arguments" do
+    before do
+      render_inline described_class.new(
+        closed_summary: "Show",
+        open_summary: "Hide"
+      ).with_content("Example content")
+    end
 
-  it "renders the closed summary text" do
-    expect(component.css("[data-label-when-hiding='View template letter']")).to be_present
-  end
+    it { is_expected.to have_text "Example content" }
 
-  it "renders the open summary text" do
-    expect(component.css("[data-label-when-showing='Hide template letter']")).to be_present
-  end
+    it "renders the closed summary text" do
+      expect(page).to have_selector "[data-label-when-hiding='Show']"
+    end
 
-  it "renders the disclosure content" do
-    expect(component.text.strip).to include "The disclosure content"
-  end
+    it "renders the open summary text" do
+      expect(page).to have_selector "[data-label-when-showing='Hide']"
+    end
 
-  it "has aria-expand set to false on initial render" do
-    expect(component.css("[aria-expanded=false]")).to be_present
-  end
+    it "has aria-expand set to false on initial render" do
+      expect(page).to have_selector "[aria-expanded=false]"
+    end
 
-  it "has aria-controls set to the id of the disclosure content" do
-    expect(component.css("[aria-controls=view-template-letter-disclosure-details]")).to be_present
+    it "has aria-controls set to the id of the disclosure content" do
+      expect(page).to have_selector "[aria-controls=show-disclosure-details]"
+    end
   end
 
   context "when there is no open summary text" do
-    let(:open_summary) { nil }
+    before do
+      render_inline described_class.new(
+        closed_summary: "Show"
+      ).with_content("Example content")
+    end
 
     it "shows the closed summary text when open" do
-      expect(component.css("[data-label-when-showing='Hide this section, View template letter']")).to be_present
+      expect(page).to have_selector "[data-label-when-showing='Hide this section, Show']"
     end
   end
 
   context "when there is no closed summary text" do
-    let(:closed_summary) { nil }
-
-    it "does not render" do
-      expect(component.children).to be_empty
+    before do
+      render_inline described_class.new(
+        closed_summary: nil
+      ).with_content("Example content")
     end
+
+    it { is_expected.to have_no_selector ".cads-disclosure" }
   end
 
   context "when there is no disclosure content" do
-    subject(:component) do
+    before do
       render_inline described_class.new(
-        closed_summary: closed_summary.presence,
-        open_summary: open_summary.presence
+        closed_summary: "Show",
+        open_summary: "Hide"
       )
     end
 
-    it "does not render" do
-      expect(component.at(".cads-disclosure")).not_to be_present
-    end
+    it { is_expected.to have_no_selector ".cads-disclosure" }
   end
 
   context "when there is custom id" do
-    subject(:component) do
+    before do
       render_inline described_class.new(
-        closed_summary: closed_summary.presence,
-        open_summary: open_summary.presence,
-        id: id
-      ).with_content(content.presence)
+        closed_summary: "Show",
+        open_summary: "Hide",
+        id: "my-id"
+      ).with_content("Example content")
     end
 
-    let(:id) { "my-id" }
-
-    it "uses the custom id" do
-      expect(component.css("[data-toggle-target-id='my-id']")).to be_present
-    end
+    it { is_expected.to have_selector "[data-toggle-target-id='my-id']" }
   end
 
-  context "when additional attributes are specified" do
+  context "when additional attributes are provided" do
     subject(:component) do
       render_inline described_class.new(
-        closed_summary: closed_summary.presence,
-        open_summary: open_summary.presence,
-        additional_attributes: additional_attributes
-      ).with_content(content.presence)
+        closed_summary: "Show",
+        open_summary: "Hide",
+        additional_attributes: { "data-additional": "example" }
+      ).with_content("Example content")
     end
 
-    let(:additional_attributes) do
-      { "data-tracking-id": "show" }
-    end
-
-    it "adds custom data attribute" do
-      expect(component.css("[data-tracking-id='show']")).to be_present
-    end
+    it { is_expected.to have_selector "[data-additional='example']" }
   end
 end

--- a/engine/spec/components/citizens_advice_components/error_summary_spec.rb
+++ b/engine/spec/components/citizens_advice_components/error_summary_spec.rb
@@ -4,9 +4,7 @@ RSpec.describe CitizensAdviceComponents::ErrorSummary, type: :component do
   subject { page }
 
   context "when there are no errors provided" do
-    before do
-      render_inline described_class.new
-    end
+    before { render_inline described_class.new }
 
     it { is_expected.not_to have_selector "cads-error-summary" }
   end

--- a/engine/spec/components/citizens_advice_components/header_spec.rb
+++ b/engine/spec/components/citizens_advice_components/header_spec.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
 
 RSpec.describe CitizensAdviceComponents::Header, type: :component do
-  describe "no slots" do
-    before { render_inline(described_class.new) }
+  subject { page }
 
-    it "does not render without any slots" do
-      expect(page).not_to have_selector "header"
-    end
+  describe "no slots" do
+    before { render_inline described_class.new }
+
+    it { is_expected.not_to have_selector "header" }
   end
 
   describe "logo slot" do
@@ -17,9 +17,7 @@ RSpec.describe CitizensAdviceComponents::Header, type: :component do
         end
       end
 
-      it "has logo link" do
-        expect(page).to have_link "Logo title", href: "/homepage"
-      end
+      it { is_expected.to have_link "Logo title", href: "/homepage" }
 
       it "does not show right column when only logo is present" do
         expect(page).not_to have_selector ".cads-header__search-row"
@@ -33,94 +31,69 @@ RSpec.describe CitizensAdviceComponents::Header, type: :component do
         end
       end
 
-      it "renders custom block" do
-        expect(page).to have_text "Custom logo HTML"
-      end
+      it { is_expected.to have_text "Custom logo HTML" }
     end
   end
 
   describe "skip_links slot" do
-    subject(:component) do
-      render_inline(described_class.new) do |c|
-        c.logo(title: "Logo title", url: "/")
-        c.skip_links(skip_links)
-      end
-    end
-
-    let(:skip_links) { [{ title: "Skip to main content", url: "#content" }] }
-
-    it "renders skip links" do
-      links = component.css(".cads-skip-links a").map do |item|
-        { url: item.attr("href"), title: item.text.strip }
-      end
-
-      expect(links).to eq skip_links
-    end
-
     context "with default skip_links" do
-      subject(:component) do
+      before do
         render_inline(described_class.new) do |c|
           c.logo(title: "Logo title", url: "/")
         end
       end
 
-      it "renders default skip links" do
-        links = component.css(".cads-skip-links a").map do |item|
-          { url: item.attr("href"), title: item.text.strip }
-        end
+      it { is_expected.to have_selector ".cads-skip-links a", count: 3 }
+      it { is_expected.to have_link "Skip to navigation", href: "#cads-navigation" }
+      it { is_expected.to have_link "Skip to main content", href: "#cads-main-content" }
+      it { is_expected.to have_link "Skip to footer", href: "#cads-footer" }
+    end
 
-        expect(links).to eq [
-          { title: "Skip to navigation", url: "#cads-navigation" },
-          { title: "Skip to main content", url: "#cads-main-content" },
-          { title: "Skip to footer", url: "#cads-footer" }
-        ]
+    context "with custom skip links" do
+      before do
+        render_inline(described_class.new) do |c|
+          c.logo(title: "Logo title", url: "/")
+          c.skip_links([{ title: "Skip to main content", url: "#content" }])
+        end
       end
+
+      it { is_expected.to have_selector ".cads-skip-links a", count: 1 }
+      it { is_expected.to have_link "Skip to main content", href: "#content" }
     end
   end
 
   describe "header_links slot" do
-    subject(:component) do
+    before do
       render_inline(described_class.new) do |c|
         c.logo(title: "Logo title", url: "/")
         c.header_links([
           { title: "Public site", url: "/", current_site: true },
           { title: "Intranet", url: "/intranet" },
-          { title: "Cymraeg", url: "?lang=cy" }
+          { title: "Cymraeg", url: "/cymraeg" }
         ])
       end
     end
 
-    it "renders header links" do
-      expect(component.css(".cads-header__links li").size).to be 3
-    end
-
-    it "renders current site as a span" do
-      expect(component.css(".cads-header__links span").text).to eq "Public site"
-    end
+    it { is_expected.to have_selector ".cads-header__links a", count: 2 }
+    it { is_expected.to have_selector "span", text: "Public site" }
+    it { is_expected.to have_link "Intranet", href: "/intranet" }
+    it { is_expected.to have_link "Cymraeg", href: "/cymraeg" }
   end
 
   describe "account_link slot" do
     context "with plain link" do
-      let(:component) do
+      before do
         render_inline(described_class.new) do |c|
           c.logo(title: "Logo title", url: "/")
           c.account_link(title: "Sign out", url: "/sign-out")
         end
       end
 
-      let(:account_link) { component.at("a[data-testid=account-link]") }
-
-      it "has expected link href" do
-        expect(account_link.attr("href")).to eq "/sign-out"
-      end
-
-      it "has expected link text" do
-        expect(account_link.text.strip).to eq "Sign out"
-      end
+      it { is_expected.to have_link "Sign out", href: "/sign-out" }
     end
 
     context "with custom block" do
-      subject(:component) do
+      before do
         render_inline(described_class.new) do |c|
           c.logo(title: "Logo title", url: "/")
           c.account_link do
@@ -129,42 +102,30 @@ RSpec.describe CitizensAdviceComponents::Header, type: :component do
         end
       end
 
-      it "renders custom block" do
-        expect(component.at("[data-testid=account-link]").text).to include "Custom account link HTML"
-      end
+      it { is_expected.to have_text "Custom account link HTML" }
     end
   end
 
   describe "search_form slot" do
-    subject(:component) do
+    before do
       render_inline(described_class.new) do |c|
         c.logo(title: "Logo title", url: "/")
         c.search_form(search_action_url: "/search")
       end
     end
 
-    it "renders search form" do
-      expect(component.at("form[role=search]").attr("action")).to eq "/search"
-    end
+    it { is_expected.to have_selector "form[role=search]" }
+    it { is_expected.to have_selector "form[action='/search']" }
 
-    it "has descriptive label" do
-      expect(component.at("input[type=search]").attr("aria-label")).to eq "Search through site content"
-    end
+    it { is_expected.to have_field "Search through site content" }
 
-    it "renders search toggle" do
-      expect(component.at("button[aria-label='Open search']")).to be_present
-    end
+    it { is_expected.to have_button "Open search" }
 
     context "when welsh language" do
-      before { I18n.locale = :cy }
+      around { |example| I18n.with_locale(:cy) { example.run } }
 
-      it "has translated descriptive label" do
-        expect(component.at("input[type=search]").attr("aria-label")).to eq "Chwiliwch trwy gynnwys y wefan"
-      end
-
-      it "has translated search label" do
-        expect(component.at("button[aria-label='Ymchwiliad agored']")).to be_present
-      end
+      it { is_expected.to have_field "Chwiliwch trwy gynnwys y wefan" }
+      it { is_expected.to have_button "Ymchwiliad agored" }
     end
   end
 end

--- a/engine/spec/components/citizens_advice_components/input_spec.rb
+++ b/engine/spec/components/citizens_advice_components/input_spec.rb
@@ -1,148 +1,153 @@
 # frozen_string_literal: true
 
 RSpec.describe CitizensAdviceComponents::Input, type: :component do
-  subject(:component) do
-    render_inline described_class.new(
-      name: "example-input",
-      label: "Example input",
-      type: type.presence,
-      options: options.presence
-    )
-  end
+  subject { page }
 
-  let(:type) { :text }
-  let(:options) { nil }
+  context "with default arguments" do
+    before do
+      render_inline described_class.new(
+        name: "example-input",
+        label: "Example input",
+        type: :text
+      )
+    end
 
-  it "renders the label" do
-    expect(component.text.strip).to include("Example input")
-  end
+    it { is_expected.to have_field "Example input", type: :text }
 
-  it "links the label to the input" do
-    expect(component.css("label").attribute("for").value).to eq("example-input-input")
-  end
+    it "links the label to the input" do
+      expect(page).to have_selector "label[for=example-input-input]"
+    end
 
-  it "renders an input" do
-    expect(component.css("input")).to be_present
-  end
+    it "adds the correct id to the input" do
+      expect(page).to have_selector "#example-input-input"
+    end
 
-  it "adds the correct id to the input" do
-    expect(component.css("input").attribute("id").value).to eq("example-input-input")
-  end
+    it "includes required attribute" do
+      expect(page).to have_selector "input[required]"
+    end
 
-  it "renders a text input" do
-    expect(component.css("input").attribute("type").value).to eq("text")
-  end
-
-  it "renders an empty input" do
-    expect(component.css("input").attribute("value")).to be_nil
-  end
-
-  it "renders a required input" do
-    expect(component.css("input").attribute("required")).to be_present
-  end
-
-  context "when a value is provided" do
-    let(:options) { { value: "This is the value of the field" } }
-
-    it "renders the value" do
-      expect(component.css("input").attribute("value").value).to eq "This is the value of the field"
+    it "does not have an aria-describedby attribute by default" do
+      expect(page).to have_no_selector "input[aria-describedby]"
     end
   end
 
-  context "when an error is present" do
-    subject(:component) do
+  context "when a value is provided" do
+    before do
       render_inline described_class.new(
         name: "example-input",
         label: "Example input",
         type: :text,
-        options: {
-          error_message: "Enter your name"
-        }
+        options: { value: "Example value" }
       )
     end
 
-    let(:error_message) { "Enter your name" }
-
-    it "renders the error message" do
-      expect(component.text.strip).to include "Enter your name"
-    end
-
-    it "adds aria-invalid to the input" do
-      expect(component.css("input").attribute("aria-invalid")).to be_present
-    end
-
-    it "adds aria-describedby to the input" do
-      expect(component.css("input").attribute("aria-describedby").value).to eq("example-input-error")
-    end
+    it { is_expected.to have_field "Example input", with: "Example value" }
   end
 
-  context "when a type is specified" do
-    let(:type) { :email }
+  context "when a valid type is specified" do
+    before do
+      render_inline described_class.new(
+        name: "example-input",
+        label: "Example input",
+        type: :email
+      )
+    end
 
-    it "renders the correct type of input" do
-      expect(component.css("input").attribute("type").value).to eq("email")
+    it { is_expected.to have_field "Example input", type: :email }
+  end
+
+  context "when an invalid type is specified" do
+    before do
+      without_fetch_or_fallback_raises do
+        render_inline described_class.new(
+          name: "example-input",
+          label: "Example input",
+          type: :invalid
+        )
+      end
+    end
+
+    it "renders a text input" do
+      expect(page).to have_field "Example input", type: :text
     end
   end
 
   context "when the input is optional" do
-    let(:options) { { optional: true } }
-
-    it "adds optional to the label" do
-      expect(component.text).to include("(optional)")
+    before do
+      render_inline described_class.new(
+        name: "example-input",
+        label: "Example input",
+        type: :text,
+        options: { optional: true }
+      )
     end
 
+    it { is_expected.to have_text "(optional)" }
+
     it "does not add required to the input" do
-      expect(component.css("input").attribute("required")).not_to be_present
+      expect(page).to have_no_selector "input[required]"
     end
 
     context "when in Cymraeg" do
-      before do
-        I18n.locale = :cy
-      end
+      around { |example| I18n.with_locale(:cy) { example.run } }
 
-      it "renders optional in Welsh" do
-        expect(component.text).to include("dewisol")
-      end
+      it { is_expected.to have_text "(dewisol)" }
     end
+  end
+
+  context "when an error is present" do
+    before do
+      render_inline described_class.new(
+        name: "example-input",
+        label: "Example input",
+        type: :text,
+        options: { error_message: "Enter your name" }
+      )
+    end
+
+    it { is_expected.to have_selector "#example-input-error", text: "Enter your name" }
+    it { is_expected.to have_selector "input[aria-invalid]" }
+    it { is_expected.to have_selector "input[aria-describedby=example-input-error]" }
   end
 
   context "when there is hint text" do
-    let(:options) { { hint: "This is the hint text" } }
-
-    it "renders the hint text" do
-      expect(component.text.strip).to include("This is the hint text")
+    before do
+      render_inline described_class.new(
+        name: "example-input",
+        label: "Example input",
+        type: :text,
+        options: { hint: "This is the hint text" }
+      )
     end
 
-    it "adds aria-describedby to the input" do
-      expect(component.css("input").attribute("aria-describedby").value).to eq("example-input-hint")
-    end
-  end
-
-  context "when there is no hint text and no error" do
-    it "does not have an aria-describedby attribute" do
-      expect(component.css("input").attribute("aria-describedby")).not_to be_present
-    end
+    it { is_expected.to have_text "This is the hint text" }
+    it { is_expected.to have_selector "input[aria-describedby=example-input-hint]" }
   end
 
   context "when there is hint text and an error" do
-    let(:options) { { hint: "this is the hint text", error_message: "Enter your name" } }
-
-    it "adds aria-describedby to the input" do
-      expect(component.css("input").attribute("aria-describedby").value).to eq("example-input-error example-input-hint")
+    before do
+      render_inline described_class.new(
+        name: "example-input",
+        label: "Example input",
+        type: :text,
+        options: { hint: "This is the hint text", error_message: "Enter your name" }
+      )
     end
+
+    it { is_expected.to have_selector "input[aria-describedby='example-input-error example-input-hint']" }
   end
 
-  context "when additional attributes are specified" do
-    let(:options) do
-      { additional_attributes: { autocomplete: "name", "data-foo": "bar" } }
+  context "when additional attributes are provided" do
+    before do
+      render_inline described_class.new(
+        name: "example-input",
+        label: "Example input",
+        type: :text,
+        options: { additional_attributes: { autocomplete: "name", "data-additional": "example" } }
+      )
     end
 
-    it "adds autocomplete attribute" do
-      expect(component.css("input").attribute("autocomplete").value).to eq("name")
-    end
-
-    it "adds custom data attribute" do
-      expect(component.css("input").attribute("data-foo").value).to eq("bar")
-    end
+    it { is_expected.to have_selector "input[autocomplete=name]" }
+    it { is_expected.to have_selector "input[data-additional=example]" }
   end
 end

--- a/engine/spec/components/citizens_advice_components/navigation_spec.rb
+++ b/engine/spec/components/citizens_advice_components/navigation_spec.rb
@@ -1,35 +1,37 @@
 # frozen_string_literal: true
 
 RSpec.describe CitizensAdviceComponents::Navigation, type: :component do
-  subject(:component) do
-    render_inline(described_class.new(links: links))
-  end
+  subject { page }
 
-  let(:links) do
-    [
-      { url: "/benefits/", title: "Benefits" },
-      { url: "/work/", title: "Work" },
-      { url: "/debt-and-money/", title: "Debt and money" },
-      { url: "/consumer/", title: "Consumer" },
-      { url: "/housing/", title: "Housing" },
-      { url: "/family/", title: "Family" },
-      { url: "/law-and-courts/", title: "Law and courts" },
-      { url: "/immigration/", title: "Immigration" },
-      { url: "/health/", title: "Health" },
-      { url: "/more", title: "More from us" }
-    ]
-  end
+  context "when links are provided" do
+    before do
+      render_inline described_class.new(
+        links: [
+          { url: "/benefits/", title: "Benefits" },
+          { url: "/work/", title: "Work" },
+          { url: "/debt-and-money/", title: "Debt and money" },
+          { url: "/consumer/", title: "Consumer" },
+          { url: "/housing/", title: "Housing" },
+          { url: "/family/", title: "Family" },
+          { url: "/law-and-courts/", title: "Law and courts" },
+          { url: "/immigration/", title: "Immigration" },
+          { url: "/health/", title: "Health" },
+          { url: "/more", title: "More from us" }
+        ]
+      )
+    end
 
-  it "renders navigation" do
-    result = component.css("a").map { |item| { title: item.text.strip, url: item.attr("href") } }
-    expect(result).to eq links
+    it { is_expected.to have_selector ".cads-navigation" }
+    it { is_expected.to have_selector "a", count: 10 }
+    it { is_expected.to have_link "Benefits", href: "/benefits/" }
+    it { is_expected.to have_link "Work", href: "/work/" }
   end
 
   context "when no links" do
-    let(:links) { nil }
-
-    it "does not render" do
-      expect(component.at(".cads-navigation")).not_to be_present
+    before do
+      render_inline described_class.new(links: nil)
     end
+
+    it { is_expected.to have_no_selector ".cads-navigation" }
   end
 end

--- a/engine/spec/components/citizens_advice_components/notice_banner_spec.rb
+++ b/engine/spec/components/citizens_advice_components/notice_banner_spec.rb
@@ -1,27 +1,25 @@
 # frozen_string_literal: true
 
 RSpec.describe CitizensAdviceComponents::NoticeBanner, type: :component do
-  subject(:component) do
-    render_inline(described_class.new(label: "Example label")) do
-      "Example content"
+  subject { page }
+
+  context "with default arguments" do
+    before do
+      render_inline(described_class.new(label: "Example label")) do
+        "Example content"
+      end
     end
-  end
 
-  it "has a label" do
-    expect(component.at("span").text).to include "Example label"
-  end
-
-  it "renders content block" do
-    expect(component.text).to include "Example content"
+    it { is_expected.to have_selector ".cads-notice-banner" }
+    it { is_expected.to have_selector "span", text: "Example label" }
+    it { is_expected.to have_text "Example content" }
   end
 
   context "when no content present" do
-    subject(:component) do
+    before do
       render_inline(described_class.new(label: "Example label"))
     end
 
-    it "does not render" do
-      expect(component.at(".cads-notice-banner")).not_to be_present
-    end
+    it { is_expected.to have_no_selector ".cads-notice-banner" }
   end
 end

--- a/engine/spec/components/citizens_advice_components/on_this_page_spec.rb
+++ b/engine/spec/components/citizens_advice_components/on_this_page_spec.rb
@@ -1,103 +1,92 @@
 # frozen_string_literal: true
 
 RSpec.describe CitizensAdviceComponents::OnThisPage, type: :component do
-  subject(:component) do
-    render_inline described_class.new(show_nested_links: show_nested_links) do |c|
-      c.links(links)
-    end
-  end
-
-  let(:links) { nil }
-
-  let(:simple_links) do
-    [
-      { label: "Link 1", id: "link-1" },
-      { label: "Link 2", id: "link-2" },
-      { label: "Link 3", id: "link-3" },
-      { label: "Link 4", id: "link-4" }
-    ]
-  end
-
-  let(:nested_links) do
-    [
-      { label: "Link 1", id: "link-1" },
-      { label: "Link 2", id: "link-2", children: [
-        { label: "Link 2.1", id: "link-2-1" },
-        { label: "Link 2.2", id: "link-2-2" }
-      ] },
-      { label: "Link 3", id: "link-3" },
-      { label: "Link 4", id: "link-4", children: [
-        { label: "Link 4.1", id: "link-4-1" }
-      ] },
-      { label: "Link 5", id: "link-5" }
-    ]
-  end
-
-  let(:show_nested_links) { false }
+  subject { page }
 
   context "when no links present" do
-    it "will not render anything" do
-      expect(component.children).to be_empty
-    end
+    before { render_inline described_class.new }
+
+    it { is_expected.to have_no_selector ".cads-on-this-page" }
   end
 
   context "when there are links present" do
-    let(:links) { simple_links }
-
-    it "renders a list of top-level links" do
-      links = component.css("[data-testid='on-this-page-link']")
-      expect(links.map { |item| item.text.strip }).to eq [
-        "Link 1",
-        "Link 2",
-        "Link 3",
-        "Link 4"
-      ]
+    before do
+      render_inline described_class.new do |c|
+        c.links([
+          { label: "Link 1", id: "link-1" },
+          { label: "Link 2", id: "link-2" },
+          { label: "Link 3", id: "link-3" },
+          { label: "Link 4", id: "link-4" }
+        ])
+      end
     end
 
+    it { is_expected.to have_selector "a", count: "4" }
+    it { is_expected.to have_link "Link 1", href: "#link-1" }
+    it { is_expected.to have_link "Link 2", href: "#link-2" }
+    it { is_expected.to have_link "Link 3", href: "#link-3" }
+    it { is_expected.to have_link "Link 4", href: "#link-4" }
+
     it "does not render toggle buttons" do
-      expect(component.at("[data-testid='on-this-page-toggle']")).to be_nil
+      expect(page).to have_no_selector "[data-testid='on-this-page-toggle']"
     end
 
     it "does not render nested links" do
-      expect(component.at("[data-testid='on-this-page-children']")).to be_nil
+      expect(page).to have_no_selector "[data-testid='on-this-page-children']"
     end
   end
 
-  context "when show_nested_links is true" do
-    let(:show_nested_links) { true }
-
+  describe "nested links" do
     context "when there are only top-level links present" do
-      let(:body) { only_h2s }
+      before do
+        render_inline described_class.new(show_nested_links: true) do |c|
+          c.links([
+            { label: "Link 1", id: "link-1" },
+            { label: "Link 2", id: "link-2" },
+            { label: "Link 3", id: "link-3" },
+            { label: "Link 4", id: "link-4" }
+          ])
+        end
+      end
 
       it "does not render toggle buttons" do
-        expect(component.at("[data-testid='on-this-page-toggle']")).to be_nil
+        expect(page).to have_no_selector "[data-testid='on-this-page-toggle']"
       end
 
       it "does not render nested links" do
-        expect(component.at("[data-testid='on-this-page-children']")).to be_nil
+        expect(page).to have_no_selector "[data-testid='on-this-page-children']"
       end
     end
 
     context "when there are nested links present" do
-      let(:links) { nested_links }
-
-      it "renders a list of top-level links" do
-        links = component.css("[data-testid='on-this-page-link']")
-        expect(links.map { |item| item.text.strip }).to eq [
-          "Link 1",
-          "Link 2",
-          "Link 3",
-          "Link 4",
-          "Link 5"
-        ]
+      before do
+        render_inline described_class.new(show_nested_links: true) do |c|
+          c.links([
+            { label: "Link 1", id: "link-1" },
+            { label: "Link 2", id: "link-2", children: [
+              { label: "Link 2.1", id: "link-2-1" },
+              { label: "Link 2.2", id: "link-2-2" }
+            ] },
+            { label: "Link 3", id: "link-3" },
+            { label: "Link 4", id: "link-4", children: [
+              { label: "Link 4.1", id: "link-4-1" }
+            ] },
+            { label: "Link 5", id: "link-5" }
+          ])
+        end
       end
 
-      it "renders nested links" do
-        expect(component.at("[data-testid='on-this-page-children']")).not_to be_nil
-      end
+      it { is_expected.to have_link "Link 1", href: "#link-1" }
+      it { is_expected.to have_link "Link 2", href: "#link-2" }
+      it { is_expected.to have_link "Link 2.1", href: "#link-2-1" }
+      it { is_expected.to have_link "Link 2.2", href: "#link-2-2" }
+      it { is_expected.to have_link "Link 3", href: "#link-3" }
+      it { is_expected.to have_link "Link 4", href: "#link-4" }
+      it { is_expected.to have_link "Link 4.1", href: "#link-4-1" }
+      it { is_expected.to have_link "Link 5", href: "#link-5" }
 
       it "renders the correct number of toggle buttons" do
-        expect(component.css("[data-testid='on-this-page-toggle']").length).to eq(2)
+        expect(page).to have_selector "[data-testid='on-this-page-toggle']", count: 2
       end
     end
   end

--- a/engine/spec/components/citizens_advice_components/page_review_spec.rb
+++ b/engine/spec/components/citizens_advice_components/page_review_spec.rb
@@ -1,45 +1,50 @@
 # frozen_string_literal: true
 
 RSpec.describe CitizensAdviceComponents::PageReview, type: :component do
-  subject(:component) do
-    described_class.new(
-      page_review_date: page_review_date.presence,
-      date_format: date_format.presence
-    )
-  end
+  subject { page }
 
-  let(:page_review_date) { Date.new(2021, 6, 12) }
-  let(:date_format) { nil }
+  context "with default arguments" do
+    before do
+      render_inline described_class.new(
+        page_review_date: Date.new(2021, 6, 12)
+      )
+    end
 
-  it "renders a formatted date" do
-    render_inline component
-    expect(page).to have_text "Page last reviewed on 12 June 2021"
+    it { is_expected.to have_selector ".cads-page-review", text: "Page last reviewed on 12 June 2021" }
+
+    context "when welsh language" do
+      around { |example| I18n.with_locale(:cy) { example.run } }
+
+      it { is_expected.to have_text "Adolygwyd y dudalen ar 12 Mehefin 2021" }
+    end
   end
 
   context "when no date" do
-    let(:page_review_date) { nil }
-
-    it "does not render" do
-      render_inline component
-      expect(page).to have_no_selector ".cads-page-review"
+    before do
+      render_inline described_class.new(page_review_date: nil)
     end
+
+    it { is_expected.to have_no_selector ".cads-page-review" }
   end
 
   context "when custom date format" do
-    let(:date_format) { :short }
-
-    it "renders date with custom format" do
-      render_inline component
-      expect(page).to have_text "Page last reviewed on Jun 12"
+    before do
+      render_inline described_class.new(
+        page_review_date: Date.new(2021, 6, 12),
+        date_format: :short
+      )
     end
+
+    it { is_expected.to have_text "Page last reviewed on Jun 12" }
   end
 
-  context "when welsh language" do
-    before { I18n.locale = :cy }
+  context "when invalid date format" do
+    let(:component) do
+      described_class.new(page_review_date: Date.new(2021, 20, 12))
+    end
 
-    it "has translated date" do
-      render_inline component
-      expect(page).to have_text "Adolygwyd y dudalen ar 12 Mehefin 2021"
+    it "raises error for invalid dates" do
+      expect { render_inline component }.to raise_error(Date::Error)
     end
   end
 end

--- a/engine/spec/components/citizens_advice_components/pagination_spec.rb
+++ b/engine/spec/components/citizens_advice_components/pagination_spec.rb
@@ -1,113 +1,112 @@
 # frozen_string_literal: true
 
 RSpec.describe CitizensAdviceComponents::Pagination, type: :component do
-  subject(:component) do
-    render_inline described_class.new(
-      current_params: { "q" => "debt and money" },
-      num_pages: 100,
-      current_page: current_page
-    )
-  end
+  subject { page }
 
-  let(:current_page) { 1 }
-
-  let(:paging_controls) { component.css("[data-testid='paging-control']") }
-  let(:paging_aria_labels) { paging_controls.map { |item| item.attr("aria-label") } }
-  let(:paging_labels) { paging_controls.map { |item| item.text.strip } }
-
-  context "when on first page" do
-    let(:current_page) { 1 }
-
-    it "has expected labels" do
-      expect(paging_labels).to eq %w[1 2 3 Next Last]
+  context "when multiple pages" do
+    before do
+      render_inline described_class.new(
+        current_params: { "q" => "debt and money" },
+        num_pages: 100,
+        current_page: current_page
+      )
     end
 
-    it "has aria labels" do
-      expect(paging_aria_labels).to eq [
-        "Go to page 1",
-        "Go to page 2",
-        "Go to page 3",
-        "Go to next page",
-        "Go to last page"
-      ]
+    context "when on first page" do
+      let(:current_page) { 1 }
+
+      it { is_expected.to have_selector "a", count: 5 }
+      it { is_expected.to have_selector "a[aria-current]", count: 1 }
+
+      it { is_expected.to have_link "1", href: "?page=1&q=debt+and+money" }
+      it { is_expected.to have_link "2", href: "?page=2&q=debt+and+money" }
+      it { is_expected.to have_link "3", href: "?page=3&q=debt+and+money" }
+      it { is_expected.to have_link "Next", href: "?page=2&q=debt+and+money" }
+      it { is_expected.to have_link "Last", href: "?page=100&q=debt+and+money" }
+
+      it "has aria labels" do
+        expect(paging_aria_labels).to eq [
+          "Go to page 1",
+          "Go to page 2",
+          "Go to page 3",
+          "Go to next page",
+          "Go to last page"
+        ]
+      end
+
+      it { is_expected.to have_selector "nav[aria-label='Pagination navigation']" }
     end
 
-    it "generates valid query strings" do
-      expect(paging_controls.first.attr("href")).to eq "?page=1&q=debt+and+money"
+    context "when on second page" do
+      let(:current_page) { 2 }
+
+      it "has expected labels" do
+        expect(paging_labels).to eq %w[Previous 1 2 3 Next Last]
+      end
+
+      it "has aria labels" do
+        expect(paging_aria_labels).to eq [
+          "Go to previous page",
+          "Go to page 1",
+          "Go to page 2",
+          "Go to page 3",
+          "Go to next page",
+          "Go to last page"
+        ]
+      end
     end
 
-    it "has aria-label for navigation" do
-      expect(component.at("nav").attr("aria-label")).to eq "Pagination navigation"
+    context "when on tenth page" do
+      let(:current_page) { 10 }
+
+      it "has expected labels" do
+        expect(paging_labels).to eq %w[First Previous 8 9 10 11 12 Next Last]
+      end
+
+      it "has aria labels" do
+        expect(paging_aria_labels).to eq [
+          "Go to first page",
+          "Go to previous page",
+          "Go to page 8",
+          "Go to page 9",
+          "Go to page 10",
+          "Go to page 11",
+          "Go to page 12",
+          "Go to next page",
+          "Go to last page"
+        ]
+      end
     end
 
-    it "has single aria-current for current page" do
-      expect(component.css("[aria-current]:contains(1)").size).to be 1
-    end
-  end
+    context "when on last page" do
+      let(:current_page) { 100 }
 
-  context "when on second page" do
-    let(:current_page) { 2 }
+      it "has expected labels" do
+        expect(paging_labels).to eq %w[First Previous 98 99 100]
+      end
 
-    it "has expected labels" do
-      expect(paging_labels).to eq %w[Previous 1 2 3 Next Last]
-    end
-
-    it "has aria labels" do
-      expect(paging_aria_labels).to eq [
-        "Go to previous page",
-        "Go to page 1",
-        "Go to page 2",
-        "Go to page 3",
-        "Go to next page",
-        "Go to last page"
-      ]
-    end
-  end
-
-  context "when on tenth page" do
-    let(:current_page) { 10 }
-
-    it "has expected labels" do
-      expect(paging_labels).to eq %w[First Previous 8 9 10 11 12 Next Last]
-    end
-
-    it "has aria labels" do
-      expect(paging_aria_labels).to eq [
-        "Go to first page",
-        "Go to previous page",
-        "Go to page 8",
-        "Go to page 9",
-        "Go to page 10",
-        "Go to page 11",
-        "Go to page 12",
-        "Go to next page",
-        "Go to last page"
-      ]
-    end
-  end
-
-  context "when on last page" do
-    let(:current_page) { 100 }
-
-    it "has expected labels" do
-      expect(paging_labels).to eq %w[First Previous 98 99 100]
-    end
-
-    it "has aria labels" do
-      expect(paging_aria_labels).to eq [
-        "Go to first page",
-        "Go to previous page",
-        "Go to page 98",
-        "Go to page 99",
-        "Go to page 100"
-      ]
+      it "has aria labels" do
+        expect(paging_aria_labels).to eq [
+          "Go to first page",
+          "Go to previous page",
+          "Go to page 98",
+          "Go to page 99",
+          "Go to page 100"
+        ]
+      end
     end
   end
 
   context "when welsh language" do
-    before { I18n.locale = :cy }
+    around { |example| I18n.with_locale(:cy) { example.run } }
 
-    let(:current_page) { 10 }
+    before do
+      render_inline described_class.new(
+        current_params: { "q" => "debt and money" },
+        num_pages: 100,
+        current_page: 10
+      )
+    end
 
     it "has translated labels" do
       expect(paging_labels).to eq %w[Cyntaf Blaenorol 8 9 10 11 12 Nesaf Diwethaf]
@@ -129,7 +128,7 @@ RSpec.describe CitizensAdviceComponents::Pagination, type: :component do
   end
 
   context "when single page" do
-    subject(:component) do
+    before do
       render_inline described_class.new(
         current_params: { "q" => "debt and money" },
         num_pages: 1,
@@ -137,13 +136,11 @@ RSpec.describe CitizensAdviceComponents::Pagination, type: :component do
       )
     end
 
-    it "does not render" do
-      expect(component.at("nav")).to be_nil
-    end
+    it { is_expected.to have_no_selector "nav" }
   end
 
   context "when custom param_name" do
-    subject(:component) do
+    before do
       render_inline described_class.new(
         current_params: { "q" => "debt and money" },
         num_pages: 100,
@@ -152,8 +149,20 @@ RSpec.describe CitizensAdviceComponents::Pagination, type: :component do
       )
     end
 
-    it "generates valid query string" do
-      expect(paging_controls.first.attr("href")).to eq "?page_number=1&q=debt+and+money"
-    end
+    it { is_expected.to have_link "1", href: "?page_number=1&q=debt+and+money" }
+  end
+
+  private
+
+  def paging_labels
+    paging_controls.map { |item| item.native.text.strip }
+  end
+
+  def paging_aria_labels
+    paging_controls.map { |item| item.native["aria-label"] }
+  end
+
+  def paging_controls
+    page.all("[data-testid='paging-control']")
   end
 end

--- a/engine/spec/components/citizens_advice_components/radio_group_spec.rb
+++ b/engine/spec/components/citizens_advice_components/radio_group_spec.rb
@@ -1,64 +1,208 @@
 # frozen_string_literal: true
 
-# default behaviour - large, list, one for each option, value, checked, name, id
-# optional behaviour - optional, hint, inline, small, error, layout
-# invalid params - size, layout, optional
-
 RSpec.describe CitizensAdviceComponents::RadioGroup, type: :component do
-  subject(:component) do
-    render_inline described_class.new(
-      legend: "Radio button group field",
-      name: "radio-buttons",
-      options: options.presence
-    ) do |c|
-      c.inputs(inputs)
+  subject { page }
+
+  context "when default arguments are provided" do
+    before do
+      render_inline described_class.new(
+        legend: "Radio button group field",
+        name: "radio-group"
+      ) do |c|
+        c.inputs(sample_inputs)
+      end
+    end
+
+    it { is_expected.to have_field "Option 1", with: "1" }
+    it { is_expected.to have_field "Option 2", with: "2" }
+
+    it "has the expected number of options" do
+      expect(page).to have_selector "input[type=radio]", count: 2
+    end
+
+    it "has no checked inputs by default" do
+      expect(page).to have_no_selector "input[checked]"
+    end
+
+    it "constructs the ids of the inputs correctly" do
+      expect(page).to have_selector "#radio-group-1"
+    end
+
+    it "associates the labels with the inputs correctly" do
+      expect(page).to have_selector "label[for=radio-group-1]"
     end
   end
 
-  let(:inputs) do
+  context "when there are no options" do
+    before do
+      render_inline described_class.new(
+        legend: "Radio button group field",
+        name: "radio-group"
+      )
+    end
+
+    it { is_expected.to have_no_selector ".cads-form-field" }
+  end
+
+  context "when an error message is provided" do
+    before do
+      render_inline described_class.new(
+        legend: "Radio group field",
+        name: "radio-group",
+        options: { error_message: "This is the error message" }
+      ) do |c|
+        c.inputs(sample_inputs)
+      end
+    end
+
+    it { is_expected.to have_selector ".cads-form-field--has-error" }
+    it { is_expected.to have_text "This is the error message" }
+  end
+
+  context "when an hint text is provided" do
+    before do
+      render_inline described_class.new(
+        legend: "Radio group field",
+        name: "radio-group",
+        options: { hint: "This is the hint text" }
+      ) do |c|
+        c.inputs(sample_inputs)
+      end
+    end
+
+    it { is_expected.to have_text "This is the hint text" }
+  end
+
+  context "when field is marked as optional" do
+    before do
+      render_inline described_class.new(
+        legend: "Radio group field",
+        name: "radio-group",
+        options: { optional: true }
+      ) do |c|
+        c.inputs(sample_inputs)
+      end
+    end
+
+    it { is_expected.to have_text "(optional)" }
+
+    context "when in Cymraeg" do
+      around { |example| I18n.with_locale(:cy) { example.run } }
+
+      it { is_expected.to have_text "(dewisol)" }
+    end
+  end
+
+  describe "layout options" do
+    context "when an invalid layout option is passed" do
+      before do
+        without_fetch_or_fallback_raises do
+          render_inline described_class.new(
+            legend: "Radio group field",
+            name: "radio-group",
+            options: { layout: :invalid }
+          ) do |c|
+            c.inputs(sample_inputs)
+          end
+        end
+      end
+
+      it "renders the radio group in list layout" do
+        expect(page).to have_selector ".cads-radio-group--list"
+      end
+    end
+
+    context "when the list layout option is passed" do
+      before do
+        render_inline described_class.new(
+          legend: "Radio group field",
+          name: "radio-group",
+          options: { layout: :list }
+        ) do |c|
+          c.inputs(sample_inputs)
+        end
+      end
+
+      it "renders the radio group in list layout" do
+        expect(page).to have_selector ".cads-radio-group--list"
+      end
+    end
+
+    context "when the inline layout option is passed" do
+      before do
+        render_inline described_class.new(
+          legend: "Radio group field",
+          name: "radio-group",
+          options: { layout: :inline }
+        ) do |c|
+          c.inputs(sample_inputs)
+        end
+      end
+
+      it "renders the radio group in list layout" do
+        expect(page).to have_selector ".cads-radio-group--inline"
+      end
+    end
+  end
+
+  describe "size options" do
+    context "when an invalid size option is passed" do
+      before do
+        without_fetch_or_fallback_raises do
+          render_inline described_class.new(
+            legend: "Radio group field",
+            name: "radio-group",
+            options: { size: :invalid }
+          ) do |c|
+            c.inputs(sample_inputs)
+          end
+        end
+      end
+
+      it "renders the regular size radio group" do
+        expect(page).to have_selector ".cads-radio-group--regular"
+      end
+    end
+
+    context "when the regular size option is passed" do
+      before do
+        render_inline described_class.new(
+          legend: "Radio group field",
+          name: "radio-group",
+          options: { size: :regular }
+        ) do |c|
+          c.inputs(sample_inputs)
+        end
+      end
+
+      it "renders the regular size radio group" do
+        expect(page).to have_selector ".cads-radio-group--regular"
+      end
+    end
+
+    context "when the inline layout option is passed" do
+      before do
+        render_inline described_class.new(
+          legend: "Radio group field",
+          name: "radio-group",
+          options: { size: :small }
+        ) do |c|
+          c.inputs(sample_inputs)
+        end
+      end
+
+      it "renders the small size radio group" do
+        expect(page).to have_selector ".cads-radio-group--small"
+      end
+    end
+  end
+
+  private
+
+  def sample_inputs
     [
       { label: "Option 1", value: "1", name: "radio-group" },
       { label: "Option 2", value: "2", name: "radio-group" }
     ]
-  end
-
-  context "when invalid size parameter is passed" do
-    let(:options) { { size: :bananas } }
-
-    it "renders a normal size input" do
-      without_fetch_or_fallback_raises do
-        expect(component.css(".cads-radio-group--regular")).to be_present
-      end
-    end
-  end
-
-  context "when invalid layout parameter is passed" do
-    let(:options) { { layout: :bananas } }
-
-    it "renders the radio buttons in list layout" do
-      without_fetch_or_fallback_raises do
-        expect(component.css(".cads-radio-group--list")).to be_present
-      end
-    end
-  end
-
-  context "when there are optional parameters" do
-    let(:options) do
-      {
-        error_message: "This is the error message",
-        optional: true,
-        hint: "This is the hint text",
-        layout: :inline,
-        size: :small
-      }
-    end
-
-    it "has the correct layout" do
-      expect(component.css(".cads-radio-group--inline")).to be_present
-    end
-
-    it "has the correct size buttons" do
-      expect(component.css(".cads-radio-group--small")).to be_present
-    end
   end
 end

--- a/engine/spec/components/citizens_advice_components/search_spec.rb
+++ b/engine/spec/components/citizens_advice_components/search_spec.rb
@@ -1,51 +1,42 @@
 # frozen_string_literal: true
 
 RSpec.describe CitizensAdviceComponents::Search, type: :component do
-  subject(:component) do
-    render_inline(described_class.new)
-  end
+  subject { page }
 
-  it "renders search input" do
-    expect(component.at(".cads-search")).to be_present
-  end
+  context "with no arguments" do
+    before { render_inline(described_class.new) }
 
-  it "renders search button with label" do
-    expect(component.at("button").text).to include "Search"
-  end
+    it { is_expected.to have_selector ".cads-search" }
+    it { is_expected.to have_field "Search through site content" }
+    it { is_expected.to have_button "Search" }
 
-  it "has no value" do
-    expect(component.at("input[type=search]").attr("value")).to be_nil
-  end
+    it "has no value" do
+      input = page.find("input[type=search]").native
+      expect(input.attr("value")).to be_nil
+    end
 
-  it "has default param name" do
-    expect(component.at("input[type=search]").attr("name")).to eq "q"
+    it "has default param name" do
+      expect(page).to have_selector "input[name=q]"
+    end
+
+    context "when welsh language" do
+      around { |example| I18n.with_locale(:cy) { example.run } }
+
+      it { is_expected.to have_button "Chwilio" }
+    end
   end
 
   context "with value" do
-    subject(:component) do
-      render_inline(described_class.new(value: "Example value"))
-    end
+    before { render_inline(described_class.new(value: "Example value")) }
 
-    it "has a value" do
-      expect(component.at("input[type=search]").attr("value")).to eq "Example value"
-    end
+    it { is_expected.to have_field "Search through site content", with: "Example value" }
   end
 
   context "with custom param_name" do
-    subject(:component) do
-      render_inline(described_class.new(param_name: :query))
-    end
+    before { render_inline(described_class.new(param_name: :query)) }
 
     it "has custom param name" do
-      expect(component.at("input[type=search]").attr("name")).to eq "query"
-    end
-  end
-
-  context "when welsh language" do
-    before { I18n.locale = :cy }
-
-    it "has translated label" do
-      expect(component.at("button").text).to include "Chwilio"
+      expect(page).to have_selector "input[name=query]"
     end
   end
 end

--- a/engine/spec/components/citizens_advice_components/section_links_spec.rb
+++ b/engine/spec/components/citizens_advice_components/section_links_spec.rb
@@ -1,62 +1,34 @@
 # frozen_string_literal: true
 
 RSpec.describe CitizensAdviceComponents::SectionLinks, type: :component do
-  let(:section_links) do
-    [
-      { title: "Preparing to apply for pre-settled and settled status",
-        url: "/immigration/preparing-to-apply-for-pre-settled-and-settled-status" },
-      { title: "Applying for pre-settled and settled status", url: "/immigration/applying-for-settled-status" },
-      { title: "Updating and proving your pre-settled or settled status", url: "/immigration/viewing-your-pre-settled-or-settled-status" },
-      { title: "Switching from pre-settled to settled status", url: "/immigration/switching-from-pre-settled-to-settled-status" },
-      { title: "Problems with your settled status decision", url: "/immigration/problems-with-your-settled-status-decision" }
-    ]
-  end
+  subject { page }
 
-  let(:additional_attribute_links) do
-    [
-      { title: "Preparing to apply for pre-settled and settled status",
-        url: "/immigration/preparing-to-apply-for-pre-settled-and-settled-status", "aria-current": "page" },
-      { title: "Applying for pre-settled and settled status", url: "/immigration/applying-for-settled-status" },
-      { title: "Updating and proving your pre-settled or settled status", url: "/immigration/viewing-your-pre-settled-or-settled-status" },
-      { title: "Switching from pre-settled to settled status", url: "/immigration/switching-from-pre-settled-to-settled-status" },
-      { title: "Problems with your settled status decision", url: "/immigration/problems-with-your-settled-status-decision" }
-    ]
-  end
-
-  context "when default options are present" do
+  context "with default arguments" do
     before do
-      render_inline(
-        described_class.new(
-          title: "Related Content",
-          section_title: "Applying to the EU settlement scheme",
-          section_title_url: "#"
-        )
+      render_inline described_class.new(
+        title: "Related Content",
+        section_title: "Applying to the EU settlement scheme",
+        section_title_url: "#"
       ) do |c|
-        c.section_links(section_links)
+        c.section_links(sample_section_links)
       end
     end
 
-    it "renders the title" do
-      expect(page).to have_text "Related Content"
-    end
+    it { is_expected.to have_selector "h2", text: "Related Content" }
 
-    it "renders the section title" do
-      expect(page).to have_text "Applying to the EU settlement scheme"
-    end
+    it { is_expected.to have_selector "h3", text: "Applying to the EU settlement scheme" }
 
     it "renders a link for each sibling" do
-      expect(page).to have_selector "[data-testid='section-links-link']", count: section_links.count
+      expect(page).to have_selector "[data-testid='section-links-link']", count: sample_section_links.count
     end
   end
 
   context "when custom content slot is present" do
     before do
-      render_inline(
-        described_class.new(
-          title: "Related Content",
-          section_title: "Applying to the EU settlement scheme",
-          section_title_url: "#"
-        )
+      render_inline described_class.new(
+        title: "Related Content",
+        section_title: "Applying to the EU settlement scheme",
+        section_title_url: "#"
       ) do |c|
         c.section_links(additional_attribute_links)
         c.custom_content { "Example content" }
@@ -72,12 +44,10 @@ RSpec.describe CitizensAdviceComponents::SectionLinks, type: :component do
     before do
       allow(ActiveSupport::Deprecation).to receive(:warn)
 
-      render_inline(
-        described_class.new(
-          title: "Related Content",
-          section_title: "Applying to the EU settlement scheme",
-          section_title_url: "#"
-        )
+      render_inline described_class.new(
+        title: "Related Content",
+        section_title: "Applying to the EU settlement scheme",
+        section_title_url: "#"
       ) do |c|
         c.section_links(additional_attribute_links)
         "Example content"
@@ -95,65 +65,82 @@ RSpec.describe CitizensAdviceComponents::SectionLinks, type: :component do
   end
 
   context "when additional link attributes are present" do
-    subject(:component) do
+    before do
       render_inline described_class.new(title: "Related Content", section_title: "Applying to the EU settlement scheme") do |c|
         c.section_links(additional_attribute_links)
-        c.custom_content { "Example content" }
       end
     end
 
     it "renders the additional attributes" do
-      expect(component.css("[data-testid='section-links-link']")).to have_selector "[aria-current='page']"
+      expect(page).to have_selector "[data-testid='section-links-link'][aria-current='page']"
     end
   end
 
   context "when only section links are present" do
-    subject(:component) do
+    before do
       render_inline described_class.new(title: nil, section_title: nil, section_title_url: nil) do |c|
-        c.section_links(section_links)
+        c.section_links(sample_section_links)
       end
     end
 
-    it "renders the component" do
-      expect(component.at(".cads-section-links")).to be_present
-    end
+    it { is_expected.to have_selector ".cads-section-links" }
   end
 
   context "when only section title is present" do
-    subject(:component) do
+    before do
       render_inline described_class.new(title: nil, section_title: "Applying to the EU settlement scheme", section_title_url: nil) do |c|
         c.section_links(nil)
       end
     end
 
-    it "renders the component" do
-      expect(component.at(".cads-section-links")).to be_present
-    end
+    it { is_expected.to have_selector ".cads-section-links" }
   end
 
   context "when only content is present" do
-    subject(:component) do
+    before do
       render_inline described_class.new(title: nil, section_title: nil, section_title_url: nil) do |c|
         c.section_links(nil)
         c.custom_content { "Example content" }
       end
     end
 
-    it "renders the component" do
-      expect(component.at(".cads-section-links")).to be_present
-    end
+    it { is_expected.to have_selector ".cads-section-links" }
   end
 
   context "when no section title url present" do
-    subject(:component) do
+    before do
       render_inline described_class.new(title: "Related Content", section_title: "Applying to the EU settlement scheme") do |c|
-        c.section_links(section_links)
+        c.section_links(sample_section_links)
         c.custom_content { "Example content" }
       end
     end
 
     it "does not render section title as a link" do
-      expect(component.at("[data-testid='section-title-link']")).not_to be_present
+      expect(page).to have_no_selector "[data-testid='section-title-link']"
     end
+  end
+
+  private
+
+  def sample_section_links
+    [
+      { title: "Preparing to apply for pre-settled and settled status",
+        url: "/immigration/preparing-to-apply-for-pre-settled-and-settled-status" },
+      { title: "Applying for pre-settled and settled status", url: "/immigration/applying-for-settled-status" },
+      { title: "Updating and proving your pre-settled or settled status", url: "/immigration/viewing-your-pre-settled-or-settled-status" },
+      { title: "Switching from pre-settled to settled status", url: "/immigration/switching-from-pre-settled-to-settled-status" },
+      { title: "Problems with your settled status decision", url: "/immigration/problems-with-your-settled-status-decision" }
+    ]
+  end
+
+  def additional_attribute_links
+    [
+      { title: "Preparing to apply for pre-settled and settled status",
+        url: "/immigration/preparing-to-apply-for-pre-settled-and-settled-status", "aria-current": "page" },
+      { title: "Applying for pre-settled and settled status", url: "/immigration/applying-for-settled-status" },
+      { title: "Updating and proving your pre-settled or settled status", url: "/immigration/viewing-your-pre-settled-or-settled-status" },
+      { title: "Switching from pre-settled to settled status", url: "/immigration/switching-from-pre-settled-to-settled-status" },
+      { title: "Problems with your settled status decision", url: "/immigration/problems-with-your-settled-status-decision" }
+    ]
   end
 end

--- a/engine/spec/components/citizens_advice_components/success_message_spec.rb
+++ b/engine/spec/components/citizens_advice_components/success_message_spec.rb
@@ -1,26 +1,21 @@
 # frozen_string_literal: true
 
 RSpec.describe CitizensAdviceComponents::SuccessMessage, type: :component do
-  subject(:component) do
-    rendered = render_inline(described_class.new(message: message))
-    rendered.at(".cads-success-message")
-  end
+  subject { page }
 
-  let(:message) { "Thank you for your feedback" }
+  context "with default arguments" do
+    before do
+      render_inline described_class.new(message: "Thank you for your feedback")
+    end
 
-  it "renders message" do
-    expect(component.text.strip).to include message
-  end
+    it { is_expected.to have_selector ".cads-success-message", text: "Thank you for your feedback" }
 
-  it "renders aria-live region" do
-    expect(component.attr("aria-live")).to eq "polite"
+    it { is_expected.to have_selector "[aria-live=polite]" }
   end
 
   context "when no message present" do
-    let(:message) { nil }
+    before { render_inline described_class.new(message: nil) }
 
-    it "does not render" do
-      expect(component).not_to be_present
-    end
+    it { is_expected.to have_no_selector ".cads-success-message" }
   end
 end

--- a/engine/spec/components/citizens_advice_components/table_spec.rb
+++ b/engine/spec/components/citizens_advice_components/table_spec.rb
@@ -1,79 +1,94 @@
 # frozen_string_literal: true
 
 RSpec.describe CitizensAdviceComponents::Table, type: :component do
-  let(:sample_header) do
-    ["Your location", "Post box collection times"]
-  end
-
-  let(:sample_rows) do
-    [
-      ["City or town", "9am to 6.30pm"],
-      ["Areas with lots of businesses - known as commercial", "9am to 7.30pm"],
-      ["Very rural areas - for example, where there aren't many people", "9am to 4pm"],
-      ["Rest of the UK", "9am to 5.30pm"]
-    ]
-  end
+  subject { page }
 
   context "when missing headers" do
-    subject(:component) do
-      described_class.new(header: [], rows: sample_rows)
+    before do
+      render_inline described_class.new(
+        header: [],
+        rows: sample_rows
+      )
     end
 
-    it "does not render" do
-      render_inline component
-      expect(page).to have_no_table
-    end
+    it { is_expected.to have_no_table }
   end
 
   context "when missing rows" do
-    subject(:component) do
-      described_class.new(header: sample_header, rows: [])
+    before do
+      render_inline described_class.new(
+        header: sample_header,
+        rows: []
+      )
     end
 
-    it "does not render" do
-      render_inline component
-      expect(page).to have_no_table
-    end
+    it { is_expected.to have_no_table }
   end
 
   context "when valid table" do
-    subject(:component) do
-      described_class.new(
+    before do
+      render_inline described_class.new(
         header: sample_header,
         rows: sample_rows
       )
     end
 
-    it "matches snapshot" do
-      expect(render_inline(component).to_html).to match_snapshot("table")
-    end
+    it { is_expected.to have_selector ".cads-table-container" }
+    it { is_expected.to have_selector ".cads-table" }
+    it { is_expected.to have_no_selector "caption" }
+
+    it { is_expected.to have_selector "thead", count: 1 }
+    it { is_expected.to have_selector "tbody", count: 1 }
+
+    it { is_expected.to have_selector "th", count: sample_header.size }
+    it { is_expected.to have_selector "th[scope=col]", text: "Your location" }
+    it { is_expected.to have_selector "th[scope=col]", text: "Post box collection times" }
+    it { is_expected.to have_selector ".cads-table__th-heading", text: "Your location", count: sample_rows.size }
+    it { is_expected.to have_selector ".cads-table__th-heading", text: "Post box collection time", count: sample_rows.size }
+
+    it { is_expected.to have_selector "tbody tr", count: sample_rows.size }
+    it { is_expected.to have_selector "tbody td", count: sample_rows.size * 2 }
+    it { is_expected.to have_selector "td", text: "City or town" }
+    it { is_expected.to have_selector "td", text: "9am to 6.30pm" }
   end
 
   context "when a caption is present" do
-    subject(:component) do
-      described_class.new(
+    before do
+      render_inline described_class.new(
         header: sample_header,
         rows: sample_rows,
         caption: "Example caption"
       )
     end
 
-    it "renders a caption" do
-      render_inline component
-      expect(page).to have_selector "caption", text: "Example caption"
-    end
+    it { is_expected.to have_selector "caption", text: "Example caption" }
   end
 
   context "when additional empty rows" do
-    subject(:component) do
-      described_class.new(
+    before do
+      render_inline described_class.new(
         header: sample_header,
         rows: sample_rows.concat([["", ""], [nil, nil], ["", nil]])
       )
     end
 
     it "strips empty rows" do
-      expect(render_inline(component).to_html).to match_snapshot("table")
+      expect(page).to have_selector "tbody tr", count: sample_rows.size
     end
+  end
+
+  private
+
+  def sample_header
+    ["Your location", "Post box collection times"]
+  end
+
+  def sample_rows
+    [
+      ["City or town", "9am to 6.30pm"],
+      ["Areas with lots of businesses - known as commercial", "9am to 7.30pm"],
+      ["Very rural areas - for example, where there aren't many people", "9am to 4pm"],
+      ["Rest of the UK", "9am to 5.30pm"]
+    ]
   end
 end

--- a/engine/spec/components/citizens_advice_components/text_input_spec.rb
+++ b/engine/spec/components/citizens_advice_components/text_input_spec.rb
@@ -1,53 +1,185 @@
 # frozen_string_literal: true
 
 RSpec.describe CitizensAdviceComponents::TextInput, type: :component do
-  subject(:component) do
-    render_inline described_class.new(
-      name: name.presence,
-      label: label.presence,
-      type: type.presence,
-      width: width.presence
-    )
+  subject { page }
+
+  context "with default arguments" do
+    before do
+      render_inline described_class.new(
+        name: "example-input",
+        label: "Example input",
+        type: :text
+      )
+    end
+
+    it { is_expected.to have_field "Example input", type: :text }
+
+    it "links the label to the input" do
+      expect(page).to have_selector "label[for=example-input-input]"
+    end
+
+    it "adds the correct id to the input" do
+      expect(page).to have_selector "#example-input-input"
+    end
+
+    it "includes required attribute" do
+      expect(page).to have_selector "input[required]"
+    end
+
+    it "does not have an aria-describedby attribute by default" do
+      expect(page).to have_no_selector "input[aria-describedby]"
+    end
   end
 
-  let(:name) { "example-input" }
-  let(:label) { "Example input" }
-  let(:type) { :text }
-  let(:width) { nil }
+  context "when a value is provided" do
+    before do
+      render_inline described_class.new(
+        name: "example-input",
+        label: "Example input",
+        type: :text,
+        options: { value: "Example value" }
+      )
+    end
 
-  it "renders a text input" do
-    expect(component.css("input").attribute("type").value).to eq("text")
+    it { is_expected.to have_field "Example input", with: "Example value" }
   end
 
-  it "renders a full width version" do
-    expect(component.css("input").attribute("class").value).to eq("cads-input")
+  context "when a valid type is specified" do
+    before do
+      render_inline described_class.new(
+        name: "example-input",
+        label: "Example input",
+        type: :email
+      )
+    end
+
+    it { is_expected.to have_field "Example input", type: :email }
+  end
+
+  context "when an invalid type is specified" do
+    before do
+      without_fetch_or_fallback_raises do
+        render_inline described_class.new(
+          name: "example-input",
+          label: "Example input",
+          type: :invalid
+        )
+      end
+    end
+
+    it "renders a text input" do
+      expect(page).to have_field "Example input", type: :text
+    end
+  end
+
+  context "when the input is optional" do
+    before do
+      render_inline described_class.new(
+        name: "example-input",
+        label: "Example input",
+        type: :text,
+        options: { optional: true }
+      )
+    end
+
+    it { is_expected.to have_text "(optional)" }
+
+    it "does not add required to the input" do
+      expect(page).to have_no_selector "input[required]"
+    end
+
+    context "when in Cymraeg" do
+      around { |example| I18n.with_locale(:cy) { example.run } }
+
+      it { is_expected.to have_text "(dewisol)" }
+    end
+  end
+
+  context "when an error is present" do
+    before do
+      render_inline described_class.new(
+        name: "example-input",
+        label: "Example input",
+        type: :text,
+        options: { error_message: "Enter your name" }
+      )
+    end
+
+    it { is_expected.to have_selector "#example-input-error", text: "Enter your name" }
+    it { is_expected.to have_selector "input[aria-invalid]" }
+    it { is_expected.to have_selector "input[aria-describedby=example-input-error]" }
+  end
+
+  context "when there is hint text" do
+    before do
+      render_inline described_class.new(
+        name: "example-input",
+        label: "Example input",
+        type: :text,
+        options: { hint: "This is the hint text" }
+      )
+    end
+
+    it { is_expected.to have_text "This is the hint text" }
+    it { is_expected.to have_selector "input[aria-describedby=example-input-hint]" }
+  end
+
+  context "when there is hint text and an error" do
+    before do
+      render_inline described_class.new(
+        name: "example-input",
+        label: "Example input",
+        type: :text,
+        options: { hint: "This is the hint text", error_message: "Enter your name" }
+      )
+    end
+
+    it { is_expected.to have_selector "input[aria-describedby='example-input-error example-input-hint']" }
+  end
+
+  context "when additional attributes are provided" do
+    before do
+      render_inline described_class.new(
+        name: "example-input",
+        label: "Example input",
+        type: :text,
+        options: { additional_attributes: { autocomplete: "name", "data-additional": "example" } }
+      )
+    end
+
+    it { is_expected.to have_selector "input[autocomplete=name]" }
+    it { is_expected.to have_selector "input[data-additional=example]" }
   end
 
   context "when a valid width is specified" do
-    let(:width) { :four_chars }
+    before do
+      render_inline described_class.new(
+        name: "example-input",
+        label: "Example input",
+        type: :text,
+        width: :four_chars
+      )
+    end
 
     it "renders the input at the correct width" do
-      expect(component.css(".cads-input--four-chars")).to be_present
+      expect(page).to have_selector ".cads-input--four-chars"
     end
   end
 
   context "when an invalid width is specified" do
-    let(:width) { "banana" }
-
-    it "renders a full width version" do
+    before do
       without_fetch_or_fallback_raises do
-        expect(component.css("input").attribute("class").value).to eq("cads-input")
+        render_inline described_class.new(
+          name: "example-input",
+          label: "Example input",
+          type: :text,
+          width: :invalid
+        )
       end
     end
-  end
 
-  context "when an invalid type is specified" do
-    let(:type) { :date }
-
-    it "renders a text input" do
-      without_fetch_or_fallback_raises do
-        expect(component.css("input").attribute("type").value).to eq("text")
-      end
+    it "renders a full width version" do
+      expect(page).to have_selector ".cads-input"
     end
   end
 end

--- a/engine/spec/components/citizens_advice_components/textarea_spec.rb
+++ b/engine/spec/components/citizens_advice_components/textarea_spec.rb
@@ -1,64 +1,168 @@
 # frozen_string_literal: true
 
 RSpec.describe CitizensAdviceComponents::Textarea, type: :component do
-  subject(:component) do
-    render_inline described_class.new(
-      name: name.presence,
-      label: label.presence,
-      type: type.presence
-    )
-  end
+  subject { page }
 
-  let(:name) { "example-input" }
-  let(:label) { "Example input" }
-  let(:type) { nil }
-
-  it "renders a text area" do
-    expect(component.css("textarea")).to be_present
-  end
-
-  it "renders 8 rows" do
-    expect(component.css("textarea").attribute("rows").value).to eq("8")
-  end
-
-  context "when a type is specified" do
-    let(:type) { :email }
-
-    it "does not render the type attribute" do
-      expect(component.css("textarea").attribute("type")).to be_nil
-    end
-  end
-
-  context "when a valid number of rows is specified" do
-    subject(:component) do
+  context "with default arguments" do
+    before do
       render_inline described_class.new(
-        name: name.presence,
-        label: label.presence,
-        type: type.presence,
-        rows: rows.presence
+        name: "example-textarea",
+        label: "Example textarea"
       )
     end
 
-    let(:rows) { 10 }
+    it "links the label to the input" do
+      expect(page).to have_selector "label[for=example-textarea-input]"
+    end
+
+    it "adds the correct id to the input" do
+      expect(page).to have_selector "#example-textarea-input"
+    end
+
+    it "includes required attribute" do
+      expect(page).to have_selector "textarea[required]"
+    end
+
+    it "does not have an aria-describedby attribute by default" do
+      expect(page).to have_no_selector "textarea[aria-describedby]"
+    end
+
+    it "renders a textarea with 8 rows" do
+      expect(page).to have_selector "textarea[rows=8]"
+    end
+  end
+
+  context "when a value is provided" do
+    before do
+      render_inline described_class.new(
+        name: "example-textarea",
+        label: "Example textarea",
+        options: { value: "Example value" }
+      )
+    end
+
+    it { is_expected.to have_field "Example textarea", with: "Example value" }
+
+    it "does not set value as attribute" do
+      expect(page).to have_no_selector "textarea[value='Example value']"
+    end
+  end
+
+  context "when the textarea is optional" do
+    before do
+      render_inline described_class.new(
+        name: "example-textarea",
+        label: "Example textarea",
+        options: { optional: true }
+      )
+    end
+
+    it { is_expected.to have_text "(optional)" }
+
+    it "does not add required to the input" do
+      expect(page).to have_no_selector "textarea[required]"
+    end
+
+    context "when in Cymraeg" do
+      around { |example| I18n.with_locale(:cy) { example.run } }
+
+      it { is_expected.to have_text "(dewisol)" }
+    end
+  end
+
+  context "when an error is present" do
+    before do
+      render_inline described_class.new(
+        name: "example-textarea",
+        label: "Example textarea",
+        options: { error_message: "Enter your name" }
+      )
+    end
+
+    it { is_expected.to have_selector "#example-textarea-error", text: "Enter your name" }
+    it { is_expected.to have_selector "textarea[aria-invalid=true]" }
+    it { is_expected.to have_selector "textarea[aria-describedby=example-textarea-error]" }
+  end
+
+  context "when there is hint text" do
+    before do
+      render_inline described_class.new(
+        name: "example-textarea",
+        label: "Example textarea",
+        options: { hint: "This is the hint text" }
+      )
+    end
+
+    it { is_expected.to have_text "This is the hint text" }
+    it { is_expected.to have_selector "textarea[aria-describedby=example-textarea-hint]" }
+  end
+
+  context "when there is hint text and an error" do
+    before do
+      render_inline described_class.new(
+        name: "example-textarea",
+        label: "Example textarea",
+        options: { hint: "This is the hint text", error_message: "Enter your name" }
+      )
+    end
+
+    it { is_expected.to have_selector "textarea[aria-describedby='example-textarea-error example-textarea-hint']" }
+  end
+
+  context "when a type is specified" do
+    before do
+      render_inline described_class.new(
+        name: "example-textarea",
+        label: "Example textarea",
+        type: :email
+      )
+    end
+
+    it "does not render the type attribute" do
+      expect(page).to have_no_selector "textarea[type]"
+    end
+  end
+
+  context "when additional attributes are provided" do
+    before do
+      render_inline described_class.new(
+        name: "example-textarea",
+        label: "Example textarea",
+        options: { additional_attributes: { autocomplete: "name", "data-additional": "example" } }
+      )
+    end
+
+    it { is_expected.to have_selector "textarea[autocomplete=name]" }
+    it { is_expected.to have_selector "textarea[data-additional=example]" }
+  end
+
+  context "when a valid number of rows is specified" do
+    before do
+      render_inline described_class.new(
+        name: "example-textarea",
+        label: "Example textarea",
+        rows: 10
+      )
+    end
 
     it "renders the textarea with the correct number of rows" do
-      expect(component.css("textarea").attribute("rows").value).to eq("10")
+      expect(page).to have_selector "textarea[rows=10]"
     end
   end
 
   context "when an invalid number of rows is specified" do
-    subject(:component) do
+    before do
       render_inline described_class.new(
-        name: name.presence,
-        label: label.presence,
-        rows: rows.presence
+        name: "example-textarea",
+        label: "Example textarea",
+        rows: "invalid"
       )
     end
 
     let(:rows) { "banana" }
 
     it "renders the default number of rows" do
-      expect(component.css("textarea").attribute("rows").value).to eq("8")
+      expect(page).to have_selector "textarea[rows=8]"
     end
   end
 end

--- a/engine/spec/spec_helper.rb
+++ b/engine/spec/spec_helper.rb
@@ -24,6 +24,9 @@ module TestHelpers
   end
 end
 
+# enable [aria-label] support for field finders
+Capybara.enable_aria_label = true
+
 RSpec.configure do |config|
   config.include ActiveSupport::Testing::TimeHelpers
   config.include ViewComponent::TestHelpers, type: :component


### PR DESCRIPTION
Does a bit of clean up on the component specs, mainly to:

1. Convert remaining specs to use capybara matchers
2. Fix rubocop warnings in locale specific tests
3. Clarify any scenarios where the previous specs were misleading

Includes a few notable updates:

**Checkbox group specs**

Splits out the optional arguments scenarios into multiple blocks. In the process clarifies that the layout and size options don't apply to checkbox groups, only radio groups.

**Radio group specs**

Expands specs to cover the same scenarios as checkbox groups. Whilst they inherit a base class they are ultimately separate interfaces so we should test both fully. Expands specs for layout and size options which are unique to radio groups.

**Text input and textarea specs**

Expands text input and textarea specs to cover the same scenarios as the base input class. Whilst they inherit a base class they are ultimately separate interfaces so we should test both fully. This ultimately allows us more flexibility if we need to decouple their interfaces in future.

**Targeted content specs**

Fixes an issue where the no content scenario tested against the callout component by mistake.

**Table specs**

Remove rspec-snapshot. This is the only set of specs that uses it so we are better off replacing this with more explicit matchers.

---

This is a fairly substantial clean up so I can absolutely extract some of these changes out into smaller pull requests if we prefer.