### PR TITLE
Consolidate CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # Global owners - all PRs will be assigned to these users
-*       @citizensadvice/design-system-owners @davidrapson @davidsauntson @marianayovcheva @cnorthwood @akamike @pksterling
+*       @citizensadvice/design-system-owners


### PR DESCRIPTION
Use the design-system-owners team to manage CODEOWNERS