### PR TITLE
Remove unused `type` option from select component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Remove support for Ruby 2.7
 - Callout: Deprecate `title` attribute; replace with more general  `attributes`
 - Inputs: added optional `id` attribute
+- Selects: remove unused (but required) `type` attribute
 
 ## v5.6.0
 

--- a/design-system-docs/src/_component_examples/_select/default.erb
+++ b/design-system-docs/src/_component_examples/_select/default.erb
@@ -10,5 +10,4 @@ title: default
     ["Find your local Citizens Advice", "FYLCA"]
   ],
   name: "product",
-  label: "Choose a product",
-  type: :text))%>
+  label: "Choose a product")) %>

--- a/design-system-docs/src/_component_examples/_select/optional.erb
+++ b/design-system-docs/src/_component_examples/_select/optional.erb
@@ -11,7 +11,6 @@ title: optional
       ],
       name: "product",
       label: "Choose a product",
-      type: :text,
       options: {
         optional: true
       }

--- a/design-system-docs/src/_component_examples/_select/with_error.erb
+++ b/design-system-docs/src/_component_examples/_select/with_error.erb
@@ -11,5 +11,4 @@ title: with error
   ],
   name: "product",
   label: "Choose a product",
-  type: :text,
   options: { error_message: "Select a product" })) %>

--- a/design-system-docs/src/_component_examples/_select/with_hint_text.erb
+++ b/design-system-docs/src/_component_examples/_select/with_hint_text.erb
@@ -11,5 +11,4 @@ title: with hint text
   ],
   name: "product",
   label: "Choose a product",
-  type: :text,
-  options: { hint: "Choose a product from the list below" }))%>
+  options: { hint: "Choose a product from the list below" })) %>

--- a/design-system-docs/src/_component_examples/_select/with_value.erb
+++ b/design-system-docs/src/_component_examples/_select/with_value.erb
@@ -11,5 +11,4 @@ title: with value
   ],
   name: "product",
   label: "Choose a product",
-  type: :text,
-  options: { value: "FYLCA", hint: "Choose a product from the list below" }))%>
+  options: { value: "FYLCA", hint: "Choose a product from the list below" })) %>

--- a/engine/app/components/citizens_advice_components/select.rb
+++ b/engine/app/components/citizens_advice_components/select.rb
@@ -6,7 +6,7 @@ module CitizensAdviceComponents
 
     def initialize(select_options:, **args)
       @select_options = select_options
-      @base_input_args = args
+      @base_input_args = args.merge(type: nil)
       super(**@base_input_args)
     end
 

--- a/engine/spec/components/citizens_advice_components/select_spec.rb
+++ b/engine/spec/components/citizens_advice_components/select_spec.rb
@@ -20,7 +20,6 @@ RSpec.describe CitizensAdviceComponents::Select, type: :component do
       select_options: select_options,
       name: name.presence,
       label: label.presence,
-      type: nil,
       options: options
     )
   end


### PR DESCRIPTION
This was only needed because `CitizensAdviceComponents::Select` inherits from `CitizensAdviceComponents::Input` which does require a `type`.

Instead, we pass `type: nil` by default into the initialiser.