### PR TITLE
Remove conditional footer logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+**New**
+
+- Footer: Make new office address the default and remove conditional address logic
+
 ## v5.8.1
 
 ### 8 March 2024

--- a/engine/app/components/citizens_advice_components/footer.rb
+++ b/engine/app/components/citizens_advice_components/footer.rb
@@ -54,22 +54,11 @@ module CitizensAdviceComponents
     end
 
     def legal_summary_text
-      legal_summary.presence || legal_summary_fallback.presence
-    end
-
-    def legal_summary_fallback
-      return if legal_summary
-
-      legal_summary_default
+      legal_summary.presence || legal_summary_default
     end
 
     def legal_summary_default
-      # Change to new registered address following office move
-      if Time.current.to_date >= Date.new(2024, 3, 15)
-        t("citizens_advice_components.footer.legal_summary_new_address")
-      else
-        t("citizens_advice_components.footer.legal_summary")
-      end
+      t("citizens_advice_components.footer.legal_summary")
     end
 
     class FooterColumn < Base

--- a/engine/config/locales/cy.yml
+++ b/engine/config/locales/cy.yml
@@ -9,8 +9,7 @@ cy:
       title: Mae yna problem
     footer:
       copyright: Hawlfraint ©%{year} Cyngor ar Bopeth. Cedwir pob hawl.
-      legal_summary: 'Cyngor ar Bopeth yn enw gweithredol ar Gymdeithas Genedlaethol Cyngor ar Bopeth. Rhif elusen gofrestredig 279057. Rhif TAW 726 0202 76. Cwmni cyfyngedig drwy warant. Rhif cofrestredig 0143694 Lloegr. Swyddfa gofrestredig: Cyngor ar Bopeth, 3ydd Llawr Gogledd, 200 Aldersgate, Llundain, EC1A 4HD'
-      legal_summary_new_address: 'Cyngor ar Bopeth yn enw gweithredol ar Gymdeithas Genedlaethol Cyngor ar Bopeth. Rhif elusen gofrestredig 279057. Rhif TAW 726 0202 76. Cwmni cyfyngedig drwy warant. Rhif cofrestredig 0143694 Lloegr. Swyddfa gofrestredig: Cyngor ar Bopeth, 3ydd Llawr, 1 Easton Street, Llundain, WC1X 0DW'
+      legal_summary: 'Cyngor ar Bopeth yn enw gweithredol ar Gymdeithas Genedlaethol Cyngor ar Bopeth. Rhif elusen gofrestredig 279057. Rhif TAW 726 0202 76. Cwmni cyfyngedig drwy warant. Rhif cofrestredig 0143694 Lloegr. Swyddfa gofrestredig: Cyngor ar Bopeth, 3ydd Llawr, 1 Easton Street, Llundain, WC1X 0DW'
       logo_title: Hafan Cyngor ar Bopeth
       navigation_title: Llywio Troedyn
       website_feedback: A oes unrhyw beth o'i le ar y dudalen hon? Gadewch i ni wybod

--- a/engine/config/locales/en.yml
+++ b/engine/config/locales/en.yml
@@ -9,8 +9,7 @@ en:
       title: There is a problem
     footer:
       copyright: Copyright ©%{year} Citizens Advice. All rights reserved.
-      legal_summary: 'Citizens Advice is an operating name of the National Association of Citizens Advice Bureaux. Registered charity number 279057. VAT number 726 0202 76. Company limited by guarantee. Registered number 01436945 England. Registered office: Citizens Advice, 3rd Floor North, 200 Aldersgate, London, EC1A 4HD'
-      legal_summary_new_address: 'Citizens Advice is an operating name of the National Association of Citizens Advice Bureaux. Registered charity number 279057. VAT number 726 0202 76. Company limited by guarantee. Registered number 01436945 England. Registered office: Citizens Advice, 3rd Floor, 1 Easton Street, London, WC1X 0DW'
+      legal_summary: 'Citizens Advice is an operating name of the National Association of Citizens Advice Bureaux. Registered charity number 279057. VAT number 726 0202 76. Company limited by guarantee. Registered number 01436945 England. Registered office: Citizens Advice, 3rd Floor, 1 Easton Street, London, WC1X 0DW'
       logo_title: Citizens Advice homepage
       navigation_title: Footer Navigation
       website_feedback: Is there anything wrong with this page? Let us know

--- a/engine/spec/components/citizens_advice_components/footer_spec.rb
+++ b/engine/spec/components/citizens_advice_components/footer_spec.rb
@@ -23,84 +23,40 @@ RSpec.describe CitizensAdviceComponents::Footer, type: :component do
 
   describe "custom legal summary valid" do
     before do
-      travel_to fake_date
       render_inline(described_class.new) do |c|
         c.with_legal_summary("Legal summary custom text")
       end
     end
 
-    context "when before the office move" do
-      let(:fake_date) { Date.new(2024, 2, 28) }
-
-      it { is_expected.to have_selector "[data-testid='legal-summary']", text: "Legal summary custom text" }
-    end
-
-    context "when after the office move" do
-      let(:fake_date) { Date.new(2024, 3, 15) }
-
-      it { is_expected.to have_selector "[data-testid='legal-summary']", text: "Legal summary custom text" }
-    end
+    it { is_expected.to have_selector "[data-testid='legal-summary']", text: "Legal summary custom text" }
   end
 
   describe "custom legal summary whitespace" do
     before do
-      travel_to fake_date
       render_inline(described_class.new) do |c|
         c.with_legal_summary(" ")
       end
     end
 
-    context "when before the office move" do
-      let(:fake_date) { Date.new(2024, 2, 28) }
-
-      it { is_expected.to have_selector "[data-testid='legal-summary']", text: "200 Aldersgate" }
-    end
-
-    context "when after the office move" do
-      let(:fake_date) { Date.new(2024, 3, 15) }
-
-      it { is_expected.to have_selector "[data-testid='legal-summary']", text: "1 Easton Street" }
-    end
+    it { is_expected.to have_selector "[data-testid='legal-summary']", text: "1 Easton Street" }
   end
 
   describe "custom legal summary empty" do
     before do
-      travel_to fake_date
       render_inline(described_class.new) do |c|
         c.with_legal_summary("")
       end
     end
 
-    context "when before the office move" do
-      let(:fake_date) { Date.new(2024, 2, 28) }
-
-      it { is_expected.to have_selector "[data-testid='legal-summary']", text: "200 Aldersgate" }
-    end
-
-    context "when after the office move" do
-      let(:fake_date) { Date.new(2024, 3, 15) }
-
-      it { is_expected.to have_selector "[data-testid='legal-summary']", text: "1 Easton Street" }
-    end
+    it { is_expected.to have_selector "[data-testid='legal-summary']", text: "1 Easton Street" }
   end
 
   describe "fallback legal summary" do
     before do
-      travel_to fake_date
       render_inline(described_class.new)
     end
 
-    context "when before the office move" do
-      let(:fake_date) { Date.new(2024, 2, 28) }
-
-      it { is_expected.to have_selector "[data-testid='legal-summary']", text: "200 Aldersgate" }
-    end
-
-    context "when after the office move" do
-      let(:fake_date) { Date.new(2024, 3, 15) }
-
-      it { is_expected.to have_selector "[data-testid='legal-summary']", text: "1 Easton Street" }
-    end
+    it { is_expected.to have_selector "[data-testid='legal-summary']", text: "1 Easton Street" }
   end
 
   describe "columns" do


### PR DESCRIPTION
The office move date has now passed we can remove the conditional logic and only ship the new office address.