### PR TITLE
Bundle Welsh translations for date formats

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -7,11 +7,6 @@ CHANGELOG.md
 docs/
 lib/
 
-# Ignore locale files from prettier
-# formatted by i18n-tasks
-/engine/config/locales/
-/demo/config/locales/
-
 # Ignore Rails demo app files
 /demo/public/
 /demo/visual-regression/backstop_data/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
-
 **Bugfixes**
 
 - On this page: Fix css columns overflow bug with expandable on this-page elements.
+- Bundle Welsh translations for core date formats. The rails-i18n gem historically provided these but the cy locale was removed in `7.0.6` due to lack of support
 
 ## v5.5.0-alpha.2
 

--- a/demo/Gemfile.lock
+++ b/demo/Gemfile.lock
@@ -12,7 +12,6 @@ PATH
   specs:
     citizens_advice_components (0.1.0)
       actionpack (>= 6.0.0, < 8.0)
-      rails-i18n (= 7.0.5)
       railties (>= 6.0.0, < 8.0)
       view_component (>= 2.0.0, < 3.0)
 
@@ -175,9 +174,6 @@ GEM
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.4.4)
       loofah (~> 2.19, >= 2.19.1)
-    rails-i18n (7.0.5)
-      i18n (>= 0.7, < 2)
-      railties (>= 6.0.0, < 8)
     railties (7.0.4)
       actionpack (= 7.0.4)
       activesupport (= 7.0.4)

--- a/design-system-docs/Gemfile.lock
+++ b/design-system-docs/Gemfile.lock
@@ -12,7 +12,6 @@ PATH
   specs:
     citizens_advice_components (0.1.0)
       actionpack (>= 6.0.0, < 8.0)
-      rails-i18n (= 7.0.5)
       railties (>= 6.0.0, < 8.0)
       view_component (>= 2.0.0, < 3.0)
 
@@ -153,9 +152,6 @@ GEM
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.4.4)
       loofah (~> 2.19, >= 2.19.1)
-    rails-i18n (7.0.5)
-      i18n (>= 0.7, < 2)
-      railties (>= 6.0.0, < 8)
     railties (7.0.3.1)
       actionpack (= 7.0.3.1)
       activesupport (= 7.0.3.1)

--- a/engine/Gemfile.lock
+++ b/engine/Gemfile.lock
@@ -12,7 +12,6 @@ PATH
   specs:
     citizens_advice_components (0.1.0)
       actionpack (>= 6.0.0, < 8.0)
-      rails-i18n (= 7.0.5)
       railties (>= 6.0.0, < 8.0)
       view_component (>= 2.0.0, < 3.0)
 

--- a/engine/citizens_advice_components.gemspec
+++ b/engine/citizens_advice_components.gemspec
@@ -28,9 +28,5 @@ Gem::Specification.new do |spec|
     spec.add_runtime_dependency rails_lib, [">= 6.0.0", "< 8.0"]
   end
 
-  # rails-i18n is pinned to 7.0.5 as 7.0.6 removes welsh language locales
-  # due to lack of support. We only use these locales for basic date formats
-  # so we could inline the parts we need and remove this dependency in future.
-  spec.add_runtime_dependency "rails-i18n", "7.0.5"
   spec.add_runtime_dependency "view_component", [">= 2.0.0", "< 3.0"]
 end

--- a/engine/config/i18n-tasks.yml
+++ b/engine/config/i18n-tasks.yml
@@ -19,3 +19,10 @@ search:
     - 'app/components'
   relative_roots:
     - 'app/components'
+
+# Ignore core locale translations from linting rules as
+# they are already included by Rails for the default en locale.
+ignore_missing:
+  - 'date.*'
+ignore_unused:
+  - 'date.*'

--- a/engine/config/locales/cy.yml
+++ b/engine/config/locales/cy.yml
@@ -44,3 +44,64 @@ cy:
       close_label: Cau
       descriptive_label_hide: cau’r adran hon
       descriptive_label_show: dangos yr adran hon
+
+  # The rails-i18n gem historically provided these but
+  # the cy locale was removed in 7.0.6 due to lack of support.
+  # See https://github.com/svenfuchs/rails-i18n/pull/1007
+  #
+  # As we only need a small set of translations for date
+  # formatted provided by design system components we bundle
+  # the necessary translations ourselves.
+  date:
+    abbr_day_names:
+      - Sul
+      - Llun
+      - Maw
+      - Mer
+      - Iau
+      - Gwe
+      - Sad
+    abbr_month_names:
+      -
+      - Ion
+      - Chw
+      - Maw
+      - Ebr
+      - Mai
+      - Meh
+      - Gor
+      - Awst
+      - Med
+      - Hyd
+      - Tach
+      - Rha
+    day_names:
+      - Dydd Sul
+      - Dydd Llun
+      - Dydd Mawrth
+      - Dydd Mercher
+      - Dydd Iau
+      - Dydd Gwener
+      - Dydd Sadwrn
+    formats:
+      default: '%d-%m-%Y'
+      long: '%d %B %Y'
+      short: '%d %b'
+    month_names:
+      -
+      - Ionawr
+      - Chwefror
+      - Mawrth
+      - Ebrill
+      - Mai
+      - Mehefin
+      - Gorffennaf
+      - Awst
+      - Medi
+      - Hydref
+      - Tachwedd
+      - Rhagfyr
+    order:
+      - :year
+      - :month
+      - :day

--- a/engine/lib/citizens_advice_components/engine.rb
+++ b/engine/lib/citizens_advice_components/engine.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "rails/engine"
-require "rails-i18n"
 require "view_component"
 
 module CitizensAdviceComponents

--- a/engine/spec/i18n_spec.rb
+++ b/engine/spec/i18n_spec.rb
@@ -18,14 +18,6 @@ RSpec.describe I18n do
                            "#{unused_keys.leaves.count} unused i18n keys, run `i18n-tasks unused' to show them"
   end
 
-  it "files are normalized" do
-    non_normalized = i18n.non_normalized_paths
-    error_message = "The following files need to be normalized:\n" \
-                    "#{non_normalized.map { |path| "  #{path}" }.join("\n")}\n" \
-                    "Please run `i18n-tasks normalize' to fix"
-    expect(non_normalized).to be_empty, error_message
-  end
-
   it "does not have inconsistent interpolations" do
     error_message = "#{inconsistent_interpolations.leaves.count} i18n keys have inconsistent interpolations.\n" \
                     "Run `i18n-tasks check-consistent-interpolations' to show them"


### PR DESCRIPTION
The rails-i18n gem historically provided these but the cy locale was removed in 7.0.6 due to lack of support. See https://github.com/svenfuchs/rails-i18n/pull/1007

As we only need a small set of translations for date formatted provided by design system components we bundle the necessary translations ourselves.

Fixes #2478