### PR TITLE
Use with slot format in specs

### DIFF
--- a/demo/spec/components/previews/footer_preview.rb
+++ b/demo/spec/components/previews/footer_preview.rb
@@ -65,8 +65,8 @@ class FooterPreview < ViewComponent::Preview
 
   def custom_legal_summary
     render CitizensAdviceComponents::Footer.new do |c|
-      c.feedback_link(url: "https://www.research.net/r/J8PLH2H", external: true, new_tab: true)
-      c.legal_summary(legal_summary_text)
+      c.with_feedback_link(url: "https://www.research.net/r/J8PLH2H", external: true, new_tab: true)
+      c.with_legal_summary(legal_summary_text)
     end
   end
 

--- a/engine/spec/components/citizens_advice_components/button_spec.rb
+++ b/engine/spec/components/citizens_advice_components/button_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe CitizensAdviceComponents::Button, type: :component do
 
     it "renders left icon slot" do
       render_inline(component) do |c|
-        c.icon_left { "Left slot" }
+        c.with_icon_left { "Left slot" }
       end
 
       expect(page).to have_selector ".cads-button__icon-left", text: "Left slot"
@@ -93,7 +93,7 @@ RSpec.describe CitizensAdviceComponents::Button, type: :component do
 
     it "renders right icon slot" do
       render_inline(component) do |c|
-        c.icon_right { "Right slot" }
+        c.with_icon_right { "Right slot" }
       end
 
       expect(page).to have_selector ".cads-button__icon-right", text: "Right slot"

--- a/engine/spec/components/citizens_advice_components/checkbox_group_spec.rb
+++ b/engine/spec/components/citizens_advice_components/checkbox_group_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe CitizensAdviceComponents::CheckboxGroup, type: :component do
         legend: "Checkbox group field",
         name: "checkboxes"
       ) do |c|
-        c.inputs(sample_inputs)
+        c.with_inputs(sample_inputs)
       end
     end
 
@@ -51,7 +51,7 @@ RSpec.describe CitizensAdviceComponents::CheckboxGroup, type: :component do
         name: "checkboxes",
         options: { optional: "bananas" }
       ) do |c|
-        c.inputs(sample_inputs)
+        c.with_inputs(sample_inputs)
       end
     end
 
@@ -65,7 +65,7 @@ RSpec.describe CitizensAdviceComponents::CheckboxGroup, type: :component do
         name: "checkboxes",
         options: { error_message: "This is the error message" }
       ) do |c|
-        c.inputs(sample_inputs)
+        c.with_inputs(sample_inputs)
       end
     end
 
@@ -80,7 +80,7 @@ RSpec.describe CitizensAdviceComponents::CheckboxGroup, type: :component do
         name: "checkboxes",
         options: { hint: "This is the hint text" }
       ) do |c|
-        c.inputs(sample_inputs)
+        c.with_inputs(sample_inputs)
       end
     end
 
@@ -94,7 +94,7 @@ RSpec.describe CitizensAdviceComponents::CheckboxGroup, type: :component do
         name: "checkboxes",
         options: { optional: true }
       ) do |c|
-        c.inputs(sample_inputs)
+        c.with_inputs(sample_inputs)
       end
     end
 
@@ -113,7 +113,7 @@ RSpec.describe CitizensAdviceComponents::CheckboxGroup, type: :component do
         legend: "Checkbox group field",
         name: "checkboxes"
       ) do |c|
-        c.inputs([
+        c.with_inputs([
           { label: "Option 1", value: "1", name: "checkbox-1", "data-additional": "example" }
         ])
       end

--- a/engine/spec/components/citizens_advice_components/checkbox_single_spec.rb
+++ b/engine/spec/components/citizens_advice_components/checkbox_single_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe CitizensAdviceComponents::CheckboxSingle, type: :component do
       render_inline described_class.new(
         name: "my-checkbox"
       ) do |c|
-        c.checkbox(label: "Option 1", value: "1")
+        c.with_checkbox(label: "Option 1", value: "1")
       end
     end
 
@@ -35,7 +35,7 @@ RSpec.describe CitizensAdviceComponents::CheckboxSingle, type: :component do
         name: "my-checkbox",
         error_message: "This is the error message"
       ) do |c|
-        c.checkbox(label: "Option 1", value: "1")
+        c.with_checkbox(label: "Option 1", value: "1")
       end
     end
 
@@ -50,7 +50,7 @@ RSpec.describe CitizensAdviceComponents::CheckboxSingle, type: :component do
         name: "my-checkbox",
         error_message: "This is the error message"
       ) do |c|
-        c.checkbox(label: "Option 1", value: "1", "data-additional": "example")
+        c.with_checkbox(label: "Option 1", value: "1", "data-additional": "example")
       end
     end
 

--- a/engine/spec/components/citizens_advice_components/error_summary_spec.rb
+++ b/engine/spec/components/citizens_advice_components/error_summary_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe CitizensAdviceComponents::ErrorSummary, type: :component do
   context "when errors are provided" do
     before do
       render_inline described_class.new do |c|
-        c.errors(sample_error_messages)
+        c.with_errors(sample_error_messages)
       end
     end
 
@@ -25,7 +25,7 @@ RSpec.describe CitizensAdviceComponents::ErrorSummary, type: :component do
   context "when custom heading_level is provided" do
     before do
       render_inline described_class.new(heading_level: 3) do |c|
-        c.errors(sample_error_messages)
+        c.with_errors(sample_error_messages)
       end
     end
 
@@ -35,7 +35,7 @@ RSpec.describe CitizensAdviceComponents::ErrorSummary, type: :component do
   context "when custom autofocus option is provided" do
     before do
       render_inline described_class.new(autofocus: false) do |c|
-        c.errors(sample_error_messages)
+        c.with_errors(sample_error_messages)
       end
     end
 

--- a/engine/spec/components/citizens_advice_components/footer_spec.rb
+++ b/engine/spec/components/citizens_advice_components/footer_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe CitizensAdviceComponents::Footer, type: :component do
     context "when valid legal summary" do
       before do
         render_inline(described_class.new) do |c|
-          c.legal_summary("Legal summary custom text")
+          c.with_legal_summary("Legal summary custom text")
         end
       end
 
@@ -35,7 +35,7 @@ RSpec.describe CitizensAdviceComponents::Footer, type: :component do
     context "when whitespace legal summary" do
       before do
         render_inline(described_class.new) do |c|
-          c.legal_summary(" ")
+          c.with_legal_summary(" ")
         end
       end
 
@@ -45,7 +45,7 @@ RSpec.describe CitizensAdviceComponents::Footer, type: :component do
     context "when empty legal summary" do
       before do
         render_inline(described_class.new) do |c|
-          c.legal_summary("")
+          c.with_legal_summary("")
         end
       end
 
@@ -58,7 +58,7 @@ RSpec.describe CitizensAdviceComponents::Footer, type: :component do
       allow(ActiveSupport::Deprecation).to receive(:warn)
 
       render_inline(described_class.new) do |c|
-        c.columns(columns)
+        c.with_columns(columns)
       end
     end
 
@@ -103,7 +103,7 @@ RSpec.describe CitizensAdviceComponents::Footer, type: :component do
     context "with url only" do
       before do
         render_inline(described_class.new) do |c|
-          c.feedback_link(url: "https://example.com/")
+          c.with_feedback_link(url: "https://example.com/")
         end
       end
 
@@ -114,7 +114,7 @@ RSpec.describe CitizensAdviceComponents::Footer, type: :component do
     context "with custom title" do
       before do
         render_inline(described_class.new) do |c|
-          c.feedback_link(title: "Custom link title", url: "https://example.com/")
+          c.with_feedback_link(title: "Custom link title", url: "https://example.com/")
         end
       end
 
@@ -124,7 +124,7 @@ RSpec.describe CitizensAdviceComponents::Footer, type: :component do
     context "with new_tab set to true" do
       before do
         render_inline(described_class.new) do |c|
-          c.feedback_link(url: "https://example.com/", new_tab: true)
+          c.with_feedback_link(url: "https://example.com/", new_tab: true)
         end
       end
 
@@ -134,7 +134,7 @@ RSpec.describe CitizensAdviceComponents::Footer, type: :component do
     context "with URI builder object" do
       before do
         render_inline(described_class.new) do |c|
-          c.feedback_link(url: URI::HTTPS.build(host: "example.com", path: "/example-path"))
+          c.with_feedback_link(url: URI::HTTPS.build(host: "example.com", path: "/example-path"))
         end
       end
 

--- a/engine/spec/components/citizens_advice_components/header_spec.rb
+++ b/engine/spec/components/citizens_advice_components/header_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe CitizensAdviceComponents::Header, type: :component do
     context "with default logo" do
       before do
         render_inline(described_class.new) do |c|
-          c.logo(title: "Logo title", url: "/homepage")
+          c.with_logo(title: "Logo title", url: "/homepage")
         end
       end
 
@@ -27,7 +27,7 @@ RSpec.describe CitizensAdviceComponents::Header, type: :component do
     context "with custom block" do
       before do
         render_inline(described_class.new) do |c|
-          c.logo { "Custom logo HTML" }
+          c.with_logo { "Custom logo HTML" }
         end
       end
 
@@ -39,7 +39,7 @@ RSpec.describe CitizensAdviceComponents::Header, type: :component do
     context "with default skip_links" do
       before do
         render_inline(described_class.new) do |c|
-          c.logo(title: "Logo title", url: "/")
+          c.with_logo(title: "Logo title", url: "/")
         end
       end
 
@@ -52,8 +52,8 @@ RSpec.describe CitizensAdviceComponents::Header, type: :component do
     context "with custom skip links" do
       before do
         render_inline(described_class.new) do |c|
-          c.logo(title: "Logo title", url: "/")
-          c.skip_links([{ title: "Skip to main content", url: "#content" }])
+          c.with_logo(title: "Logo title", url: "/")
+          c.with_skip_links([{ title: "Skip to main content", url: "#content" }])
         end
       end
 
@@ -65,8 +65,8 @@ RSpec.describe CitizensAdviceComponents::Header, type: :component do
   describe "header_links slot" do
     before do
       render_inline(described_class.new) do |c|
-        c.logo(title: "Logo title", url: "/")
-        c.header_links([
+        c.with_logo(title: "Logo title", url: "/")
+        c.with_header_links([
           { title: "Public site", url: "/", current_site: true },
           { title: "Intranet", url: "/intranet" },
           { title: "Cymraeg", url: "/cymraeg" }
@@ -84,8 +84,8 @@ RSpec.describe CitizensAdviceComponents::Header, type: :component do
     context "with plain link" do
       before do
         render_inline(described_class.new) do |c|
-          c.logo(title: "Logo title", url: "/")
-          c.account_link(title: "Sign out", url: "/sign-out")
+          c.with_logo(title: "Logo title", url: "/")
+          c.with_account_link(title: "Sign out", url: "/sign-out")
         end
       end
 
@@ -95,8 +95,8 @@ RSpec.describe CitizensAdviceComponents::Header, type: :component do
     context "with custom block" do
       before do
         render_inline(described_class.new) do |c|
-          c.logo(title: "Logo title", url: "/")
-          c.account_link do
+          c.with_logo(title: "Logo title", url: "/")
+          c.with_account_link do
             "Custom account link HTML"
           end
         end
@@ -109,8 +109,8 @@ RSpec.describe CitizensAdviceComponents::Header, type: :component do
   describe "search_form slot" do
     before do
       render_inline(described_class.new) do |c|
-        c.logo(title: "Logo title", url: "/")
-        c.search_form(search_action_url: "/search")
+        c.with_logo(title: "Logo title", url: "/")
+        c.with_search_form(search_action_url: "/search")
       end
     end
 

--- a/engine/spec/components/citizens_advice_components/on_this_page_spec.rb
+++ b/engine/spec/components/citizens_advice_components/on_this_page_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe CitizensAdviceComponents::OnThisPage, type: :component do
   context "when there are links present" do
     before do
       render_inline described_class.new do |c|
-        c.links([
+        c.with_links([
           { label: "Link 1", id: "link-1" },
           { label: "Link 2", id: "link-2" },
           { label: "Link 3", id: "link-3" },
@@ -40,7 +40,7 @@ RSpec.describe CitizensAdviceComponents::OnThisPage, type: :component do
     context "when there are only top-level links present" do
       before do
         render_inline described_class.new(show_nested_links: true) do |c|
-          c.links([
+          c.with_links([
             { label: "Link 1", id: "link-1" },
             { label: "Link 2", id: "link-2" },
             { label: "Link 3", id: "link-3" },
@@ -61,7 +61,7 @@ RSpec.describe CitizensAdviceComponents::OnThisPage, type: :component do
     context "when there are nested links present" do
       before do
         render_inline described_class.new(show_nested_links: true) do |c|
-          c.links([
+          c.with_links([
             { label: "Link 1", id: "link-1" },
             { label: "Link 2", id: "link-2", children: [
               { label: "Link 2.1", id: "link-2-1" },

--- a/engine/spec/components/citizens_advice_components/radio_group_spec.rb
+++ b/engine/spec/components/citizens_advice_components/radio_group_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe CitizensAdviceComponents::RadioGroup, type: :component do
         legend: "Radio button group field",
         name: "radio-group"
       ) do |c|
-        c.inputs(sample_inputs)
+        c.with_inputs(sample_inputs)
       end
     end
 
@@ -51,7 +51,7 @@ RSpec.describe CitizensAdviceComponents::RadioGroup, type: :component do
         name: "radio-group",
         options: { error_message: "This is the error message" }
       ) do |c|
-        c.inputs(sample_inputs)
+        c.with_inputs(sample_inputs)
       end
     end
 
@@ -66,7 +66,7 @@ RSpec.describe CitizensAdviceComponents::RadioGroup, type: :component do
         name: "radio-group",
         options: { hint: "This is the hint text" }
       ) do |c|
-        c.inputs(sample_inputs)
+        c.with_inputs(sample_inputs)
       end
     end
 
@@ -80,7 +80,7 @@ RSpec.describe CitizensAdviceComponents::RadioGroup, type: :component do
         name: "radio-group",
         options: { optional: true }
       ) do |c|
-        c.inputs(sample_inputs)
+        c.with_inputs(sample_inputs)
       end
     end
 
@@ -102,7 +102,7 @@ RSpec.describe CitizensAdviceComponents::RadioGroup, type: :component do
             name: "radio-group",
             options: { layout: :invalid }
           ) do |c|
-            c.inputs(sample_inputs)
+            c.with_inputs(sample_inputs)
           end
         end
       end
@@ -119,7 +119,7 @@ RSpec.describe CitizensAdviceComponents::RadioGroup, type: :component do
           name: "radio-group",
           options: { layout: :list }
         ) do |c|
-          c.inputs(sample_inputs)
+          c.with_inputs(sample_inputs)
         end
       end
 
@@ -135,7 +135,7 @@ RSpec.describe CitizensAdviceComponents::RadioGroup, type: :component do
           name: "radio-group",
           options: { layout: :inline }
         ) do |c|
-          c.inputs(sample_inputs)
+          c.with_inputs(sample_inputs)
         end
       end
 
@@ -154,7 +154,7 @@ RSpec.describe CitizensAdviceComponents::RadioGroup, type: :component do
             name: "radio-group",
             options: { size: :invalid }
           ) do |c|
-            c.inputs(sample_inputs)
+            c.with_inputs(sample_inputs)
           end
         end
       end
@@ -171,7 +171,7 @@ RSpec.describe CitizensAdviceComponents::RadioGroup, type: :component do
           name: "radio-group",
           options: { size: :regular }
         ) do |c|
-          c.inputs(sample_inputs)
+          c.with_inputs(sample_inputs)
         end
       end
 
@@ -187,7 +187,7 @@ RSpec.describe CitizensAdviceComponents::RadioGroup, type: :component do
           name: "radio-group",
           options: { size: :small }
         ) do |c|
-          c.inputs(sample_inputs)
+          c.with_inputs(sample_inputs)
         end
       end
 

--- a/engine/spec/components/citizens_advice_components/section_links_spec.rb
+++ b/engine/spec/components/citizens_advice_components/section_links_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe CitizensAdviceComponents::SectionLinks, type: :component do
         section_title: "Applying to the EU settlement scheme",
         section_title_url: "#"
       ) do |c|
-        c.section_links(sample_section_links)
+        c.with_section_links(sample_section_links)
       end
     end
 
@@ -30,8 +30,8 @@ RSpec.describe CitizensAdviceComponents::SectionLinks, type: :component do
         section_title: "Applying to the EU settlement scheme",
         section_title_url: "#"
       ) do |c|
-        c.section_links(additional_attribute_links)
-        c.custom_content { "Example content" }
+        c.with_section_links(additional_attribute_links)
+        c.with_custom_content { "Example content" }
       end
     end
 
@@ -49,7 +49,7 @@ RSpec.describe CitizensAdviceComponents::SectionLinks, type: :component do
         section_title: "Applying to the EU settlement scheme",
         section_title_url: "#"
       ) do |c|
-        c.section_links(additional_attribute_links)
+        c.with_section_links(additional_attribute_links)
         "Example content"
       end
     end
@@ -67,7 +67,7 @@ RSpec.describe CitizensAdviceComponents::SectionLinks, type: :component do
   context "when additional link attributes are present" do
     before do
       render_inline described_class.new(title: "Related Content", section_title: "Applying to the EU settlement scheme") do |c|
-        c.section_links(additional_attribute_links)
+        c.with_section_links(additional_attribute_links)
       end
     end
 
@@ -79,7 +79,7 @@ RSpec.describe CitizensAdviceComponents::SectionLinks, type: :component do
   context "when only section links are present" do
     before do
       render_inline described_class.new(title: nil, section_title: nil, section_title_url: nil) do |c|
-        c.section_links(sample_section_links)
+        c.with_section_links(sample_section_links)
       end
     end
 
@@ -88,9 +88,7 @@ RSpec.describe CitizensAdviceComponents::SectionLinks, type: :component do
 
   context "when only section title is present" do
     before do
-      render_inline described_class.new(title: nil, section_title: "Applying to the EU settlement scheme", section_title_url: nil) do |c|
-        c.section_links(nil)
-      end
+      render_inline described_class.new(title: nil, section_title: "Applying to the EU settlement scheme", section_title_url: nil)
     end
 
     it { is_expected.to have_selector ".cads-section-links" }
@@ -99,8 +97,7 @@ RSpec.describe CitizensAdviceComponents::SectionLinks, type: :component do
   context "when only content is present" do
     before do
       render_inline described_class.new(title: nil, section_title: nil, section_title_url: nil) do |c|
-        c.section_links(nil)
-        c.custom_content { "Example content" }
+        c.with_custom_content { "Example content" }
       end
     end
 
@@ -110,8 +107,8 @@ RSpec.describe CitizensAdviceComponents::SectionLinks, type: :component do
   context "when no section title url present" do
     before do
       render_inline described_class.new(title: "Related Content", section_title: "Applying to the EU settlement scheme") do |c|
-        c.section_links(sample_section_links)
-        c.custom_content { "Example content" }
+        c.with_section_links(sample_section_links)
+        c.with_custom_content { "Example content" }
       end
     end
 


### PR DESCRIPTION
This is extracted from https://github.com/citizensadvice/design-system/pull/2758

In recent versions of viewcomponent a new format was introduced for using slots, using a `with_` prefix.

See: https://viewcomponent.org/adrs/0004-slots-separate-getter-setter.html

This is optional is version 2 but required in version 3 which has now been released. We can prepare for this upgrade ahead of time by replacing any internal slot references with the new format, starting with specs.