### PR TITLE
Amend CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # Global owners - all PRs will be assigned to these users
-*       @davidrapson @davidsauntson @marianayovcheva
+*       @davidrapson @davidsauntson @marianayovcheva @cnorthwood


### PR DESCRIPTION
Ensures cnorthwood is able to approve PRs as CODEOWNER for the repository.