### PR TITLE
Remove deprecations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,9 @@
 
 Remove a number of deprecations from the view components.
 
-- Remove deprecated content slot from section links
 - Remove deprecated callout title attribute
+- Remove deprecated feedback_url from footer
+- Remove deprecated content slot from section links
 
 ### Consistent javascript module imports
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 Remove a number of deprecations from the view components.
 
+- Remove deprecated content slot from section links
 - Remove deprecated callout title attribute
 
 ### Consistent javascript module imports

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Unreleased
 
+### Remove deprecations
+
+Remove a number of deprecations from the view components.
+
+- Remove deprecated callout title attribute
+
 ### Consistent javascript module imports
 
 Allow all modules to be imported using a consistent interface, either via:

--- a/design-system-docs/src/_data/component_arguments.yml
+++ b/design-system-docs/src/_data/component_arguments.yml
@@ -87,8 +87,6 @@ callout:
     description: 'Optional type. One of <code>:standard</code>, <code>:example</code>, <code>:important</code>, or <code>:adviser</code>. Defaults to <code>:standard</code>.'
   - argument: attributes
     description: Optional, attributes passed on to callout container element
-  - argument: title
-    description: '<strong>(Deprecated: use attributes hash instead)</strong> This previously set an aria-label which is not supported on non-interactive elements'
 search:
   - argument: value
     description: Optional, current value
@@ -114,8 +112,6 @@ on_this_page_links_slot:
   - argument: children
     description: Optional, array for nested links
 footer:
-  - argument: feedback_url
-    description: '<strong>(Deprecated: use feedback_link slot)</strong> If present, a link to this feedback form will be displayed'
   - argument: homepage_url
     description: 'Optional, defaults to <code>/</code>'
 footer_feedback_link_slot:

--- a/engine/app/components/citizens_advice_components/callout.rb
+++ b/engine/app/components/citizens_advice_components/callout.rb
@@ -2,9 +2,9 @@
 
 module CitizensAdviceComponents
   class Callout < Base
-    attr_reader :type, :title, :attributes
+    attr_reader :type, :attributes
 
-    def initialize(type: nil, title: nil, attributes: nil)
+    def initialize(type: nil, attributes: nil)
       super
       @type = fetch_or_fallback(
         allowed_values: %i[standard example important adviser],
@@ -12,9 +12,6 @@ module CitizensAdviceComponents
         fallback: :standard
       )
       @attributes = attributes.to_h
-      @title = title
-
-      title_deprecation
     end
 
     def show_badge?
@@ -23,14 +20,6 @@ module CitizensAdviceComponents
 
     def render?
       content.present?
-    end
-
-    def title_deprecation
-      return if @title.blank?
-
-      CitizensAdviceComponents.deprecator.warn(
-        "The title attribute is deprecated, use attributes instead"
-      )
     end
   end
 end

--- a/engine/app/components/citizens_advice_components/footer.html.erb
+++ b/engine/app/components/citizens_advice_components/footer.html.erb
@@ -1,14 +1,14 @@
 <footer id="cads-footer" class="cads-footer">
   <div class="cads-grid-container">
-    <% if feedback&.url.present? %>
+    <% if feedback_link&.url.present? %>
       <div class="cads-grid-row">
         <div class="cads-grid-col">
           <p class="cads-footer__feedback">
             <%= link_to(
-              feedback.title || t("citizens_advice_components.footer.website_feedback"),
-              feedback.url,
+              feedback_link.title || t("citizens_advice_components.footer.website_feedback"),
+              feedback_link.url,
               class: "cads-footer__hyperlink js-cads-footer-feedback",
-              **feedback.new_tab_attributes
+              **feedback_link.new_tab_attributes
             ) %>
           </p>
         </div>

--- a/engine/app/components/citizens_advice_components/footer.rb
+++ b/engine/app/components/citizens_advice_components/footer.rb
@@ -2,7 +2,7 @@
 
 module CitizensAdviceComponents
   class Footer < Base
-    attr_reader :homepage_url, :feedback_url
+    attr_reader :homepage_url
 
     renders_one :feedback_link, "FooterFeedbackLink"
 
@@ -12,12 +12,9 @@ module CitizensAdviceComponents
 
     renders_many :columns, "FooterColumn"
 
-    def initialize(homepage_url: nil, feedback_url: nil)
+    def initialize(homepage_url: nil)
       super
       @homepage_url = homepage_url || "/"
-      @feedback_url = feedback_url.to_s
-
-      feedback_url_deprecation
     end
 
     def current_year
@@ -26,31 +23,6 @@ module CitizensAdviceComponents
 
     def columns_to_show
       columns.take(4)
-    end
-
-    def feedback
-      feedback_link.presence || feedback_link_fallback.presence
-    end
-
-    def feedback_link_fallback
-      return if @feedback_url.blank?
-
-      # Provide a fallback FooterFeedbackLink instance
-      # using the previous defaults for backwards compatability
-      # with the deprecated @feedback_url param.
-      FooterFeedbackLink.new(
-        url: @feedback_url,
-        title: t("citizens_advice_components.footer.website_feedback"),
-        new_tab: true
-      )
-    end
-
-    def feedback_url_deprecation
-      return if @feedback_url.blank?
-
-      CitizensAdviceComponents.deprecator.warn(
-        "feedback_url argument is deprecated used feedback_link slot instead"
-      )
     end
 
     def legal_summary_text

--- a/engine/app/components/citizens_advice_components/section_links.html.erb
+++ b/engine/app/components/citizens_advice_components/section_links.html.erb
@@ -18,8 +18,8 @@
           </li>
         <% end %>
       </ul>
-      <% if extra_content.present? %>
-        <%= extra_content %>
+      <% if custom_content? %>
+        <%= custom_content %>
       <% end %>
     </nav>
   </div>

--- a/engine/app/components/citizens_advice_components/section_links.rb
+++ b/engine/app/components/citizens_advice_components/section_links.rb
@@ -16,25 +16,7 @@ module CitizensAdviceComponents
     end
 
     def render?
-      section_links.present? || section_title.present? || extra_content.present?
-    end
-
-    def extra_content
-      @extra_content ||= extra_content_with_deprecation
-    end
-
-    private
-
-    def extra_content_with_deprecation
-      if custom_content.present?
-        custom_content
-      elsif content.respond_to?(:to_str) && content.present?
-        CitizensAdviceComponents.deprecator.warn(
-          "Use custom_content slot instead of default content block"
-        )
-
-        content
-      end
+      section_links.present? || section_title.present? || custom_content.present?
     end
 
     class SectionLink

--- a/engine/spec/components/citizens_advice_components/callout_spec.rb
+++ b/engine/spec/components/citizens_advice_components/callout_spec.rb
@@ -71,19 +71,6 @@ RSpec.describe CitizensAdviceComponents::Callout, type: :component do
     it { is_expected.to have_text "Example content" }
   end
 
-  context "when deprecated title is provided" do
-    before do
-      allow(CitizensAdviceComponents.deprecator).to receive(:warn)
-
-      render_inline(described_class.new(type: :standard, title: "Deprecated title")) { "Example content" }
-    end
-
-    it "logs deprecation warning" do
-      expect(CitizensAdviceComponents.deprecator).to have_received(:warn)
-        .with(/title attribute is deprecated/)
-    end
-  end
-
   context "when no content present" do
     before do
       render_inline(described_class.new(type: :standard))

--- a/engine/spec/components/citizens_advice_components/footer_spec.rb
+++ b/engine/spec/components/citizens_advice_components/footer_spec.rb
@@ -61,8 +61,6 @@ RSpec.describe CitizensAdviceComponents::Footer, type: :component do
 
   describe "columns" do
     before do
-      allow(CitizensAdviceComponents.deprecator).to receive(:warn)
-
       render_inline(described_class.new) do |c|
         c.with_columns(columns)
       end
@@ -127,27 +125,6 @@ RSpec.describe CitizensAdviceComponents::Footer, type: :component do
       end
 
       it { is_expected.to have_link "Is there anything wrong", href: "https://example.com/example-path" }
-    end
-  end
-
-  describe "deprecated feedback_url" do
-    before do
-      allow(CitizensAdviceComponents.deprecator).to receive(:warn)
-
-      render_inline(described_class.new(feedback_url: "https://example.com/"))
-    end
-
-    it { is_expected.to have_link "Is there anything wrong", href: "https://example.com/" }
-
-    it "logs deprecation warning" do
-      expect(CitizensAdviceComponents.deprecator).to have_received(:warn)
-        .with(/feedback_url argument is deprecated/)
-    end
-
-    it "allows passing a URI builder object" do
-      render_inline(described_class.new(feedback_url: URI::HTTPS.build(host: "example.com", path: "/example-path")))
-
-      expect(page).to have_link "Is there anything wrong", href: "https://example.com/example-path"
     end
   end
 

--- a/engine/spec/components/citizens_advice_components/section_links_spec.rb
+++ b/engine/spec/components/citizens_advice_components/section_links_spec.rb
@@ -40,30 +40,6 @@ RSpec.describe CitizensAdviceComponents::SectionLinks, type: :component do
     end
   end
 
-  describe "deprecated content block" do
-    before do
-      allow(CitizensAdviceComponents.deprecator).to receive(:warn)
-
-      render_inline described_class.new(
-        title: "Related Content",
-        section_title: "Applying to the EU settlement scheme",
-        section_title_url: "#"
-      ) do |c|
-        c.with_section_links(additional_attribute_links)
-        "Example content"
-      end
-    end
-
-    it "renders the additional content" do
-      expect(page).to have_text "Example content"
-    end
-
-    it "logs deprecation warning" do
-      expect(CitizensAdviceComponents.deprecator).to have_received(:warn)
-        .with(/Use custom_content slot instead of default content block/)
-    end
-  end
-
   context "when additional link attributes are present" do
     before do
       render_inline described_class.new(title: "Related Content", section_title: "Applying to the EU settlement scheme") do |c|


### PR DESCRIPTION
This removes the following deprecations from component code:

- deprecated feedback_url from footer
- deprecated content slot from section links
- deprecated title attribute from callout

We deprecated all of this a while a go and to my knowledge our application code has since been updated so these should be safe enough to remove now.