### PR TITLE
Feat/custom legal summary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+**New**
+
+- Footer: allows customising the `legal_summary`
+
 ## v5.5.0-alpha.3
 
 ### 6 January 2023

--- a/demo/spec/components/previews/footer_preview.rb
+++ b/demo/spec/components/previews/footer_preview.rb
@@ -64,8 +64,9 @@ class FooterPreview < ViewComponent::Preview
   end
 
   def custom_legal_summary
-    render CitizensAdviceComponents::Footer.new(legal_summary: legal_summary_text) do |c|
+    render CitizensAdviceComponents::Footer.new do |c|
       c.feedback_link(url: "https://www.research.net/r/J8PLH2H", external: true, new_tab: true)
+      c.legal_summary_slot(text: legal_summary_text)
     end
   end
 

--- a/demo/spec/components/previews/footer_preview.rb
+++ b/demo/spec/components/previews/footer_preview.rb
@@ -63,7 +63,19 @@ class FooterPreview < ViewComponent::Preview
     end
   end
 
+  def custom_legal_summary
+    render CitizensAdviceComponents::Footer.new(legal_summary: legal_summary_text) do |c|
+      c.feedback_link(url: "https://www.research.net/r/J8PLH2H", external: true, new_tab: true)
+    end
+  end
+
   def minimal
     render CitizensAdviceComponents::Footer.new
+  end
+
+  private
+
+  def legal_summary_text
+    "Custom legal summary text. Citizens Advice is an operating name of the National Association of Citizens Advice Bureaux. Registered charity number 279057. VAT number 726 0202 76. Company limited by guarantee. Registered number 01436945 England. Registered office: Citizens Advice, 3rd Floor North, 200 Aldersgate, London, EC1A 4HD."
   end
 end

--- a/demo/spec/components/previews/footer_preview.rb
+++ b/demo/spec/components/previews/footer_preview.rb
@@ -66,7 +66,7 @@ class FooterPreview < ViewComponent::Preview
   def custom_legal_summary
     render CitizensAdviceComponents::Footer.new do |c|
       c.feedback_link(url: "https://www.research.net/r/J8PLH2H", external: true, new_tab: true)
-      c.legal_summary_slot(text: legal_summary_text)
+      c.legal_summary(legal_summary_text)
     end
   end
 

--- a/design-system-docs/src/_component_docs/footer.md
+++ b/design-system-docs/src/_component_docs/footer.md
@@ -46,6 +46,8 @@ Each slot accepts the following named arguments:
 
 ### Legal summary slot
 
-The component accepts `legal_summary_slot` slot to render a customised legal summary. The slot accepts the following named arguments:
+The component accepts `legal_summary_slot` to render a customised legal summary. The slot accepts the following named argument:
 
 <%= render Shared::ArgumentsTable.new(:footer_legal_summary_slot) %>
+
+If the slot is not provided, the legal summary will display default text.

--- a/design-system-docs/src/_component_docs/footer.md
+++ b/design-system-docs/src/_component_docs/footer.md
@@ -43,3 +43,9 @@ end %>
 Each slot accepts the following named arguments:
 
 <%= render Shared::ArgumentsTable.new(:footer_column_slot) %>
+
+### Legal summary slot
+
+The component accepts `legal_summary_slot` slot to render a customised legal summary. The slot accepts the following named arguments:
+
+<%= render Shared::ArgumentsTable.new(:footer_legal_summary_slot) %>

--- a/design-system-docs/src/_component_docs/footer.md
+++ b/design-system-docs/src/_component_docs/footer.md
@@ -46,8 +46,6 @@ Each slot accepts the following named arguments:
 
 ### Legal summary slot
 
-The component accepts `legal_summary_slot` to render a customised legal summary. The slot accepts the following named argument:
-
-<%= render Shared::ArgumentsTable.new(:footer_legal_summary_slot) %>
+The component accepts `legal_summary` to render a customised text at the bottom of the footer. The slot requires a text string.
 
 If the slot is not provided, the legal summary will display default text.

--- a/design-system-docs/src/_data/component_arguments.yml
+++ b/design-system-docs/src/_data/component_arguments.yml
@@ -132,9 +132,6 @@ footer_column_slot:
     description: '→ Optional, is this an external link?'
   - argument: 'link[:new_tab]'
     description: '→ Optional, should this link open in a new tab?'
-footer_legal_summary_slot:
-  - argument: text
-    description: 'Required, legal summary text'
 navigation:
   - argument: links
     description: 'Required, an array of hashes, each with the following:'

--- a/design-system-docs/src/_data/component_arguments.yml
+++ b/design-system-docs/src/_data/component_arguments.yml
@@ -112,6 +112,8 @@ footer:
     description: '<strong>(Deprecated: use feedback_link slot)</strong> If present, a link to this feedback form will be displayed'
   - argument: homepage_url
     description: 'Optional, defaults to <code>/</code>'
+  - argument: legal_summary
+    description: 'Optional, allows customising the legal summary that appears at the bottom of the footer'
 footer_feedback_link_slot:
   - argument: title
     description: 'Optional, title for the column'

--- a/design-system-docs/src/_data/component_arguments.yml
+++ b/design-system-docs/src/_data/component_arguments.yml
@@ -112,8 +112,6 @@ footer:
     description: '<strong>(Deprecated: use feedback_link slot)</strong> If present, a link to this feedback form will be displayed'
   - argument: homepage_url
     description: 'Optional, defaults to <code>/</code>'
-  - argument: legal_summary
-    description: 'Optional, allows customising the legal summary that appears at the bottom of the footer'
 footer_feedback_link_slot:
   - argument: title
     description: 'Optional, title for the column'
@@ -134,6 +132,9 @@ footer_column_slot:
     description: '→ Optional, is this an external link?'
   - argument: 'link[:new_tab]'
     description: '→ Optional, should this link open in a new tab?'
+footer_legal_summary_slot:
+  - argument: text
+    description: 'Optional, allows customising the legal summary. If not provided, a default legal summary would appear'
 navigation:
   - argument: links
     description: 'Required, an array of hashes, each with the following:'

--- a/design-system-docs/src/_data/component_arguments.yml
+++ b/design-system-docs/src/_data/component_arguments.yml
@@ -134,7 +134,7 @@ footer_column_slot:
     description: '→ Optional, should this link open in a new tab?'
 footer_legal_summary_slot:
   - argument: text
-    description: 'Optional, allows customising the legal summary. If not provided, a default legal summary would appear'
+    description: 'Required, legal summary text'
 navigation:
   - argument: links
     description: 'Required, an array of hashes, each with the following:'

--- a/engine/app/components/citizens_advice_components/footer.html.erb
+++ b/engine/app/components/citizens_advice_components/footer.html.erb
@@ -49,7 +49,7 @@
       </div>
       <div class="cads-footer__meta">
         <p class="cads-footer__meta-text" data-testid="copyright"><%= t(".copyright", year: current_year) %></p>
-        <p class="cads-footer__meta-text" data-testid="legal-summary"><%= legal_summary.text %></p>
+        <p class="cads-footer__meta-text" data-testid="legal-summary"><%= legal_summary_text %></p>
       </div>
     </div>
   </div>

--- a/engine/app/components/citizens_advice_components/footer.html.erb
+++ b/engine/app/components/citizens_advice_components/footer.html.erb
@@ -49,7 +49,7 @@
       </div>
       <div class="cads-footer__meta">
         <p class="cads-footer__meta-text" data-testid="copyright"><%= t(".copyright", year: current_year) %></p>
-        <p class="cads-footer__meta-text" data-testid="legal-summary"><%= t(".legal_summary") %></p>
+        <p class="cads-footer__meta-text" data-testid="legal-summary"><%= legal_summary %></p>
       </div>
     </div>
   </div>

--- a/engine/app/components/citizens_advice_components/footer.html.erb
+++ b/engine/app/components/citizens_advice_components/footer.html.erb
@@ -49,7 +49,7 @@
       </div>
       <div class="cads-footer__meta">
         <p class="cads-footer__meta-text" data-testid="copyright"><%= t(".copyright", year: current_year) %></p>
-        <p class="cads-footer__meta-text" data-testid="legal-summary"><%= legal_summary %></p>
+        <p class="cads-footer__meta-text" data-testid="legal-summary"><%= legal_summary.text %></p>
       </div>
     </div>
   </div>

--- a/engine/app/components/citizens_advice_components/footer.rb
+++ b/engine/app/components/citizens_advice_components/footer.rb
@@ -2,17 +2,18 @@
 
 module CitizensAdviceComponents
   class Footer < Base
-    attr_reader :homepage_url, :feedback_url, :legal_summary
+    attr_reader :homepage_url, :feedback_url
 
     renders_one :feedback_link, "FooterFeedbackLink"
 
+    renders_one :legal_summary_slot, "FooterLegalSummarySlot"
+
     renders_many :columns, "FooterColumn"
 
-    def initialize(homepage_url: nil, feedback_url: nil, legal_summary: nil)
+    def initialize(homepage_url: nil, feedback_url: nil)
       super
       @homepage_url = homepage_url || "/"
       @feedback_url = feedback_url.to_s
-      @legal_summary = legal_summary || t("citizens_advice_components.footer.legal_summary")
 
       feedback_url_deprecation
     end
@@ -29,6 +30,10 @@ module CitizensAdviceComponents
       feedback_link.presence || feedback_link_fallback.presence
     end
 
+    def legal_summary
+      legal_summary_slot.presence || legal_summary_fallback.presence
+    end
+
     def feedback_link_fallback
       return if @feedback_url.blank?
 
@@ -40,6 +45,14 @@ module CitizensAdviceComponents
         title: t("citizens_advice_components.footer.website_feedback"),
         external: true,
         new_tab: true
+      )
+    end
+
+    def legal_summary_fallback
+      return if legal_summary_slot
+
+      FooterLegalSummarySlot.new(
+        text: t("citizens_advice_components.footer.legal_summary")
       )
     end
 
@@ -99,6 +112,16 @@ module CitizensAdviceComponents
           rel: "noopener",
           "aria-label": "#{title} (opens in a new tab)"
         }
+      end
+    end
+
+    class FooterLegalSummarySlot < Base
+      attr_reader :text
+
+      def initialize(text: nil)
+        super
+
+        @text = text
       end
     end
   end

--- a/engine/app/components/citizens_advice_components/footer.rb
+++ b/engine/app/components/citizens_advice_components/footer.rb
@@ -30,10 +30,6 @@ module CitizensAdviceComponents
       feedback_link.presence || feedback_link_fallback.presence
     end
 
-    def legal_summary
-      legal_summary_slot.presence || legal_summary_fallback.presence
-    end
-
     def feedback_link_fallback
       return if @feedback_url.blank?
 
@@ -48,20 +44,22 @@ module CitizensAdviceComponents
       )
     end
 
-    def legal_summary_fallback
-      return if legal_summary_slot
-
-      FooterLegalSummarySlot.new(
-        text: t("citizens_advice_components.footer.legal_summary")
-      )
-    end
-
     def feedback_url_deprecation
       return if @feedback_url.blank?
 
       ActiveSupport::Deprecation.warn(
         "feedback_url argument is deprecated used feedback_link slot instead"
       )
+    end
+
+    def legal_summary
+      legal_summary_slot.presence || legal_summary_fallback.presence
+    end
+
+    def legal_summary_fallback
+      return if legal_summary_slot
+
+      FooterLegalSummarySlot.new(text: t("citizens_advice_components.footer.legal_summary"))
     end
 
     class FooterColumn < Base
@@ -118,10 +116,11 @@ module CitizensAdviceComponents
     class FooterLegalSummarySlot < Base
       attr_reader :text
 
-      def initialize(text: nil)
+      def initialize(text:)
         super
 
-        @text = text
+        # Prevents adding empty string like "" or " "
+        @text = text.presence || t("citizens_advice_components.footer.legal_summary")
       end
     end
   end

--- a/engine/app/components/citizens_advice_components/footer.rb
+++ b/engine/app/components/citizens_advice_components/footer.rb
@@ -2,16 +2,17 @@
 
 module CitizensAdviceComponents
   class Footer < Base
-    attr_reader :homepage_url, :feedback_url
+    attr_reader :homepage_url, :feedback_url, :legal_summary
 
     renders_one :feedback_link, "FooterFeedbackLink"
 
     renders_many :columns, "FooterColumn"
 
-    def initialize(homepage_url: nil, feedback_url: nil)
+    def initialize(homepage_url: nil, feedback_url: nil, legal_summary: nil)
       super
       @homepage_url = homepage_url || "/"
       @feedback_url = feedback_url.to_s
+      @legal_summary = legal_summary || t("citizens_advice_components.footer.legal_summary")
 
       feedback_url_deprecation
     end

--- a/engine/app/components/citizens_advice_components/footer.rb
+++ b/engine/app/components/citizens_advice_components/footer.rb
@@ -6,7 +6,9 @@ module CitizensAdviceComponents
 
     renders_one :feedback_link, "FooterFeedbackLink"
 
-    renders_one :legal_summary_slot, "FooterLegalSummarySlot"
+    renders_one :legal_summary, lambda { |text|
+      text.presence || t("citizens_advice_components.footer.legal_summary")
+    }
 
     renders_many :columns, "FooterColumn"
 
@@ -52,14 +54,14 @@ module CitizensAdviceComponents
       )
     end
 
-    def legal_summary
-      legal_summary_slot.presence || legal_summary_fallback.presence
+    def legal_summary_text
+      legal_summary.presence || legal_summary_fallback.presence
     end
 
     def legal_summary_fallback
-      return if legal_summary_slot
+      return if legal_summary
 
-      FooterLegalSummarySlot.new(text: t("citizens_advice_components.footer.legal_summary"))
+      t("citizens_advice_components.footer.legal_summary")
     end
 
     class FooterColumn < Base
@@ -110,17 +112,6 @@ module CitizensAdviceComponents
           rel: "noopener",
           "aria-label": "#{title} (opens in a new tab)"
         }
-      end
-    end
-
-    class FooterLegalSummarySlot < Base
-      attr_reader :text
-
-      def initialize(text:)
-        super
-
-        # Prevents adding empty string like "" or " "
-        @text = text.presence || t("citizens_advice_components.footer.legal_summary")
       end
     end
   end

--- a/engine/spec/components/citizens_advice_components/footer_spec.rb
+++ b/engine/spec/components/citizens_advice_components/footer_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe CitizensAdviceComponents::Footer, type: :component do
     context "when valid legal summary" do
       before do
         render_inline(described_class.new) do |c|
-          c.legal_summary_slot(text: "Legal summary custom text")
+          c.legal_summary("Legal summary custom text")
         end
       end
 
@@ -35,7 +35,7 @@ RSpec.describe CitizensAdviceComponents::Footer, type: :component do
     context "when whitespace legal summary" do
       before do
         render_inline(described_class.new) do |c|
-          c.legal_summary_slot(text: " ")
+          c.legal_summary(" ")
         end
       end
 
@@ -45,7 +45,7 @@ RSpec.describe CitizensAdviceComponents::Footer, type: :component do
     context "when empty legal summary" do
       before do
         render_inline(described_class.new) do |c|
-          c.legal_summary_slot(text: "")
+          c.legal_summary("")
         end
       end
 

--- a/engine/spec/components/citizens_advice_components/footer_spec.rb
+++ b/engine/spec/components/citizens_advice_components/footer_spec.rb
@@ -22,7 +22,12 @@ RSpec.describe CitizensAdviceComponents::Footer, type: :component do
   end
 
   describe "custom legal summary" do
-    before { render_inline described_class.new(legal_summary: "Legal summary custom text") }
+    before { render_inline described_class.new }
+    before do
+      render_inline(described_class.new) do |c|
+        c.legal_summary_slot(text: "Legal summary custom text")
+      end
+    end
 
     it { is_expected.to have_selector "[data-testid='legal-summary']", text: "Legal summary custom text" }
   end

--- a/engine/spec/components/citizens_advice_components/footer_spec.rb
+++ b/engine/spec/components/citizens_advice_components/footer_spec.rb
@@ -21,6 +21,12 @@ RSpec.describe CitizensAdviceComponents::Footer, type: :component do
     end
   end
 
+  describe "custom legal summary" do
+    before { render_inline described_class.new(legal_summary: "Legal summary custom text") }
+
+    it { is_expected.to have_selector "[data-testid='legal-summary']", text: "Legal summary custom text" }
+  end
+
   describe "columns" do
     before do
       allow(ActiveSupport::Deprecation).to receive(:warn)

--- a/engine/spec/components/citizens_advice_components/footer_spec.rb
+++ b/engine/spec/components/citizens_advice_components/footer_spec.rb
@@ -22,14 +22,35 @@ RSpec.describe CitizensAdviceComponents::Footer, type: :component do
   end
 
   describe "custom legal summary" do
-    before { render_inline described_class.new }
-    before do
-      render_inline(described_class.new) do |c|
-        c.legal_summary_slot(text: "Legal summary custom text")
+    context "when valid legal summary" do
+      before do
+        render_inline(described_class.new) do |c|
+          c.legal_summary_slot(text: "Legal summary custom text")
+        end
       end
+
+      it { is_expected.to have_selector "[data-testid='legal-summary']", text: "Legal summary custom text" }
     end
 
-    it { is_expected.to have_selector "[data-testid='legal-summary']", text: "Legal summary custom text" }
+    context "when whitespace legal summary" do
+      before do
+        render_inline(described_class.new) do |c|
+          c.legal_summary_slot(text: " ")
+        end
+      end
+
+      it { is_expected.to have_selector "[data-testid='legal-summary']", text: "Citizens Advice is an operating name of" }
+    end
+
+    context "when empty legal summary" do
+      before do
+        render_inline(described_class.new) do |c|
+          c.legal_summary_slot(text: "")
+        end
+      end
+
+      it { is_expected.to have_selector "[data-testid='legal-summary']", text: "Citizens Advice is an operating name of" }
+    end
   end
 
   describe "columns" do


### PR DESCRIPTION
Added the ability to customise the legal summary - for example if the product using the footer has a different address or requires different legal information. If no custom legal summary was provided, defaults to the standard legal summary.

There is another open PR about footer changes (https://github.com/citizensadvice/design-system/pull/2611), but this one takes priority as the changes to the legal summary are non breaking and cannot currently be achieved unless the html of the component is copied over. 