### PR TITLE
Add missing foundation colours and deprecate duplicate colour variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 **New**
 
 - Document error and success colours in foundations
+- Deprecate `$cads-language__warning-colour` as this was a duplicate of `$cads-language__error-colour`
 - Include Rails 7.1 in supported version
 - Remove Rails 6.0 from supported versions
 - Remove support for Ruby 2.7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 **New**
 
+- Document error and success colours in foundations
 - Include Rails 7.1 in supported version
 - Remove Rails 6.0 from supported versions
 - Remove support for Ruby 2.7

--- a/design-system-docs/src/_foundations/colours.md
+++ b/design-system-docs/src/_foundations/colours.md
@@ -59,6 +59,15 @@ Use the ‘Input border’ for interactive elements like input boxes so it meets
 ['Button hover', 'primary-button-hover-colour'],
 ])) %>
 
+## Statuses
+
+Used for error and success statues.
+
+<%= render(Shared::ColourTable.new([
+['Error', 'error'],
+['Success', 'success']
+])) %>
+
 ### Adviser
 
 Only use ‘Adviser’ colours for adviser-related components, like ‘Adviser callout’. This is also the brand colour for AdviserNet.

--- a/scss/1-settings/_colour-language.scss
+++ b/scss/1-settings/_colour-language.scss
@@ -1,22 +1,32 @@
 @use '../1-settings/colour-palette' as palette;
 
+// Brand
 $cads-language__brand-primary: palette.$cads-palette__heritage-blue !default;
 $cads-language__brand-secondary: palette.$cads-palette__heritage-yellow !default;
 $cads-language__brand-primary-contrast: palette.$cads-palette__white !default;
 $cads-language__brand-adviser: palette.$cads-palette__blue-adviser !default;
+
+// Text
 $cads-language__text-colour: palette.$cads-palette__black !default;
 $cads-language__secondary-text-colour: palette.$cads-palette__dark-grey !default;
+
+// Links
 $cads-language__link-colour: palette.$cads-palette__heritage-blue !default;
 $cads-language__link-hover-colour: palette.$cads-palette__heritage-blue-dark !default;
 $cads-language__link-visited-colour: palette.$cads-palette__purple !default;
 $cads-language__link-active-colour: palette.$cads-palette__dark-grey !default;
 $cads-language__hover-background-colour: palette.$cads-palette__blue-light !default;
+
+// Focus
 $cads-language__focus-colour: palette.$cads-palette__yellow !default;
 $cads-language__focus-border-colour: palette.$cads-palette__dark-grey !default;
 $cads-language__focus-text-colour: palette.$cads-palette__black !default;
+
+// Borders
 $cads-language__input-border-colour: palette.$cads-palette__mid-grey !default;
 $cads-language__border-colour: palette.$cads-palette__light-grey !default;
-$cads-language__error-colour: palette.$cads-palette__red !default;
+
+// Buttons
 $cads-language__primary-button-colour: palette.$cads-palette__teal !default;
 $cads-language__primary-button-text-colour: palette.$cads-palette__white !default;
 $cads-language__primary-button-hover-colour: palette.$cads-palette__teal-dark !default;
@@ -25,7 +35,10 @@ $cads-language__tertiary-button-dark-hover-background-colour: palette.$cads-pale
 $cads-language__tertiary-button-dark-hover-colour: $cads-language__brand-primary-contrast !default;
 $cads-language__tertiary-button-dark-hover-border-colour: $cads-language__brand-primary-contrast !default;
 $cads-language__button-shadow-colour: palette.$cads-palette__teal-dark !default;
-$cads-language__warning-colour: palette.$cads-palette__red !default;
+
+// Statuses
+$cads-language__warning-colour: palette.$cads-palette__red !default; // @deprecated: Historically identical to the error colour
+$cads-language__error-colour: palette.$cads-palette__red !default;
 $cads-language__success-colour: palette.$cads-palette__green !default;
 
 // Navigation colours

--- a/scss/6-components/_error-summary.scss
+++ b/scss/6-components/_error-summary.scss
@@ -7,7 +7,7 @@
   border: solid $cads-border-width-medium $cads-language__border-colour;
   border-radius: $cads-border-radius;
   padding: $cads-spacing-4;
-  color: $cads-language__warning-colour;
+  color: $cads-language__error-colour;
   margin-bottom: $cads-spacing-4;
 
   &:focus {
@@ -33,7 +33,7 @@
       }
 
       a {
-        color: $cads-language__warning-colour;
+        color: $cads-language__error-colour;
         font-weight: $cads-font-weight__bold;
         text-decoration: underline;
 

--- a/scss/6-components/forms/fields.scss
+++ b/scss/6-components/forms/fields.scss
@@ -59,7 +59,7 @@
 
 .cads-form-field__error-message {
   display: none;
-  color: $cads-language__warning-colour;
+  color: $cads-language__error-colour;
   font-weight: $cads-font-weight__bold;
   margin: 0 0 $cads-spacing-3 0;
 }
@@ -77,7 +77,7 @@
     position: relative;
     padding: 0;
     width: 0;
-    border: $cads-border-width-small solid $cads-language__warning-colour;
+    border: $cads-border-width-small solid $cads-language__error-colour;
 
     &::before {
       content: '';


### PR DESCRIPTION
Fixes https://github.com/citizensadvice/design-system/issues/3031

Adds missing status colours to the foundations documentation. In the process realised that `$cads-language__warning-colour` is a duplicate of `$cads-language__error-colour`. I've removed internal references to the duplicate variable and document it as deprecated.

We could simply remove the variable and require applications to replace the reference or leave it for a little while and replace it more gradually. There's no way to add a deprecation warning to a plain variable.
