### PR TITLE
Raise deprecations in demo app

### DIFF
--- a/demo/config/environments/development.rb
+++ b/demo/config/environments/development.rb
@@ -37,8 +37,9 @@ Rails.application.configure do
     config.cache_store = :null_store
   end
 
-  # Print deprecation notices to the Rails logger.
-  config.active_support.deprecation = :log
+  # Raise deprecation errors to ensure no
+  # examples use deprecated design system methods
+  config.active_support.deprecation = :raise
 
   # Raise exceptions for disallowed deprecations.
   config.active_support.disallowed_deprecation = :raise

--- a/demo/config/environments/test.rb
+++ b/demo/config/environments/test.rb
@@ -38,8 +38,9 @@ Rails.application.configure do
   # Disable request forgery protection in test environment.
   config.action_controller.allow_forgery_protection = false
 
-  # Print deprecation notices to the stderr.
-  config.active_support.deprecation = :stderr
+  # Raise deprecation errors to ensure no
+  # examples use deprecated design system methods
+  config.active_support.deprecation = :raise
 
   # Raise exceptions for disallowed deprecations.
   config.active_support.disallowed_deprecation = :raise


### PR DESCRIPTION
Following on from https://github.com/citizensadvice/design-system/pull/3074 configure the demo application to raise on deprecations in development and test environments to ensure that any example code isn't using deprecated design system arguments or methods.

Includes a failing commit (https://github.com/citizensadvice/design-system/pull/3075/commits/7edbe80dd172bdff31392763469ccdd123f8c955) which will be removed from this PR once it has demonstrated that CI fails when a component preview contains a deprecated argument.

See: https://github.com/citizensadvice/design-system/actions/runs/6801856332/job/18493622727?pr=3075#step:11:62

Fails via the Cypress accessibility smoke-test because that's what actually loads every single component example which is a _little_ counter intuitive but the a) the log message contains the deprecation and b) will raise in development too so it should be pretty obvious what's going on.

### Screenshot

<img width="679" alt="image" src="https://github.com/citizensadvice/design-system/assets/123386/84bfa791-ff70-462d-913e-ba3bbda7c30c">
