### PR TITLE
Fix Rails 7.0.x CI version constraint

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -25,7 +25,7 @@ jobs:
       fail-fast: false
       matrix:
         ruby_version: ['2.7', '3.0', '3.1', '3.2']
-        rails_version: ['~> 6.0', '~> 6.1', '~> 7.0']
+        rails_version: ['~> 6.0', '~> 6.1', '~> 7.0.0']
         view_component_version: ['~> 2.82']
         exclude:
           - rails_version: '~> 6.0'
@@ -34,7 +34,7 @@ jobs:
             ruby_version: '3.1'
         include:
           - ruby_version: '3.1'
-            rails_version: '~> 7.0'
+            rails_version: '~> 7.0.0'
             view_component_version: '~> 3'
     env:
       RAILS_VERSION: ${{ matrix.rails_version }}


### PR DESCRIPTION
Current CI version constraint has started matching Rails 7.1 which is now out. Make sure the range covers 7.0.x explicitly. We'll need to add Rails 7.1 to the build matrix and fix any issues but this gets the build passing.