### PR TITLE
Remove rails main from test matrix

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -25,7 +25,7 @@ jobs:
       fail-fast: false
       matrix:
         ruby_version: ['2.7', '3.0', '3.1']
-        rails_version: ['6.0.6', '6.1.7', '7.0.4', 'main']
+        rails_version: ['6.0.6', '6.1.7', '7.0.4']
         exclude:
           - rails_version: '6.0.6'
             ruby_version: '3.0'


### PR DESCRIPTION
There's a downstream issue with the edge version of rails that is causing our builds to fail.

Given that for our use case we have a relatively small number of known consumers and know the exact rails versions they all run we probably don't need to be testing against the bleeding-edge version of rails.

Removing it should fix the current build failures.