### PR TITLE
feat: trying to verify google search console

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -16,3 +16,4 @@ lib/
 /design-system-docs/.bridgetown-webpack/
 /design-system-docs/.bridgetown-cache/
 /design-system-docs/src/_data/colour_language.json
+/design-system-docs/src/google72951c9396a77d88.html

--- a/design-system-docs/src/google72951c9396a77d88.html
+++ b/design-system-docs/src/google72951c9396a77d88.html
@@ -1,0 +1,1 @@
+google-site-verification: google72951c9396a77d88.html


### PR DESCRIPTION
We've been having some alerts about dangerous content from Chrome and Firefox. We can use google search console to investigate and submit our site for review. We need to verify the site ownership. I'm not 100% this will work because we're currently using netlify subdomain, but I want to try to see what will happen with HTML file upload for verification. I'll remove the file once we finish the verification. 