### PR TITLE
Add library specific deprecator

### DIFF
--- a/engine/app/components/citizens_advice_components/callout.rb
+++ b/engine/app/components/citizens_advice_components/callout.rb
@@ -28,7 +28,7 @@ module CitizensAdviceComponents
     def title_deprecation
       return if @title.blank?
 
-      ActiveSupport::Deprecation.warn(
+      CitizensAdviceComponents.deprecator.warn(
         "The title attribute is deprecated, use attributes instead"
       )
     end

--- a/engine/app/components/citizens_advice_components/footer.rb
+++ b/engine/app/components/citizens_advice_components/footer.rb
@@ -49,7 +49,7 @@ module CitizensAdviceComponents
     def feedback_url_deprecation
       return if @feedback_url.blank?
 
-      ActiveSupport::Deprecation.warn(
+      CitizensAdviceComponents.deprecator.warn(
         "feedback_url argument is deprecated used feedback_link slot instead"
       )
     end
@@ -78,7 +78,7 @@ module CitizensAdviceComponents
       def icon_option_deprecation
         return unless links.any? { |link| link[:icon].present? }
 
-        ActiveSupport::Deprecation.warn(
+        CitizensAdviceComponents.deprecator.warn(
           "generic `icon` property for column links is deprecated use `external: true` instead"
         )
       end

--- a/engine/app/components/citizens_advice_components/section_links.rb
+++ b/engine/app/components/citizens_advice_components/section_links.rb
@@ -29,7 +29,7 @@ module CitizensAdviceComponents
       if custom_content.present?
         custom_content
       elsif content.respond_to?(:to_str) && content.present?
-        ActiveSupport::Deprecation.warn(
+        CitizensAdviceComponents.deprecator.warn(
           "Use custom_content slot instead of default content block"
         )
 

--- a/engine/lib/citizens_advice_components.rb
+++ b/engine/lib/citizens_advice_components.rb
@@ -4,4 +4,8 @@ require "citizens_advice_components/engine"
 require "citizens_advice_components/version"
 
 module CitizensAdviceComponents
+  def self.deprecator
+    # https://api.rubyonrails.org/classes/ActiveSupport/Deprecation.html
+    @deprecator ||= ActiveSupport::Deprecation.new("6.0", "CitizensAdviceComponents")
+  end
 end

--- a/engine/lib/citizens_advice_components/engine.rb
+++ b/engine/lib/citizens_advice_components/engine.rb
@@ -11,5 +11,15 @@ module CitizensAdviceComponents
       #{CitizensAdviceComponents::Engine.root.join('app/components')}
       #{CitizensAdviceComponents::Engine.root.join('app/lib')}
     ]
+
+    # Ensure that application level configuration settings apply to
+    # library specific deprecation warnings. Introduced in Rails 7.1
+    # https://api.rubyonrails.org/classes/ActiveSupport/Deprecation.html
+    # https://guides.rubyonrails.org/7_1_release_notes.html#add-rails-application-deprecators
+    if Rails.version.to_f >= 7.1
+      initializer "citizens_advice_components.deprecator" do |app|
+        app.deprecators[:citizens_advice_components] = CitizensAdviceComponents.deprecator
+      end
+    end
   end
 end

--- a/engine/spec/components/citizens_advice_components/callout_spec.rb
+++ b/engine/spec/components/citizens_advice_components/callout_spec.rb
@@ -73,13 +73,13 @@ RSpec.describe CitizensAdviceComponents::Callout, type: :component do
 
   context "when deprecated title is provided" do
     before do
-      allow(ActiveSupport::Deprecation).to receive(:warn)
+      allow(CitizensAdviceComponents.deprecator).to receive(:warn)
 
       render_inline(described_class.new(type: :standard, title: "Deprecated title")) { "Example content" }
     end
 
     it "logs deprecation warning" do
-      expect(ActiveSupport::Deprecation).to have_received(:warn)
+      expect(CitizensAdviceComponents.deprecator).to have_received(:warn)
         .with(/title attribute is deprecated/)
     end
   end

--- a/engine/spec/components/citizens_advice_components/footer_spec.rb
+++ b/engine/spec/components/citizens_advice_components/footer_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe CitizensAdviceComponents::Footer, type: :component do
 
   describe "columns" do
     before do
-      allow(ActiveSupport::Deprecation).to receive(:warn)
+      allow(CitizensAdviceComponents.deprecator).to receive(:warn)
 
       render_inline(described_class.new) do |c|
         c.with_columns(columns)
@@ -91,7 +91,7 @@ RSpec.describe CitizensAdviceComponents::Footer, type: :component do
       end
 
       it "logs deprecation warning" do
-        expect(ActiveSupport::Deprecation).to have_received(:warn)
+        expect(CitizensAdviceComponents.deprecator).to have_received(:warn)
           .with(/generic `icon` property for column links is deprecated/)
       end
     end
@@ -144,7 +144,7 @@ RSpec.describe CitizensAdviceComponents::Footer, type: :component do
 
   describe "deprecated feedback_url" do
     before do
-      allow(ActiveSupport::Deprecation).to receive(:warn)
+      allow(CitizensAdviceComponents.deprecator).to receive(:warn)
 
       render_inline(described_class.new(feedback_url: "https://example.com/"))
     end
@@ -152,7 +152,7 @@ RSpec.describe CitizensAdviceComponents::Footer, type: :component do
     it { is_expected.to have_link "Is there anything wrong", href: "https://example.com/" }
 
     it "logs deprecation warning" do
-      expect(ActiveSupport::Deprecation).to have_received(:warn)
+      expect(CitizensAdviceComponents.deprecator).to have_received(:warn)
         .with(/feedback_url argument is deprecated/)
     end
 

--- a/engine/spec/components/citizens_advice_components/section_links_spec.rb
+++ b/engine/spec/components/citizens_advice_components/section_links_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe CitizensAdviceComponents::SectionLinks, type: :component do
 
   describe "deprecated content block" do
     before do
-      allow(ActiveSupport::Deprecation).to receive(:warn)
+      allow(CitizensAdviceComponents.deprecator).to receive(:warn)
 
       render_inline described_class.new(
         title: "Related Content",
@@ -59,7 +59,7 @@ RSpec.describe CitizensAdviceComponents::SectionLinks, type: :component do
     end
 
     it "logs deprecation warning" do
-      expect(ActiveSupport::Deprecation).to have_received(:warn)
+      expect(CitizensAdviceComponents.deprecator).to have_received(:warn)
         .with(/Use custom_content slot instead of default content block/)
     end
   end


### PR DESCRIPTION
In the latest version of Rails there is a deprecation warning raised when using `ActiveSupport::Deprecation.warn`, specifically:

```
Calling warn on ActiveSupport::Deprecation is deprecated and will be removed from Rails
```

From the Rails 7.1 release notes

> All usage of `ActiveSupport::Deprecation` as a singleton is deprecated,
> the most common one being `ActiveSupport::Deprecation.warn`.
> Gem authors should now create their own deprecator (`ActiveSupport::Deprecation` object),
> and use it to emit deprecation warnings.

This updates our code to create a library specific deprecator instance with a deprecation horizon of v6.0.

It also configures the new `Rails.application.deprecators` method to allow applications to control our library specific deprecation warnings.

See:

- https://api.rubyonrails.org/classes/ActiveSupport/Deprecation.html
- https://guides.rubyonrails.org/7_1_release_notes.html#add-rails-application-deprecators