### PR TITLE
Remove misleading arguments in header examples

### DIFF
--- a/demo/app/components/form_app_header_component.html.erb
+++ b/demo/app/components/form_app_header_component.html.erb
@@ -2,7 +2,7 @@
   <% c.logo(title: "Citizens Advice homepage", url: "/") %>
   <% c.header_links(header_links) %>
   <% c.search_form(search_action_url: "/search") %>
-  <% c.account_link(title: "Sign in", url: "/sign-in") do %>
+  <% c.account_link do %>
     <% form_tag("/sign-out", class: "cads-header__account-form", authenticity_token: false) do %>
       <% button_tag("Sign out", class: %w[cads-button__tertiary cads-header__sign-out js-cads-close-on-blur]) %>
     <% end %>

--- a/design-system-docs/src/_component_docs/header.md
+++ b/design-system-docs/src/_component_docs/header.md
@@ -118,10 +118,8 @@ Or by passing a custom block to render your own HTML:
 ```erb
 <%%= render CitizensAdviceComponents::Header.new do |c| %>
   <%% c.account_link do %>
-    <%% c.account_link(title: "Sign in", url: "/sign-in") do %>
-      <%%= form_tag("/sign-out", class: "cads-header__account-form", authenticity_token: false) do %>
-        <%%= button_tag("Sign out", class: %w[cads-button__tertiary cads-header__sign-out js-cads-close-on-blur]) %>
-      <%% end %>
+    <%%= form_tag("/sign-out", class: "cads-header__account-form", authenticity_token: false) do %>
+      <%%= button_tag("Sign out", class: %w[cads-button__tertiary cads-header__sign-out js-cads-close-on-blur]) %>
     <%% end %>
   <%% end %>
 <%% end %>


### PR DESCRIPTION
The examples and demo code for using a custom `account_link` were misleading as they continued to pass arguments to the method as well as providing a block.

When providing a block this arguments are ignored. Updated the example and demo code to reflect this.

Spotted whilst pairing with @pksterling 