### PR TITLE
Pin rails-i18n version

### DIFF
--- a/demo/Gemfile.lock
+++ b/demo/Gemfile.lock
@@ -12,7 +12,7 @@ PATH
   specs:
     citizens_advice_components (0.1.0)
       actionpack (>= 6.0.0, < 8.0)
-      rails-i18n (>= 6.0.0, < 8.0)
+      rails-i18n (= 7.0.5)
       railties (>= 6.0.0, < 8.0)
       view_component (>= 2.0.0, < 3.0)
 
@@ -170,7 +170,7 @@ GEM
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.4.3)
       loofah (~> 2.3)
-    rails-i18n (7.0.3)
+    rails-i18n (7.0.5)
       i18n (>= 0.7, < 2)
       railties (>= 6.0.0, < 8)
     railties (7.0.4)
@@ -219,8 +219,9 @@ GEM
     tzinfo (2.0.5)
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.3.0)
-    view_component (2.52.0)
+    view_component (2.75.0)
       activesupport (>= 5.0.0, < 8.0)
+      concurrent-ruby (~> 1.0)
       method_source (~> 1.0)
     web-console (4.2.0)
       actionview (>= 6.0.0)
@@ -230,7 +231,7 @@ GEM
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    zeitwerk (2.6.1)
+    zeitwerk (2.6.6)
 
 PLATFORMS
   ruby

--- a/design-system-docs/Gemfile
+++ b/design-system-docs/Gemfile
@@ -25,6 +25,11 @@ gem "puma", "~> 5.6"
 
 gem "citizens_advice_components", path: "../engine"
 
+# @FIXME: Pin view_component to a fixed version due to
+# a view_component_path error in v2.75.0 when used with bridgetown
+# See: https://github.com/bridgetownrb/bridgetown-view-component/issues/3
+gem "view_component", "2.74.1"
+
 group :bridgetown_plugins do
   gem "bridgetown-seo-tag"
   gem "bridgetown-view-component", "~> 1.0"

--- a/design-system-docs/Gemfile.lock
+++ b/design-system-docs/Gemfile.lock
@@ -12,7 +12,7 @@ PATH
   specs:
     citizens_advice_components (0.1.0)
       actionpack (>= 6.0.0, < 8.0)
-      rails-i18n (>= 6.0.0, < 8.0)
+      rails-i18n (= 7.0.5)
       railties (>= 6.0.0, < 8.0)
       view_component (>= 2.0.0, < 3.0)
 
@@ -125,7 +125,7 @@ GEM
     listen (3.7.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
-    loofah (2.18.0)
+    loofah (2.19.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     method_source (1.0.0)
@@ -153,7 +153,7 @@ GEM
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.4.3)
       loofah (~> 2.3)
-    rails-i18n (7.0.3)
+    rails-i18n (7.0.5)
       i18n (>= 0.7, < 2)
       railties (>= 6.0.0, < 8)
     railties (7.0.3.1)
@@ -199,11 +199,12 @@ GEM
     tzinfo (2.0.5)
       concurrent-ruby (~> 1.0)
     unicode-display_width (1.8.0)
-    view_component (2.52.0)
+    view_component (2.75.0)
       activesupport (>= 5.0.0, < 8.0)
+      concurrent-ruby (~> 1.0)
       method_source (~> 1.0)
     webrick (1.7.0)
-    zeitwerk (2.6.0)
+    zeitwerk (2.6.6)
 
 PLATFORMS
   ruby
@@ -220,4 +221,4 @@ DEPENDENCIES
   puma (~> 5.6)
 
 BUNDLED WITH
-   2.2.31
+   2.3.21

--- a/design-system-docs/Gemfile.lock
+++ b/design-system-docs/Gemfile.lock
@@ -199,7 +199,7 @@ GEM
     tzinfo (2.0.5)
       concurrent-ruby (~> 1.0)
     unicode-display_width (1.8.0)
-    view_component (2.75.0)
+    view_component (2.74.1)
       activesupport (>= 5.0.0, < 8.0)
       concurrent-ruby (~> 1.0)
       method_source (~> 1.0)
@@ -219,6 +219,7 @@ DEPENDENCIES
   htmlbeautifier
   nokogiri
   puma (~> 5.6)
+  view_component (= 2.74.1)
 
 BUNDLED WITH
    2.3.21

--- a/engine/Gemfile.lock
+++ b/engine/Gemfile.lock
@@ -12,7 +12,7 @@ PATH
   specs:
     citizens_advice_components (0.1.0)
       actionpack (>= 6.0.0, < 8.0)
-      rails-i18n (>= 6.0.0, < 8.0)
+      rails-i18n (= 7.0.5)
       railties (>= 6.0.0, < 8.0)
       view_component (>= 2.0.0, < 3.0)
 
@@ -199,4 +199,4 @@ DEPENDENCIES
   rubocop-rspec
 
 BUNDLED WITH
-   2.1.4
+   2.3.21

--- a/engine/citizens_advice_components.gemspec
+++ b/engine/citizens_advice_components.gemspec
@@ -28,6 +28,9 @@ Gem::Specification.new do |spec|
     spec.add_runtime_dependency rails_lib, [">= 6.0.0", "< 8.0"]
   end
 
-  spec.add_runtime_dependency     "rails-i18n", [">= 6.0.0", "< 8.0"]
-  spec.add_runtime_dependency     "view_component", [">= 2.0.0", "< 3.0"]
+  # rails-i18n is pinned to 7.0.5 as 7.0.6 removes welsh language locales
+  # due to lack of support. We only use these locales for basic date formats
+  # so we could inline the parts we need and remove this dependency in future.
+  spec.add_runtime_dependency "rails-i18n", "7.0.5"
+  spec.add_runtime_dependency "view_component", [">= 2.0.0", "< 3.0"]
 end


### PR DESCRIPTION
Pin rails-i18n to 7.0.5 as 7.0.6 removes welsh language locales due to lack of support. We only use these locales for basic date formats so we could inline the parts we need and remove this dependency in future.

Fixes the broken build.