### PR TITLE
Docs: Update viewcomponent version

### DIFF
--- a/design-system-docs/Gemfile
+++ b/design-system-docs/Gemfile
@@ -25,10 +25,11 @@ gem "puma", "~> 5.6"
 
 gem "citizens_advice_components", path: "../engine"
 
-# @FIXME: Pin view_component to a fixed version due to
-# a view_component_path error in v2.75.0 when used with bridgetown
-# See: https://github.com/bridgetownrb/bridgetown-view-component/issues/3
-gem "view_component", "2.74.1"
+# ViewComponent contained an error when used with bridgetown
+# between versions  v2.75.0  and  v2.81.0. Make sure we are using a version
+# that includes https://github.com/ViewComponent/view_component/pull/1626
+# Original issues: https://github.com/bridgetownrb/bridgetown-view-component/issues/3
+gem "view_component", "~> 2.82.0"
 
 group :bridgetown_plugins do
   gem "bridgetown-seo-tag"

--- a/design-system-docs/Gemfile.lock
+++ b/design-system-docs/Gemfile.lock
@@ -195,8 +195,8 @@ GEM
     tzinfo (2.0.5)
       concurrent-ruby (~> 1.0)
     unicode-display_width (1.8.0)
-    view_component (2.74.1)
-      activesupport (>= 5.0.0, < 8.0)
+    view_component (2.82.0)
+      activesupport (>= 5.2.0, < 8.0)
       concurrent-ruby (~> 1.0)
       method_source (~> 1.0)
     webrick (1.7.0)
@@ -215,7 +215,7 @@ DEPENDENCIES
   htmlbeautifier
   nokogiri
   puma (~> 5.6)
-  view_component (= 2.74.1)
+  view_component (~> 2.82.0)
 
 BUNDLED WITH
    2.3.21

--- a/engine/Gemfile.lock
+++ b/engine/Gemfile.lock
@@ -167,7 +167,7 @@ GEM
     tzinfo (2.0.5)
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.3.0)
-    view_component (2.80.0)
+    view_component (2.82.0)
       activesupport (>= 5.2.0, < 8.0)
       concurrent-ruby (~> 1.0)
       method_source (~> 1.0)


### PR DESCRIPTION
Updates the pinned version of viewcomponent to specify anything after 2.82.0 which fixes the regression when used outside of Rails.
