### PR TITLE
Feat/site indexing

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -16,4 +16,3 @@ lib/
 /design-system-docs/.bridgetown-webpack/
 /design-system-docs/.bridgetown-cache/
 /design-system-docs/src/_data/colour_language.json
-/design-system-docs/src/google72951c9396a77d88.html

--- a/design-system-docs/src/_layouts/default.erb
+++ b/design-system-docs/src/_layouts/default.erb
@@ -4,7 +4,6 @@
     <meta charset="utf-8" />
     <%= seo %>
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta name="robots" content="noindex, nofollow">
     <meta name="format-detection" content="telephone=no">
     <link href="<%= webpack_path("fonts/open-sans-v26-latin-700.woff2") %>" rel="preload" as="font" type="font/woff2" crossorigin="true" />
     <link href="<%= webpack_path("fonts/open-sans-v26-latin-regular.woff2") %>" rel="preload" as="font" type="font/woff2" crossorigin="true" />

--- a/design-system-docs/src/google72951c9396a77d88.html
+++ b/design-system-docs/src/google72951c9396a77d88.html
@@ -1,1 +1,0 @@
-google-site-verification: google72951c9396a77d88.html


### PR DESCRIPTION
We've added the design system site to the Google Search Console. This is a follow up PR that:
- removes the file that we needed to initially verify the site
- removes the `noindex, nofollow` meta tag, flagged by the Search Console. Removed it from the design system default layout pages but intentionally left it on the component_example pages.