### PR TITLE
update footer component fallback legal text to reflect registered office move

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Remove support for end-of-life Ruby 3.0.x versions
 - Targeted content: changed icon from plus/minus to chevron
 - Removes the icon from external links
+- Footer component: Updated fallback legal summary to automatically reflect the new registered office on moving day
 
 ## v5.7.0
 

--- a/engine/app/components/citizens_advice_components/footer.rb
+++ b/engine/app/components/citizens_advice_components/footer.rb
@@ -60,7 +60,12 @@ module CitizensAdviceComponents
     def legal_summary_fallback
       return if legal_summary
 
-      t("citizens_advice_components.footer.legal_summary")
+      # Change to new registered address following office move
+      if Time.current.to_date >= Date.new(2024, 3, 15)
+        t("citizens_advice_components.footer.legal_summary_new_address")
+      else
+        t("citizens_advice_components.footer.legal_summary")
+      end
     end
 
     class FooterColumn < Base

--- a/engine/config/locales/cy.yml
+++ b/engine/config/locales/cy.yml
@@ -10,6 +10,7 @@ cy:
     footer:
       copyright: Hawlfraint ©%{year} Cyngor ar Bopeth. Cedwir pob hawl.
       legal_summary: 'Cyngor ar Bopeth yn enw gweithredol ar Gymdeithas Genedlaethol Cyngor ar Bopeth. Rhif elusen gofrestredig 279057. Rhif TAW 726 0202 76. Cwmni cyfyngedig drwy warant. Rhif cofrestredig 0143694 Lloegr. Swyddfa gofrestredig: Cyngor ar Bopeth, 3ydd Llawr Gogledd, 200 Aldersgate, Llundain, EC1A 4HD'
+      legal_summary_new_address: 'Cyngor ar Bopeth yn enw gweithredol ar Gymdeithas Genedlaethol Cyngor ar Bopeth. Rhif elusen gofrestredig 279057. Rhif TAW 726 0202 76. Cwmni cyfyngedig drwy warant. Rhif cofrestredig 0143694 Lloegr. Swyddfa gofrestredig: Cyngor ar Bopeth, 3ydd Llawr, 1 Easton Street, Llundain, WC1X 0DW'
       logo_title: Hafan Cyngor ar Bopeth
       navigation_title: Llywio Troedyn
       website_feedback: A oes unrhyw beth o'i le ar y dudalen hon? Gadewch i ni wybod

--- a/engine/config/locales/en.yml
+++ b/engine/config/locales/en.yml
@@ -10,6 +10,7 @@ en:
     footer:
       copyright: Copyright ©%{year} Citizens Advice. All rights reserved.
       legal_summary: 'Citizens Advice is an operating name of the National Association of Citizens Advice Bureaux. Registered charity number 279057. VAT number 726 0202 76. Company limited by guarantee. Registered number 01436945 England. Registered office: Citizens Advice, 3rd Floor North, 200 Aldersgate, London, EC1A 4HD'
+      legal_summary_new_address: 'Citizens Advice is an operating name of the National Association of Citizens Advice Bureaux. Registered charity number 279057. VAT number 726 0202 76. Company limited by guarantee. Registered number 01436945 England. Registered office: Citizens Advice, 3rd Floor, 1 Easton Street, London, WC1X 0DW'
       logo_title: Citizens Advice homepage
       navigation_title: Footer Navigation
       website_feedback: Is there anything wrong with this page? Let us know

--- a/engine/spec/components/citizens_advice_components/footer_spec.rb
+++ b/engine/spec/components/citizens_advice_components/footer_spec.rb
@@ -53,6 +53,25 @@ RSpec.describe CitizensAdviceComponents::Footer, type: :component do
     end
   end
 
+  describe "fallback legal summary" do
+    before do
+      travel_to fake_date
+      render_inline(described_class.new)
+    end
+
+    context "when before the office move" do
+      let(:fake_date) { Date.new(2024, 2, 28) }
+
+      it { is_expected.to have_selector "[data-testid='legal-summary']", text: "200 Aldersgate" }
+    end
+
+    context "when after the office move" do
+      let(:fake_date) { Date.new(2024, 3, 15) }
+
+      it { is_expected.to have_selector "[data-testid='legal-summary']", text: "1 Easton Street" }
+    end
+  end
+
   describe "columns" do
     before do
       allow(CitizensAdviceComponents.deprecator).to receive(:warn)


### PR DESCRIPTION
This has been implemented to check the current date and return the new registered office from moving day onwards.