### PR TITLE
fix: commonise legal summary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+**Fix**
+
+- Footer component: commonise legal summary fallback text
+
 ## v5.8.0
 
 ### 29 February 2024

--- a/engine/app/components/citizens_advice_components/footer.rb
+++ b/engine/app/components/citizens_advice_components/footer.rb
@@ -7,7 +7,7 @@ module CitizensAdviceComponents
     renders_one :feedback_link, "FooterFeedbackLink"
 
     renders_one :legal_summary, lambda { |text|
-      text.presence || t("citizens_advice_components.footer.legal_summary")
+      text.presence || legal_summary_default
     }
 
     renders_many :columns, "FooterColumn"
@@ -60,6 +60,10 @@ module CitizensAdviceComponents
     def legal_summary_fallback
       return if legal_summary
 
+      legal_summary_default
+    end
+
+    def legal_summary_default
       # Change to new registered address following office move
       if Time.current.to_date >= Date.new(2024, 3, 15)
         t("citizens_advice_components.footer.legal_summary_new_address")

--- a/engine/spec/components/citizens_advice_components/footer_spec.rb
+++ b/engine/spec/components/citizens_advice_components/footer_spec.rb
@@ -21,35 +21,66 @@ RSpec.describe CitizensAdviceComponents::Footer, type: :component do
     end
   end
 
-  describe "custom legal summary" do
-    context "when valid legal summary" do
-      before do
-        render_inline(described_class.new) do |c|
-          c.with_legal_summary("Legal summary custom text")
-        end
+  describe "custom legal summary valid" do
+    before do
+      travel_to fake_date
+      render_inline(described_class.new) do |c|
+        c.with_legal_summary("Legal summary custom text")
       end
+    end
+
+    context "when before the office move" do
+      let(:fake_date) { Date.new(2024, 2, 28) }
 
       it { is_expected.to have_selector "[data-testid='legal-summary']", text: "Legal summary custom text" }
     end
 
-    context "when whitespace legal summary" do
-      before do
-        render_inline(described_class.new) do |c|
-          c.with_legal_summary(" ")
-        end
-      end
+    context "when after the office move" do
+      let(:fake_date) { Date.new(2024, 3, 15) }
 
-      it { is_expected.to have_selector "[data-testid='legal-summary']", text: "Citizens Advice is an operating name of" }
+      it { is_expected.to have_selector "[data-testid='legal-summary']", text: "Legal summary custom text" }
+    end
+  end
+
+  describe "custom legal summary whitespace" do
+    before do
+      travel_to fake_date
+      render_inline(described_class.new) do |c|
+        c.with_legal_summary(" ")
+      end
     end
 
-    context "when empty legal summary" do
-      before do
-        render_inline(described_class.new) do |c|
-          c.with_legal_summary("")
-        end
-      end
+    context "when before the office move" do
+      let(:fake_date) { Date.new(2024, 2, 28) }
 
-      it { is_expected.to have_selector "[data-testid='legal-summary']", text: "Citizens Advice is an operating name of" }
+      it { is_expected.to have_selector "[data-testid='legal-summary']", text: "200 Aldersgate" }
+    end
+
+    context "when after the office move" do
+      let(:fake_date) { Date.new(2024, 3, 15) }
+
+      it { is_expected.to have_selector "[data-testid='legal-summary']", text: "1 Easton Street" }
+    end
+  end
+
+  describe "custom legal summary empty" do
+    before do
+      travel_to fake_date
+      render_inline(described_class.new) do |c|
+        c.with_legal_summary("")
+      end
+    end
+
+    context "when before the office move" do
+      let(:fake_date) { Date.new(2024, 2, 28) }
+
+      it { is_expected.to have_selector "[data-testid='legal-summary']", text: "200 Aldersgate" }
+    end
+
+    context "when after the office move" do
+      let(:fake_date) { Date.new(2024, 3, 15) }
+
+      it { is_expected.to have_selector "[data-testid='legal-summary']", text: "1 Easton Street" }
     end
   end
 


### PR DESCRIPTION
Adding `legal_summary_default` method which is reused in `legal_summary_feedback` (if no `legal_summary` slot is added) and if a `legal_summary` slot exists but is empty. 