### PR TITLE
Callout: Replace `title` with `attributes`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Include Rails 7.1 in supported version
 - Remove Rails 6.0 from supported versions
 - Remove support for Ruby 2.7
+- Callout: Deprecate `title` attribute; replace with more general  `attributes`
 
 ## v5.6.0
 

--- a/design-system-docs/src/_data/component_arguments.yml
+++ b/design-system-docs/src/_data/component_arguments.yml
@@ -83,8 +83,10 @@ breadcrumbs:
 callout:
   - argument: type
     description: 'Optional type. One of <code>:standard</code>, <code>:example</code>, <code>:important</code>, or <code>:adviser</code>. Defaults to <code>:standard</code>.'
-  - argument: label
-    description: Optional, title used as aria-label
+  - argument: attributes
+    description: Optional, attributes passed on to callout container element
+  - argument: title
+    description: '<strong>(Deprecated: use attributes hash instead)</strong> This previously set an aria-label which is not supported on non-interactive elements'
 search:
   - argument: value
     description: Optional, current value

--- a/engine/app/components/citizens_advice_components/callout.html.erb
+++ b/engine/app/components/citizens_advice_components/callout.html.erb
@@ -1,4 +1,4 @@
-<%= tag.section(class: "cads-callout cads-callout--#{type}", "aria-label": title) do %>
+<%= tag.section(class: "cads-callout cads-callout--#{type}", **attributes) do %>
   <% if show_badge? %><%= render(CitizensAdviceComponents::Badge.new(type: type)) %><% end %>
   <%= content %>
 <% end %>

--- a/engine/app/components/citizens_advice_components/callout.rb
+++ b/engine/app/components/citizens_advice_components/callout.rb
@@ -2,16 +2,19 @@
 
 module CitizensAdviceComponents
   class Callout < Base
-    attr_reader :type, :title
+    attr_reader :type, :title, :attributes
 
-    def initialize(type: nil, title: nil)
+    def initialize(type: nil, title: nil, attributes: nil)
       super
       @type = fetch_or_fallback(
         allowed_values: %i[standard example important adviser],
         given_value: type,
         fallback: :standard
       )
+      @attributes = attributes.to_h
       @title = title
+
+      title_deprecation
     end
 
     def show_badge?
@@ -20,6 +23,14 @@ module CitizensAdviceComponents
 
     def render?
       content.present?
+    end
+
+    def title_deprecation
+      return if @title.blank?
+
+      ActiveSupport::Deprecation.warn(
+        "The title attribute is deprecated, use attributes instead"
+      )
     end
   end
 end

--- a/engine/spec/components/citizens_advice_components/callout_spec.rb
+++ b/engine/spec/components/citizens_advice_components/callout_spec.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 RSpec.describe CitizensAdviceComponents::Callout, type: :component do
+  include ActionView::Helpers::TagHelper
+
   subject { page }
 
   context "with default arguments" do
@@ -49,14 +51,31 @@ RSpec.describe CitizensAdviceComponents::Callout, type: :component do
     it { is_expected.to have_selector ".cads-badge--adviser", text: "Adviser" }
   end
 
+  context "with custom attributes" do
+    before do
+      render_inline described_class.new(
+        type: :adviser,
+        attributes: { "aria-labelledby": "my-custom-title" }
+      ) do
+        safe_join([
+          tag.h2("Callout title", id: "my-custom-title"),
+          tag.p("Example content")
+        ])
+      end
+    end
+
+    it { is_expected.to have_selector "section[aria-labelledby='my-custom-title']" }
+
+    it { is_expected.to have_selector "h2#my-custom-title", text: "Callout title" }
+
+    it { is_expected.to have_text "Example content" }
+  end
+
   context "when deprecated title is provided" do
     before do
       allow(ActiveSupport::Deprecation).to receive(:warn)
 
-      render_inline(described_class.new(
-        type: :adviser,
-        title: "Deprecated title"
-      )) { "Example content" }
+      render_inline(described_class.new(type: :standard, title: "Deprecated title")) { "Example content" }
     end
 
     it "logs deprecation warning" do

--- a/engine/spec/components/citizens_advice_components/callout_spec.rb
+++ b/engine/spec/components/citizens_advice_components/callout_spec.rb
@@ -49,15 +49,20 @@ RSpec.describe CitizensAdviceComponents::Callout, type: :component do
     it { is_expected.to have_selector ".cads-badge--adviser", text: "Adviser" }
   end
 
-  context "when title is provided" do
+  context "when deprecated title is provided" do
     before do
+      allow(ActiveSupport::Deprecation).to receive(:warn)
+
       render_inline(described_class.new(
-                      type: :adviser,
-                      title: "Descriptive title"
-                    )) { "Example content" }
+        type: :adviser,
+        title: "Deprecated title"
+      )) { "Example content" }
     end
 
-    it { is_expected.to have_selector "section[aria-label='Descriptive title']" }
+    it "logs deprecation warning" do
+      expect(ActiveSupport::Deprecation).to have_received(:warn)
+        .with(/title attribute is deprecated/)
+    end
   end
 
   context "when no content present" do


### PR DESCRIPTION
The `title` attribute in the callout component was used as an `aria-label` for its container.

This is being changed because:
- The callout container is a non-interactive element and `aria-label` is intended for use on interactive elements only (as described in the [MDN web docs](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-label))
- Allowing only one attribute to be passed for a specific option in the container element is quite restrictive

The following changes have been made:
- A deprecation warning has now been added to the use of `title` in the callout component
- `attributes` is now an optional attribute that passes a hash of options to the callout component element