### PR TITLE
Add Ruby 3.3 to test matrix

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -25,7 +25,7 @@ jobs:
       fail-fast: false
       matrix:
         # Active Ruby versions (https://endoflife.date/ruby)
-        ruby_version: ['3.0', '3.1', '3.2']
+        ruby_version: ['3.0', '3.1', '3.2', '3.3']
         # Last 3 major Rails releases
         rails_version: ['~> 6.1', '~> 7.0.0', '~> 7.1.0']
         # Any supported ViewComponent versions


### PR DESCRIPTION
Ruby 3.3 is out now so we can add it to the test matrix.