### PR TITLE
Add option to disable icon font styles

### DIFF
--- a/scss/1-settings/_fonts.scss
+++ b/scss/1-settings/_fonts.scss
@@ -1,0 +1,1 @@
+$cads-enable-icon-font: true !default;

--- a/scss/1-settings/settings-imports.scss
+++ b/scss/1-settings/settings-imports.scss
@@ -5,5 +5,6 @@
 @import './colour-language';
 @import './spacing-sizing';
 @import './grid';
+@import './fonts';
 @import './typography';
 @import './prose';

--- a/scss/3-generics/__fonts__/fonts.tests.js
+++ b/scss/3-generics/__fonts__/fonts.tests.js
@@ -1,0 +1,22 @@
+/* eslint-env jest */
+/* eslint-disable import/no-extraneous-dependencies */
+const sass = require('sass');
+
+test('icon font styles are included by default', () => {
+  const output = sass
+    .renderSync({
+      data: `@import 'scss/lib';`,
+    })
+    .css.toString();
+  expect(output).toContain('font-family: cads');
+});
+
+test('icon font styles are included by default', () => {
+  const output = sass
+    .renderSync({
+      data: `$cads-enable-icon-font: false;
+        @import 'scss/lib';`,
+    })
+    .css.toString();
+  expect(output).not.toContain('font-family: cads');
+});

--- a/scss/3-generics/_fonts.scss
+++ b/scss/3-generics/_fonts.scss
@@ -36,22 +36,6 @@
 // Icon font
 // ============================================================================
 
-@font-face {
-  font-family: cads;
-  src:
-    url('../../assets/fonts/cads.eot?d7dccfce9cf3c38908cc8e38fb40341b?#iefix')
-      format('embedded-opentype'),
-    url('../../assets/fonts/cads.woff?d7dccfce9cf3c38908cc8e38fb40341b')
-      format('woff'),
-    url('../../assets/fonts/cads.ttf?d7dccfce9cf3c38908cc8e38fb40341b')
-      format('truetype'),
-    url('../../assets/fonts/cads.svg?d7dccfce9cf3c38908cc8e38fb40341b#cads')
-      format('svg');
-  font-weight: normal;
-  font-style: normal;
-  font-display: block;
-}
-
 @mixin cads-icon {
   font-family: cads !important;
   speak: none;
@@ -65,70 +49,88 @@
   font-size: 0.9em;
 }
 
-[class^='cads-icon_']::before,
-[class*=' cads-icon_']::before {
-  @include cads-icon;
-}
+@if $cads-enable-icon-font == true {
+  @font-face {
+    font-family: cads;
+    src:
+      url('../../assets/fonts/cads.eot?d7dccfce9cf3c38908cc8e38fb40341b?#iefix')
+        format('embedded-opentype'),
+      url('../../assets/fonts/cads.woff?d7dccfce9cf3c38908cc8e38fb40341b')
+        format('woff'),
+      url('../../assets/fonts/cads.ttf?d7dccfce9cf3c38908cc8e38fb40341b')
+        format('truetype'),
+      url('../../assets/fonts/cads.svg?d7dccfce9cf3c38908cc8e38fb40341b#cads')
+        format('svg');
+    font-weight: normal;
+    font-style: normal;
+    font-display: block;
+  }
 
-.cads-icon_arrow-right::before {
-  content: '\0041';
-}
+  [class^='cads-icon_']::before,
+  [class*=' cads-icon_']::before {
+    @include cads-icon;
+  }
 
-.cads-icon_checkmark::before {
-  content: '\0042';
-}
+  .cads-icon_arrow-right::before {
+    content: '\0041';
+  }
 
-.cads-icon_exclamation-circle::before {
-  content: '\0043';
-}
+  .cads-icon_checkmark::before {
+    content: '\0042';
+  }
 
-.cads-icon_arrow-left::before {
-  content: '\0044';
-}
+  .cads-icon_exclamation-circle::before {
+    content: '\0043';
+  }
 
-.cads-icon_file::before {
-  content: '\0046';
-}
+  .cads-icon_arrow-left::before {
+    content: '\0044';
+  }
 
-.cads-icon_minus::before {
-  content: '\0047';
-}
+  .cads-icon_file::before {
+    content: '\0046';
+  }
 
-.cads-icon_plus::before {
-  content: '\0048';
-}
+  .cads-icon_minus::before {
+    content: '\0047';
+  }
 
-.cads-icon_print::before {
-  content: '\0049';
-}
+  .cads-icon_plus::before {
+    content: '\0048';
+  }
 
-.cads-icon_redo::before {
-  content: '\004a';
-}
+  .cads-icon_print::before {
+    content: '\0049';
+  }
 
-.cads-icon_search::before {
-  content: '\004b';
-}
+  .cads-icon_redo::before {
+    content: '\004a';
+  }
 
-.cads-icon_delete::before {
-  content: '\004c';
-}
+  .cads-icon_search::before {
+    content: '\004b';
+  }
 
-.cads-icon_email::before {
-  content: '\004d';
-}
+  .cads-icon_delete::before {
+    content: '\004c';
+  }
 
-.cads-icon_references::before {
-  content: '\004e';
-}
+  .cads-icon_email::before {
+    content: '\004d';
+  }
 
-.cads-icon_undo::before {
-  content: '\004f';
-}
+  .cads-icon_references::before {
+    content: '\004e';
+  }
 
-// Close icon is + icon rotated
-.cads-icon_close::before {
-  content: '\0048';
-  display: inline-block;
-  transform: rotate(45deg);
+  .cads-icon_undo::before {
+    content: '\004f';
+  }
+
+  // Close icon is + icon rotated
+  .cads-icon_close::before {
+    content: '\0048';
+    display: inline-block;
+    transform: rotate(45deg);
+  }
 }


### PR DESCRIPTION
Adds a sass config option to disable icon font styles. Intended to be used to help us flush out any remaining uses of icon fonts both internally and within applications.