### PR TITLE
Patch ViewComponent error in docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+**Bugfixes**
+
+- Includes a fix for ViewComponent `TypeError: no implicit conversion of nil into String` errors when used outside of Rails
+
 **New**
 
 - Input: Replace the `required` attribute on inputs with `aria-required`

--- a/design-system-docs/Gemfile
+++ b/design-system-docs/Gemfile
@@ -25,11 +25,6 @@ gem "puma", "~> 5.6"
 
 gem "citizens_advice_components", path: "../engine"
 
-# @FIXME: Pin view_component to a fixed version due to
-# a view_component_path error in v2.75.0 when used with bridgetown
-# See: https://github.com/bridgetownrb/bridgetown-view-component/issues/3
-gem "view_component", "2.74.1"
-
 group :bridgetown_plugins do
   gem "bridgetown-seo-tag"
   gem "bridgetown-view-component", "~> 1.0"

--- a/design-system-docs/Gemfile.lock
+++ b/design-system-docs/Gemfile.lock
@@ -219,7 +219,6 @@ DEPENDENCIES
   htmlbeautifier
   nokogiri
   puma (~> 5.6)
-  view_component (= 2.74.1)
 
 BUNDLED WITH
    2.3.21

--- a/engine/app/components/citizens_advice_components/base.rb
+++ b/engine/app/components/citizens_advice_components/base.rb
@@ -3,5 +3,10 @@
 module CitizensAdviceComponents
   class Base < ViewComponent::Base
     include FetchOrFallbackHelper
+
+    # Workaround for https://github.com/ViewComponent/view_component/issues/1565
+    def self.config
+      @config ||= ViewComponent::Config.defaults.merge(ViewComponent::Base.config)
+    end
   end
 end


### PR DESCRIPTION
Includes a patch for ViewComponent `TypeError: no implicit conversion of nil into String` errors when used in the docs site (outside of Rails).

Avoids us needing to pin the version. Although not sure if it's better to just keep the version pinned for a while vs. patching the core design-system package 🤔 