### PR TITLE
Increase minimum Ruby version to 3.1.x

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -25,7 +25,7 @@ jobs:
       fail-fast: false
       matrix:
         # Active Ruby versions (https://endoflife.date/ruby)
-        ruby_version: ['3.0', '3.1', '3.2', '3.3']
+        ruby_version: ['3.1', '3.2', '3.3']
         # Last 3 major Rails releases
         rails_version: ['~> 6.1', '~> 7.0.0', '~> 7.1.0']
         # Any supported ViewComponent versions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+**New**
+
+- Remove support for end-of-life Ruby 3.0.x versions
+
 ## v5.7.0
 
 ### 12 February 2024

--- a/engine/.rubocop.yml
+++ b/engine/.rubocop.yml
@@ -6,15 +6,20 @@ inherit_gem:
 AllCops:
   SuggestExtensions: false
   # Match minimum target version to gemspec
-  TargetRubyVersion: 3.0
+  TargetRubyVersion: 3.1
 
-# Calls to super in subclasses of ViewComponent::Base aren't needed
-# by default and can change the behaviour of **kwargs so we
-# exclude component classes from this rule
-# https://github.com/ViewComponent/view_component/discussions/1545
 Lint/MissingSuper:
   Exclude:
+    # Calls to super in subclasses of ViewComponent::Base aren't needed
+    # by default and can change the behaviour of **kwargs so we
+    # exclude component classes from this rule
+    # https://github.com/ViewComponent/view_component/discussions/1545
     - 'app/components/**/*'
+
+Style/HashSyntax:
+  # We do not necessarily find that Ruby 3.1’s hash value shorthand syntax
+  # encourages greater readability so support either style
+  EnforcedShorthandSyntax: 'either'
 
 RSpec/ExampleLength:
   CountAsOne: ['array', 'hash']

--- a/engine/citizens_advice_components.gemspec
+++ b/engine/citizens_advice_components.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |spec|
   spec.authors = ["Citizens Advice"]
 
   spec.summary = "Citizens Advice Design System components distributed as a Rails engine"
-  spec.required_ruby_version = Gem::Requirement.new(">= 3.0")
+  spec.required_ruby_version = Gem::Requirement.new(">= 3.1")
 
   # Prevent pushing this gem to RubyGems.org. To allow pushes either set the 'allowed_push_host'
   # to allow pushing to a single host or delete this section to allow pushing to any host.


### PR DESCRIPTION
Ruby 3.0.x is due to go [end-of-life on 31 March 2024](https://endoflife.date/ruby).

To prepare for this:

1. Increase the minimum supported Ruby version to 3.1.x
2. Remove Ruby 3.0.x from our CI matrix
3. Update our rubocop rules to reflect changes in the minimum version

Raising this ahead of time but we can hold off on merging this until closer to the EOL date.