### PR TITLE
Add dependabot groups for common dev-dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,12 @@ updates:
     directory: '/'
     schedule:
       interval: weekly
+    groups:
+      dev-dependencies:
+        patterns:
+          - 'eslint*'
+          - 'jest*'
+          - 'stylelint*'
 
   ##
   # Rails engine


### PR DESCRIPTION
Now that dependabot groups are in general availability we can try configuring them for a few things.

https://github.blog/2023-08-24-a-faster-way-to-manage-version-updates-with-dependabot/

Start with rules for the testing tools that have a few related packages (eslint, stylelint, jest)