### PR TITLE
Feat/date fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+**BREAKING CHANGE**
+- Date input component: add date_field slot instead of auto generating date input fields 
+
 **New**
 
 - Include Rails 7.1 in supported version

--- a/demo/app/views/example_form/new.html.erb
+++ b/demo/app/views/example_form/new.html.erb
@@ -47,7 +47,11 @@
         }
       ) %>
 
-      <%= render CitizensAdviceComponents::DateInput.new(name: :date_of_purchase, label: "When did you purchase the goods or services?") %>
+      <%= render CitizensAdviceComponents::DateInput.new(
+        name: :date_of_purchase,
+        label: "When did you purchase the goods or services?") do |c| %>
+        <% c.with_date_fields([{ name: "purchase[day]", id: "day-id", timespan: :day}, { name: "purchase[month]", id: "month-id", timespan: :month }, { name: "purchase[year]", id: "year-id", timespan: :year, }]) %>
+      <% end %>
 
       <%= render CitizensAdviceComponents::RadioGroup.new(
         legend: "Have you contacted the trader about this complaint?",

--- a/demo/spec/components/previews/date_input_preview.rb
+++ b/demo/spec/components/previews/date_input_preview.rb
@@ -79,6 +79,15 @@ class DateInputPreview < ViewComponent::Preview
     end
   end
 
+  def autocomplete
+    render CitizensAdviceComponents::DateInput.new(
+      name: "bday",
+      label: "Date of birth"
+    ) do |c|
+      c.with_date_fields(date_fields_autocomplete)
+    end
+  end
+
   private
 
   def date_fields
@@ -143,6 +152,29 @@ class DateInputPreview < ViewComponent::Preview
         id: "year-id",
         timespan: :year,
         value: 1990
+      }
+    ]
+  end
+
+  def date_fields_autocomplete
+    [
+      {
+        name: "day",
+        id: "day-id",
+        timespan: :day,
+        autocomplete: "bday-day"
+      },
+      {
+        name: "month",
+        id: "month-id",
+        timespan: :month,
+        autocomplete: "bday-month"
+      },
+      {
+        name: "year",
+        id: "year-id",
+        timespan: :year,
+        autocomplete: "bday-year"
       }
     ]
   end

--- a/demo/spec/components/previews/date_input_preview.rb
+++ b/demo/spec/components/previews/date_input_preview.rb
@@ -2,7 +2,9 @@
 
 class DateInputPreview < ViewComponent::Preview
   def example
-    render CitizensAdviceComponents::DateInput.new(name: "dob", label: "Date of birth")
+    render CitizensAdviceComponents::DateInput.new(name: "dob", label: "Date of birth") do |c|
+      c.with_date_fields(date_fields)
+    end
   end
 
   def hint
@@ -12,7 +14,9 @@ class DateInputPreview < ViewComponent::Preview
       options: {
         hint: "Enter your date of birth, like 01 02 1990"
       }
-    )
+    ) do |c|
+      c.with_date_fields(date_fields)
+    end
   end
 
   def optional
@@ -22,7 +26,9 @@ class DateInputPreview < ViewComponent::Preview
       options: {
         optional: true
       }
-    )
+    ) do |c|
+      c.with_date_fields(date_fields)
+    end
   end
 
   def error
@@ -33,7 +39,9 @@ class DateInputPreview < ViewComponent::Preview
       options: {
         error_message: "Enter your date of birth, like 01 02 1990"
       }
-    )
+    ) do |c|
+      c.with_date_fields(date_fields)
+    end
   end
 
   def incomplete_error
@@ -41,14 +49,12 @@ class DateInputPreview < ViewComponent::Preview
       name: "bday",
       label: "Date of birth",
       errors: %i[year],
-      values: {
-        day: 1,
-        month: 1
-      },
       options: {
         error_message: "Date of birth must include a year"
       }
-    )
+    ) do |c|
+      c.with_date_fields(date_fields)
+    end
   end
 
   def validation_error
@@ -56,26 +62,88 @@ class DateInputPreview < ViewComponent::Preview
       name: "bday",
       label: "Date of birth",
       errors: %i[day],
-      values: {
-        day: 99,
-        month: 1,
-        year: 1990
-      },
       options: {
         error_message: "Date of birth must be a real date"
       }
-    )
+    ) do |c|
+      c.with_date_fields(date_fields_validation_error)
+    end
   end
 
   def values
     render CitizensAdviceComponents::DateInput.new(
       name: "bday",
-      label: "Date of birth",
-      values: {
-        day: 1,
-        month: 1,
-        year: 1990
+      label: "Date of birth"
+    ) do |c|
+      c.with_date_fields(date_fields_values)
+    end
+  end
+
+  private
+
+  def date_fields
+    [
+      {
+        name: "day",
+        id: "day-id",
+        timespan: :day
+      },
+      {
+        name: "month",
+        id: "month-id",
+        timespan: :month
+      },
+      {
+        name: "year",
+        id: "year-id",
+        timespan: :year
       }
-    )
+    ]
+  end
+
+  def date_fields_validation_error
+    [
+      {
+        name: "day",
+        id: "day-id",
+        timespan: :day,
+        value: 99
+      },
+      {
+        name: "month",
+        id: "month-id",
+        timespan: :month,
+        value: 1
+      },
+      {
+        name: "year",
+        id: "year-id",
+        timespan: :year,
+        value: 1990
+      }
+    ]
+  end
+
+  def date_fields_values
+    [
+      {
+        name: "day",
+        id: "day-id",
+        timespan: :day,
+        value: 1
+      },
+      {
+        name: "month",
+        id: "month-id",
+        timespan: :month,
+        value: 1
+      },
+      {
+        name: "year",
+        id: "year-id",
+        timespan: :year,
+        value: 1990
+      }
+    ]
   end
 end

--- a/design-system-docs/src/_component_docs/date-input.md
+++ b/design-system-docs/src/_component_docs/date-input.md
@@ -34,6 +34,10 @@ A date input field allows the user to enter a date they remember.
 
 <%= render(Shared::ComponentExample.new(:date_input, :with_values)) %>
 
+### With autocomplete
+
+<%= render(Shared::ComponentExample.new(:date_input, :with_autocomplete)) %>
+
 ## Using with Rails
 
 If you are using the `citizens_advice_components` gem, you can call the component from within a template using:
@@ -45,7 +49,7 @@ If you are using the `citizens_advice_components` gem, you can call the componen
 <%= render Shared::ArgumentsTable.new(:date_input) %>
 
 ### Date fields slot
+
 The component requires a date fields slot. Usually there are three date fields - day, month and year.
 
 <%= render Shared::ArgumentsTable.new(:date_field) %>
-

--- a/design-system-docs/src/_component_docs/date-input.md
+++ b/design-system-docs/src/_component_docs/date-input.md
@@ -43,3 +43,9 @@ If you are using the `citizens_advice_components` gem, you can call the componen
 ### Component arguments
 
 <%= render Shared::ArgumentsTable.new(:date_input) %>
+
+### Date fields slot
+The component requires a date fields slot. Usually there are three date fields - day, month and year.
+
+<%= render Shared::ArgumentsTable.new(:date_field) %>
+

--- a/design-system-docs/src/_component_examples/_date_input/default.erb
+++ b/design-system-docs/src/_component_examples/_date_input/default.erb
@@ -2,4 +2,22 @@
 title: default
 ---
 
-<%= render CitizensAdviceComponents::DateInput.new(name: "dob", label: "Date of birth") %>
+<%= render CitizensAdviceComponents::DateInput.new(name: "dob", label: "Date of birth") do |c|
+  c.with_date_fields([
+                       {
+                         name: "day",
+                         id: "day-id",
+                         timespan: :day
+                       },
+                       {
+                         name: "month",
+                         id: "month-id",
+                         timespan: :month
+                       },
+                       {
+                         name: "year",
+                         id: "year-id",
+                         timespan: :year
+                       }
+                     ])
+end %>

--- a/design-system-docs/src/_component_examples/_date_input/optional.erb
+++ b/design-system-docs/src/_component_examples/_date_input/optional.erb
@@ -8,4 +8,22 @@ title: optional
      options: {
        optional: true
      }
-   ) %>
+   ) do |c|
+      c.with_date_fields([
+                           {
+                             name: "day",
+                             id: "day-id",
+                             timespan: :day
+                           },
+                           {
+                             name: "month",
+                             id: "month-id",
+                             timespan: :month
+                           },
+                           {
+                             name: "year",
+                             id: "year-id",
+                             timespan: :year
+                           }
+                         ])
+end %>

--- a/design-system-docs/src/_component_examples/_date_input/with_autocomplete.erb
+++ b/design-system-docs/src/_component_examples/_date_input/with_autocomplete.erb
@@ -1,0 +1,34 @@
+---
+title: with autocomplete
+---
+
+<%= render CitizensAdviceComponents::DateInput.new(
+      name: "bday",
+      label: "Date of birth",
+      values: {
+        day: 1,
+        month: 1,
+        year: 1990
+      }
+    ) do |c|
+        c.with_date_fields([
+                             {
+                               name: "day",
+                               id: "day-id",
+                               timespan: :day,
+                               autocomplete: "bday-day"
+                             },
+                             {
+                               name: "month",
+                               id: "month-id",
+                               timespan: :month,
+                               autocomplete: "bday-month"
+                             },
+                             {
+                               name: "year",
+                               id: "year-id",
+                               timespan: :year,
+                               autocomplete: "bday-year"
+                             }
+                           ])
+end %>

--- a/design-system-docs/src/_component_examples/_date_input/with_error.erb
+++ b/design-system-docs/src/_component_examples/_date_input/with_error.erb
@@ -9,4 +9,22 @@ title: with error
       options: {
         error_message: "Enter your date of birth, like 01 02 1990"
       }
-    ) %>
+    ) do |c|
+        c.with_date_fields([
+                             {
+                               name: "day",
+                               id: "day-id",
+                               timespan: :day
+                             },
+                             {
+                               name: "month",
+                               id: "month-id",
+                               timespan: :month
+                             },
+                             {
+                               name: "year",
+                               id: "year-id",
+                               timespan: :year
+                             }
+                           ])
+end %>

--- a/design-system-docs/src/_component_examples/_date_input/with_hint.erb
+++ b/design-system-docs/src/_component_examples/_date_input/with_hint.erb
@@ -8,4 +8,22 @@ title: with hint
       options: {
         hint: "Enter your date of birth, like 01 02 1990"
       }
-    ) %>
+    ) do |c|
+        c.with_date_fields([
+                             {
+                               name: "day",
+                               id: "day-id",
+                               timespan: :day
+                             },
+                             {
+                               name: "month",
+                               id: "month-id",
+                               timespan: :month
+                             },
+                             {
+                               name: "year",
+                               id: "year-id",
+                               timespan: :year
+                             }
+                           ])
+end %>

--- a/design-system-docs/src/_component_examples/_date_input/with_incomplete_error.erb
+++ b/design-system-docs/src/_component_examples/_date_input/with_incomplete_error.erb
@@ -13,4 +13,24 @@ title: with incomplete error
       options: {
         error_message: "Date of birth must include a year"
       }
-    ) %>
+    ) do |c|
+        c.with_date_fields([
+                             {
+                               name: "day",
+                               id: "day-id",
+                               timespan: :day,
+                               value: 1
+                             },
+                             {
+                               name: "month",
+                               id: "month-id",
+                               timespan: :month,
+                               value: 1
+                             },
+                             {
+                               name: "year",
+                               id: "year-id",
+                               timespan: :year
+                             }
+                           ])
+end %>

--- a/design-system-docs/src/_component_examples/_date_input/with_validation_error.erb
+++ b/design-system-docs/src/_component_examples/_date_input/with_validation_error.erb
@@ -6,12 +6,28 @@ title: with error message
       name: "bday",
       label: "Date of birth",
       errors: %i[day],
-      values: {
-        day: 99,
-        month: 1,
-        year: 1990
-      },
       options: {
         error_message: "Date of birth must be a real date"
       }
-    ) %>
+    ) do |c|
+        c.with_date_fields([
+                             {
+                               name: "day",
+                               id: "day-id",
+                               timespan: :day,
+                               value: 99
+                             },
+                             {
+                               name: "month",
+                               id: "month-id",
+                               timespan: :month,
+                               value: 1
+                             },
+                             {
+                               name: "year",
+                               id: "year-id",
+                               timespan: :year,
+                               value: 1990
+                             }
+                           ])
+end %>

--- a/design-system-docs/src/_component_examples/_date_input/with_values.erb
+++ b/design-system-docs/src/_component_examples/_date_input/with_values.erb
@@ -10,4 +10,25 @@ title: with values
         month: 1,
         year: 1990
       }
-    ) %>
+    ) do |c|
+        c.with_date_fields([
+                             {
+                               name: "day",
+                               id: "day-id",
+                               timespan: :day,
+                               value: 1
+                             },
+                             {
+                               name: "month",
+                               id: "month-id",
+                               timespan: :month,
+                               value: 1
+                             },
+                             {
+                               name: "year",
+                               id: "year-id",
+                               timespan: :year,
+                               value: 1990
+                             }
+                           ])
+end %>

--- a/design-system-docs/src/_data/component_arguments.yml
+++ b/design-system-docs/src/_data/component_arguments.yml
@@ -237,8 +237,6 @@ date_input:
     description: Required, the text for the label associated with the input
   - argument: errors
     description: 'Optional, an array of which fields should be hightlighted when an error message appears. Options are <code>day</code>, <code>month</code> and <code>year</code>.'
-  - argument: values
-    description: Optional, placeholder values
   - argument: options
     description: 'Optional, a hash with one or more of the following values:'
   - argument: hint
@@ -247,6 +245,15 @@ date_input:
     description: '→ Optional, an error message for the input'
   - argument: optional
     description: '→ Optional, boolean indicating the field is optional (ie not required)'
+date_field:
+  - argument: name
+    description: 'Required, field name'
+  - argument: id
+    description: 'Required, field id'
+  - argument: timespan
+    description: 'Required, one of: <code>:day</code>, <code>:month</code>, <code>:year</code>'
+  - argument: value
+    description: 'Optional, a pre-filled value'
 select:
   - argument: name
     description: Required, field name

--- a/design-system-docs/src/_data/component_arguments.yml
+++ b/design-system-docs/src/_data/component_arguments.yml
@@ -254,6 +254,8 @@ date_field:
     description: 'Required, one of: <code>:day</code>, <code>:month</code>, <code>:year</code>'
   - argument: value
     description: 'Optional, a pre-filled value'
+  - argument: autocomplete
+    description: 'Optional, adding an input purpose'
 select:
   - argument: name
     description: Required, field name

--- a/engine/app/components/citizens_advice_components/date_input.html.erb
+++ b/engine/app/components/citizens_advice_components/date_input.html.erb
@@ -15,12 +15,12 @@
         <p class="cads-form-field__error-message"><%= error_message %></p>
       <% end %>
       <div class="cads-date-input">
-        <% %i[day month year].each do |timespan| %>
+        <% date_fields.each do |date_field| %>
           <div class="cads-date-input__item">
-            <%= tag.label(**label_attributes(timespan)) do %>
-              <%= t("citizens_advice_components.date_input.#{timespan}") %>
+            <%= tag.label(**label_attributes(date_field)) do %>
+              <%= t("citizens_advice_components.date_input.#{date_field.timespan}") %>
             <% end %>
-            <%= tag.input(**input_attributes(timespan)) %>
+            <%= tag.input(**input_attributes(date_field)) %>
           </div>
         <% end %>
       </div>

--- a/engine/app/components/citizens_advice_components/date_input.rb
+++ b/engine/app/components/citizens_advice_components/date_input.rb
@@ -2,6 +2,7 @@
 
 module CitizensAdviceComponents
   class DateInput < Input
+    renders_many :date_fields, "DateField"
     attr_reader :name, :label, :errors, :values
 
     def initialize(values: nil, errors: nil, **args)
@@ -10,44 +11,41 @@ module CitizensAdviceComponents
       @errors = errors
     end
 
-    def input_attributes(timespan)
+    def render?
+      date_fields.present?
+    end
+
+    def input_attributes(date_field)
       {
-        class: input_classes(timespan),
-        name: input_id(timespan),
-        id: input_id(timespan),
+        class: input_classes(date_field),
+        name: date_field.name,
+        id: input_id(date_field),
         inputmode: "numeric",
-        value: value_for(timespan),
-        "aria-invalid": timespan_error?(timespan),
-        "data-testid": "#{timespan}-input"
+        value: date_field.value,
+        "data-testid": "#{date_field.timespan}-input"
       }
     end
 
-    def label_attributes(timespan)
+    def label_attributes(date_field)
       {
         class: "cads-form-field__label",
-        id: "#{input_id(timespan)}-label",
-        for: input_id(timespan)
+        id: "#{input_id(date_field)}-label",
+        for: input_id(date_field)
       }
     end
 
     private
 
-    def value_for(timespan)
-      return if values.blank?
-
-      values[timespan].presence
+    def input_id(date_field)
+      date_field.id
     end
 
-    def input_id(timespan)
-      "#{name}-#{timespan}"
+    def input_classes(date_field)
+      "cads-input #{width_class(date_field.timespan)} #{error_class(date_field)}"
     end
 
-    def input_classes(timespan)
-      "cads-input #{width_class(timespan)} #{error_class(timespan)}"
-    end
-
-    def error_class(timespan)
-      "cads-input--error" if timespan_error?(timespan)
+    def error_class(date_field)
+      "cads-input--error" if timespan_error?(date_field.timespan)
     end
 
     def timespan_error?(timespan)
@@ -62,6 +60,17 @@ module CitizensAdviceComponents
         "cads-input--4ch"
       else
         "cads-input--2ch"
+      end
+    end
+
+    class DateField
+      attr_reader :name, :id, :timespan, :value
+
+      def initialize(name:, id:, timespan:, value: nil)
+        @name = name
+        @id = id
+        @timespan = timespan
+        @value = value
       end
     end
   end

--- a/engine/app/components/citizens_advice_components/date_input.rb
+++ b/engine/app/components/citizens_advice_components/date_input.rb
@@ -22,7 +22,8 @@ module CitizensAdviceComponents
         id: input_id(date_field),
         inputmode: "numeric",
         value: date_field.value,
-        "data-testid": "#{date_field.timespan}-input"
+        "data-testid": "#{input_id(date_field)}-input",
+        autocomplete: date_field.autocomplete
       }
     end
 
@@ -64,13 +65,14 @@ module CitizensAdviceComponents
     end
 
     class DateField
-      attr_reader :name, :id, :timespan, :value
+      attr_reader :name, :id, :timespan, :value, :autocomplete
 
-      def initialize(name:, id:, timespan:, value: nil)
+      def initialize(name:, id:, timespan:, value: nil, autocomplete: nil)
         @name = name
         @id = id
         @timespan = timespan
         @value = value
+        @autocomplete = autocomplete
       end
     end
   end

--- a/engine/spec/components/citizens_advice_components/date_input_spec.rb
+++ b/engine/spec/components/citizens_advice_components/date_input_spec.rb
@@ -46,6 +46,29 @@ RSpec.describe CitizensAdviceComponents::DateInput, type: :component do
     ]
   end
 
+  let(:date_fields_with_autocomplete) do
+    [
+      {
+        name: "day",
+        id: "day-id",
+        timespan: :day,
+        autocomplete: "bday-day"
+      },
+      {
+        name: "month",
+        id: "month-id",
+        timespan: :month,
+        autocomplete: "bday-month"
+      },
+      {
+        name: "year",
+        id: "year-id",
+        timespan: :year,
+        autocomplete: "bday-year"
+      }
+    ]
+  end
+
   context "with default arguments" do
     before do
       render_inline described_class.new(
@@ -118,5 +141,20 @@ RSpec.describe CitizensAdviceComponents::DateInput, type: :component do
     it { is_expected.to have_field "Day", with: "1" }
     it { is_expected.to have_field "Month", with: "2" }
     it { is_expected.to have_field "Year", with: "1990" }
+  end
+
+  context "with autocomplete" do
+    before do
+      render_inline described_class.new(
+        name: "example-date-input",
+        label: "Example date input"
+      ) do |c|
+        c.with_date_fields(date_fields_with_autocomplete)
+      end
+    end
+
+    it { is_expected.to have_selector "input[autocomplete=bday-day]" }
+    it { is_expected.to have_selector "input[autocomplete=bday-month]" }
+    it { is_expected.to have_selector "input[autocomplete=bday-year]" }
   end
 end

--- a/engine/spec/components/citizens_advice_components/date_input_spec.rb
+++ b/engine/spec/components/citizens_advice_components/date_input_spec.rb
@@ -3,6 +3,49 @@
 RSpec.describe CitizensAdviceComponents::DateInput, type: :component do
   subject { page }
 
+  let(:date_fields) do
+    [
+      {
+        name: "day",
+        id: "day-id",
+        timespan: :day
+      },
+      {
+        name: "month",
+        id: "month-id",
+        timespan: :month
+      },
+      {
+        name: "year",
+        id: "year-id",
+        timespan: :year
+      }
+    ]
+  end
+
+  let(:date_fields_with_values) do
+    [
+      {
+        name: "day",
+        id: "day-id",
+        timespan: :day,
+        value: 1
+      },
+      {
+        name: "month",
+        id: "month-id",
+        timespan: :month,
+        value: 2
+      },
+      {
+        name: "year",
+        id: "year-id",
+        timespan: :year,
+        value: 1990
+      }
+    ]
+  end
+
   context "with default arguments" do
     before do
       render_inline described_class.new(
@@ -10,7 +53,9 @@ RSpec.describe CitizensAdviceComponents::DateInput, type: :component do
         label: "Example date input",
         errors: nil,
         values: nil
-      )
+      ) do |c|
+        c.with_date_fields(date_fields)
+      end
     end
 
     it { is_expected.to have_field "Day" }
@@ -27,25 +72,35 @@ RSpec.describe CitizensAdviceComponents::DateInput, type: :component do
   end
 
   context "with errors" do
+    let(:error_message) { "Enter your date of birth, like 01 02 1990" }
+
     before do
       render_inline described_class.new(
         name: "example-date-input",
         label: "Example date input",
         errors: %i[day month year],
-        values: nil
-      )
+        options: {
+          error_message: error_message
+        }
+      ) do |c|
+        c.with_date_fields(date_fields)
+      end
+    end
+
+    it "renders the error message" do
+      expect(page).to have_text error_message
     end
 
     it "renders the day input as error" do
-      expect(page).to have_selector "[data-testid=day-input][aria-invalid=true]"
+      expect(page).to have_selector "[data-testid=day-id-input].cads-input--error"
     end
 
     it "renders the month input as error" do
-      expect(page).to have_selector "[data-testid=month-input][aria-invalid=true]"
+      expect(page).to have_selector "[data-testid=month-id-input].cads-input--error"
     end
 
     it "renders the year input as error" do
-      expect(page).to have_selector "[data-testid=year-input][aria-invalid=true]"
+      expect(page).to have_selector "[data-testid=year-id-input].cads-input--error"
     end
   end
 
@@ -54,13 +109,10 @@ RSpec.describe CitizensAdviceComponents::DateInput, type: :component do
       render_inline described_class.new(
         name: "example-date-input",
         label: "Example date input",
-        errors: %i[day month year],
-        values: {
-          day: 1,
-          month: 2,
-          year: 1990
-        }
-      )
+        errors: %i[day month year]
+      ) do |c|
+        c.with_date_fields(date_fields_with_values)
+      end
     end
 
     it { is_expected.to have_field "Day", with: "1" }


### PR DESCRIPTION
Similarly to https://github.com/citizensadvice/design-system/pull/3115 we need a way of changing the names/ids of the date input fields. This will help us when we create more Rails forms where the name has a different format: e.g `date_of_birth[day]`. To make this possible, I've added slots (date_fields) for the dates. I then thought that the behaviour of the fields is close to checkboxes (i.e part of a form group) and have tried to have DateInput inherit from FormGroup and DateField inherit from Input. There were a few problems with this approach (would require too much modification) so I decided to go with the initial date field slots. 

This is a breaking change, but wouldn't necessarily require a major release. The date fields were released fairly recently but to my knowledge, there is not product which currently uses them.