### PR TITLE
Improve font loading options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ Remove a number of deprecations from the view components.
 - Remove deprecated feedback_url from footer
 - Remove deprecated content slot from section links
 
+### Improve control over font loading
+
+Provides two new configuration option when using the SCSS styles:
+
+- `$cads-font-path` to provide a custom path to control font loading in your application
+- `$cads-enable-icon-font` to enable or disable the legacy icon font (defaults to `true`)
+
 ### Consistent javascript module imports
 
 Allow all modules to be imported using a consistent interface, either via:

--- a/demo/app/views/layouts/application.html.erb
+++ b/demo/app/views/layouts/application.html.erb
@@ -4,9 +4,9 @@
     <meta content="text/html; charset=UTF-8" http-equiv="Content-Type">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Demo</title>
-    <link href="/assets/fonts/open-sans-v26-latin-700.woff2" rel="preload" as="font" type="font/woff2" crossorigin="true" />
-    <link href="/assets/fonts/open-sans-v26-latin-regular.woff2" rel="preload" as="font" type="font/woff2" crossorigin="true" />
-    <link href="/assets/fonts/cads.woff" rel="preload" as="font" type="font/woff" crossorigin="true" />
+    <link href="<%= asset_path("open-sans-v26-latin-700.woff2") %>" rel="preload" as="font" type="font/woff2" crossorigin="true" />
+    <link href="<%= asset_path("open-sans-v26-latin-regular.woff2") %>" rel="preload" as="font" type="font/woff2" crossorigin="true" />
+    <link href="<%= asset_path("cads.woff") %>" rel="preload" as="font" type="font/woff" crossorigin="true" />
     <%= csp_meta_tag %>
     <%= stylesheet_link_tag "application", media: "all" %>
     <%= yield :custom_head %>

--- a/demo/config/initializers/assets.rb
+++ b/demo/config/initializers/assets.rb
@@ -13,5 +13,5 @@ Rails.application.config.assets.version = "1.0"
 # folder are already added.
 # Rails.application.config.assets.precompile += %w( admin.js admin.css )
 
-# Add design system assets to the load path (for fonts)
-Rails.application.config.assets.paths << Rails.root.join("../assets")
+# Add design system fonts to the asset load path
+Rails.application.config.assets.paths << Rails.root.join("node_modules/@citizensadvice/design-system/assets/fonts")

--- a/demo/package-lock.json
+++ b/demo/package-lock.json
@@ -8,6 +8,7 @@
       "name": "demo",
       "version": "0.1.0",
       "dependencies": {
+        "@citizensadvice/design-system": "file:../",
         "esbuild": "^0.20.0",
         "sass": "^1.75.0"
       },
@@ -23,6 +24,7 @@
       }
     },
     "..": {
+      "name": "@citizensadvice/design-system",
       "version": "5.8.1",
       "dev": true,
       "license": "Apache-2.0",
@@ -30,7 +32,7 @@
         "@babel/preset-env": "^7.22.20",
         "@babel/preset-typescript": "^7.23.0",
         "@size-limit/file": "^11.0.0",
-        "@testing-library/dom": "^9.3.3",
+        "@testing-library/dom": "^10.0.0",
         "@testing-library/jest-dom": "^6.1.3",
         "@testing-library/user-event": "^14.5.1",
         "@typescript-eslint/eslint-plugin": "^7.0.2",
@@ -38,8 +40,7 @@
         "autoprefixer": "^10.4.16",
         "chalk": "^4.1.2",
         "cssnano": "^6.0.1",
-        "eslint": "^8.51.0",
-        "eslint-config-airbnb-base": "^15.0.0",
+        "eslint": "^8.57.0",
         "eslint-config-prettier": "^9.0.0",
         "eslint-plugin-import": "^2.28.1",
         "git-state": "^4.1.0",

--- a/demo/package.json
+++ b/demo/package.json
@@ -14,6 +14,7 @@
     "build": "esbuild app/assets/javascript/*.* --bundle --sourcemap --outdir=app/assets/builds --public-path=assets"
   },
   "dependencies": {
+    "@citizensadvice/design-system": "file:../",
     "esbuild": "^0.20.0",
     "sass": "^1.75.0"
   },

--- a/design-system-docs/frontend/styles/standalone.scss
+++ b/design-system-docs/frontend/styles/standalone.scss
@@ -1,6 +1,6 @@
 // This file loads just the design system components for use in isolated iframes
 // We use this when we need a clean base with no theme overrides
-@import '../scss/lib';
+@import '@citizensadvice/design-system/scss/lib';
 
 body {
   margin: 1em;

--- a/design-system-docs/frontend/styles/theme.scss
+++ b/design-system-docs/frontend/styles/theme.scss
@@ -3,7 +3,7 @@
 // For isolated component pages we use the based index.scss/js
 @import 'settings';
 
-@import '../scss/lib';
+@import '@citizensadvice/design-system/scss/lib';
 
 @import 'base';
 @import 'header';

--- a/design-system-docs/package-lock.json
+++ b/design-system-docs/package-lock.json
@@ -29,13 +29,14 @@
       }
     },
     "..": {
+      "name": "@citizensadvice/design-system",
       "version": "5.8.1",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/preset-env": "^7.22.20",
         "@babel/preset-typescript": "^7.23.0",
         "@size-limit/file": "^11.0.0",
-        "@testing-library/dom": "^9.3.3",
+        "@testing-library/dom": "^10.0.0",
         "@testing-library/jest-dom": "^6.1.3",
         "@testing-library/user-event": "^14.5.1",
         "@typescript-eslint/eslint-plugin": "^7.0.2",
@@ -43,8 +44,7 @@
         "autoprefixer": "^10.4.16",
         "chalk": "^4.1.2",
         "cssnano": "^6.0.1",
-        "eslint": "^8.51.0",
-        "eslint-config-airbnb-base": "^15.0.0",
+        "eslint": "^8.57.0",
         "eslint-config-prettier": "^9.0.0",
         "eslint-plugin-import": "^2.28.1",
         "git-state": "^4.1.0",

--- a/design-system-docs/src/_guides/using-with-rails.md
+++ b/design-system-docs/src/_guides/using-with-rails.md
@@ -77,8 +77,8 @@ npm install --save-exact @citizensadvice/design-system@5.5.0
 After you've done this you'll need to add the following to your `config/initializers/assets.rb` file:
 
 ```rb
-# Add design system assets to the load path (for fonts)
-Rails.application.config.assets.paths << Rails.root.join("node_modules/@citizensadvice/design-system/assets/")
+# Add design system fonts to the asset load path
+Rails.application.config.assets.paths << Rails.root.join("node_modules/@citizensadvice/design-system/assets/fonts")
 ```
 
 And finally, add the following to your `app/assets/stylesheets/application.sass.scss` entrypoint:
@@ -112,9 +112,9 @@ The following is an annotated layout template including any Rails defaults which
     <%%= stylesheet_link_tag "application", media: "all" %>
 
     <%%# Pre-loading the Design System fonts can help with flash of unstyled text %>
-    <link href="/assets/fonts/open-sans-v26-latin-700.woff2" rel="preload" as="font" type="font/woff2" crossorigin="true" />
-    <link href="/assets/fonts/open-sans-v26-latin-regular.woff2" rel="preload" as="font" type="font/woff2" crossorigin="true" />
-    <link href="/assets/fonts/cads.woff" rel="preload" as="font" type="font/woff" crossorigin="true" />
+    <link href="<%%= asset_path("open-sans-v26-latin-700.woff2") %>" rel="preload" as="font" type="font/woff2" crossorigin="true" />
+    <link href="<%%= asset_path("open-sans-v26-latin-regular.woff2") %>" rel="preload" as="font" type="font/woff2" crossorigin="true" />
+    <link href="<%%= asset_path("cads.woff") %> rel="preload" as="font) %>" type="font/woff" crossorigin="true" />
 
     <%%# This script pairs with the no-js class on the HTML element and is needed for fallback styles. %>
     <script>document.querySelector('html').classList.remove('no-js');</script>

--- a/scss/1-settings/_fonts.scss
+++ b/scss/1-settings/_fonts.scss
@@ -1,0 +1,7 @@
+// Allows applications to control the relative path to fonts
+// Assumes by default a Rails application that is configured to bundle font-files
+// in the same directory as compiled stylesheets
+$cads-font-path: '.' !default;
+
+// Allow icon fonts to be disabled (used to test deprecating icon fonts completely)
+$cads-enable-icon-font: true !default;

--- a/scss/1-settings/settings-imports.scss
+++ b/scss/1-settings/settings-imports.scss
@@ -5,5 +5,6 @@
 @import './colour-language';
 @import './spacing-sizing';
 @import './grid';
+@import './fonts';
 @import './typography';
 @import './prose';

--- a/scss/3-generics/_fonts.scss
+++ b/scss/3-generics/_fonts.scss
@@ -10,9 +10,9 @@
   src:
     local('Open Sans Regular'),
     local('OpenSans-Regular'),
-    url('../../assets/fonts/open-sans-v26-latin-regular.woff2') format('woff2'),
+    url('#{$cads-font-path}/open-sans-v26-latin-regular.woff2') format('woff2'),
     /* Chrome 26+, Opera 23+, Firefox 39+ */
-      url('../../assets/fonts/open-sans-v26-latin-regular.woff') format('woff'); /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
+      url('#{$cads-font-path}/open-sans-v26-latin-regular.woff') format('woff'); /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
 
   font-display: swap;
 }
@@ -25,9 +25,9 @@
   src:
     local('Open Sans Bold'),
     local('OpenSans-Bold'),
-    url('../../assets/fonts/open-sans-v26-latin-700.woff2') format('woff2'),
+    url('#{$cads-font-path}/open-sans-v26-latin-700.woff2') format('woff2'),
     /* Chrome 26+, Opera 23+, Firefox 39+ */
-      url('../../assets/fonts/open-sans-v26-latin-700.woff') format('woff'); /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
+      url('#{$cads-font-path}/open-sans-v26-latin-700.woff') format('woff'); /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
 
   font-display: swap;
 }
@@ -35,22 +35,6 @@
 // ============================================================================
 // Icon font
 // ============================================================================
-
-@font-face {
-  font-family: cads;
-  src:
-    url('../../assets/fonts/cads.eot?d7dccfce9cf3c38908cc8e38fb40341b?#iefix')
-      format('embedded-opentype'),
-    url('../../assets/fonts/cads.woff?d7dccfce9cf3c38908cc8e38fb40341b')
-      format('woff'),
-    url('../../assets/fonts/cads.ttf?d7dccfce9cf3c38908cc8e38fb40341b')
-      format('truetype'),
-    url('../../assets/fonts/cads.svg?d7dccfce9cf3c38908cc8e38fb40341b#cads')
-      format('svg');
-  font-weight: normal;
-  font-style: normal;
-  font-display: block;
-}
 
 @mixin cads-icon {
   font-family: cads !important;
@@ -65,70 +49,84 @@
   font-size: 0.9em;
 }
 
-[class^='cads-icon_']::before,
-[class*=' cads-icon_']::before {
-  @include cads-icon;
-}
+@if $cads-enable-icon-font == true {
+  @font-face {
+    font-family: cads;
+    src:
+      url('#{$cads-font-path}/cads.eot?#iefix') format('embedded-opentype'),
+      url('#{$cads-font-path}/cads.woff') format('woff'),
+      url('#{$cads-font-path}/cads.ttf') format('truetype'),
+      url('#{$cads-font-path}/cads.svg#cads') format('svg');
+    font-weight: normal;
+    font-style: normal;
+    font-display: block;
+  }
 
-.cads-icon_arrow-right::before {
-  content: '\0041';
-}
+  [class^='cads-icon_']::before,
+  [class*=' cads-icon_']::before {
+    @include cads-icon;
+  }
 
-.cads-icon_checkmark::before {
-  content: '\0042';
-}
+  .cads-icon_arrow-right::before {
+    content: '\0041';
+  }
 
-.cads-icon_exclamation-circle::before {
-  content: '\0043';
-}
+  .cads-icon_checkmark::before {
+    content: '\0042';
+  }
 
-.cads-icon_arrow-left::before {
-  content: '\0044';
-}
+  .cads-icon_exclamation-circle::before {
+    content: '\0043';
+  }
 
-.cads-icon_file::before {
-  content: '\0046';
-}
+  .cads-icon_arrow-left::before {
+    content: '\0044';
+  }
 
-.cads-icon_minus::before {
-  content: '\0047';
-}
+  .cads-icon_file::before {
+    content: '\0046';
+  }
 
-.cads-icon_plus::before {
-  content: '\0048';
-}
+  .cads-icon_minus::before {
+    content: '\0047';
+  }
 
-.cads-icon_print::before {
-  content: '\0049';
-}
+  .cads-icon_plus::before {
+    content: '\0048';
+  }
 
-.cads-icon_redo::before {
-  content: '\004a';
-}
+  .cads-icon_print::before {
+    content: '\0049';
+  }
 
-.cads-icon_search::before {
-  content: '\004b';
-}
+  .cads-icon_redo::before {
+    content: '\004a';
+  }
 
-.cads-icon_delete::before {
-  content: '\004c';
-}
+  .cads-icon_search::before {
+    content: '\004b';
+  }
 
-.cads-icon_email::before {
-  content: '\004d';
-}
+  .cads-icon_delete::before {
+    content: '\004c';
+  }
 
-.cads-icon_references::before {
-  content: '\004e';
-}
+  .cads-icon_email::before {
+    content: '\004d';
+  }
 
-.cads-icon_undo::before {
-  content: '\004f';
-}
+  .cads-icon_references::before {
+    content: '\004e';
+  }
 
-// Close icon is + icon rotated
-.cads-icon_close::before {
-  content: '\0048';
-  display: inline-block;
-  transform: rotate(45deg);
+  .cads-icon_undo::before {
+    content: '\004f';
+  }
+
+  // Close icon is + icon rotated
+  .cads-icon_close::before {
+    content: '\0048';
+    display: inline-block;
+    transform: rotate(45deg);
+  }
 }

--- a/scss/__tests__/__fixtures__/with-custom-font-path.scss
+++ b/scss/__tests__/__fixtures__/with-custom-font-path.scss
@@ -1,0 +1,3 @@
+$cads-font-path: '/assets/custom';
+
+@import '../../lib';

--- a/scss/__tests__/__fixtures__/with-disabled-icon-font.scss
+++ b/scss/__tests__/__fixtures__/with-disabled-icon-font.scss
@@ -1,0 +1,3 @@
+$cads-enable-icon-font: false;
+
+@import '../../lib';

--- a/scss/__tests__/generics.test.js
+++ b/scss/__tests__/generics.test.js
@@ -1,0 +1,40 @@
+/* eslint-env jest */
+const sass = require('sass');
+const path = require('path');
+
+test('default font-path', () => {
+  // Compile against top-level entrypoint as we're testing settings
+  const output = sass.compile('scss/lib.scss').css.toString();
+
+  expect(output).toContain('url("./open-sans');
+});
+
+test('with custom font-path', () => {
+  // Compile against top-level entrypoint as we're testing settings
+  const output = sass
+    .compile(
+      path.resolve(__dirname, './__fixtures__/with-custom-font-path.scss'),
+    )
+    .css.toString();
+
+  expect(output).toContain('url("/assets/custom');
+});
+
+test('icon font styles are included by default', () => {
+  // Compile against top-level entrypoint as we're testing settings
+  const output = sass.compile('scss/lib.scss').css.toString();
+
+  expect(output).toContain('font-family: cads');
+});
+
+test('icon font styles can be disabled', () => {
+  const output = sass
+    .compile(
+      path.resolve(__dirname, './__fixtures__/with-disabled-icon-font.scss'),
+      // Use compressed style to make searching for @font-face easier
+      { style: 'compressed' },
+    )
+    .css.toString();
+
+  expect(output).not.toContain('@font-face{font-family:cads');
+});


### PR DESCRIPTION
## Background

Our SCSS styles include `@font-face` declarations which are hard-coded with relative paths to the assets distributed as part of the node module.

Our main target environment is Rails. Historically we've targeted webpack environments via [shakapacker](https://github.com/shakacode/shakapacker) and used to rely on `resolve-url-loader` to resolve these font paths.

This is one way of loading assets in Rails but not the only way. For newer applications we favour using [cssbundling-rails](https://github.com/rails/cssbundling-rails) which ultimately delegates to the Rails asset pipeline using sprockets or propshaft.

Ultimately we want to provide a way of getting the font files into the right place so that applications can correctly resolve paths.

## Using with Rails

We can use the following config to tell Rails to add the font-files to the load path.

```
Rails.application.config.assets.paths << Rails.root.join("node_modules/@citizensadvice/design-system/assets/fonts")
```

With this configuration running `bin/rails assets:clobber assets:precompile` results in something like the following:

```
├── assets
│   ├── application-8e168b94c2bc67230117de79ddaca9564a41658ef756151b9a28d03c89b61c8c.js
│   ├── application-8e168b94c2bc67230117de79ddaca9564a41658ef756151b9a28d03c89b61c8c.js.gz
│   ├── application-db8938456959929d9030c2eae5218e56479fad40acad5379ad7d6edf1582fc84.css
│   ├── application-db8938456959929d9030c2eae5218e56479fad40acad5379ad7d6edf1582fc84.css.gz
│   ├── application.js-5a2e1d51537bf860487a41faa12cf05f60b275991d5657fbfd3edd68e7c8251e.map
│   ├── application.js-5a2e1d51537bf860487a41faa12cf05f60b275991d5657fbfd3edd68e7c8251e.map.gz
│   ├── cads-9ff379853966eee0177bcf4cba11c485c3fa736c75272d51b7794df8796ebf53.eot
│   ├── cads-9ff379853966eee0177bcf4cba11c485c3fa736c75272d51b7794df8796ebf53.eot.gz
│   ├── cads-b805314b26ac59bc2d4020c7fc067bffe328726c04864597ed5b0fdc80fe26cf.ttf
│   ├── cads-b805314b26ac59bc2d4020c7fc067bffe328726c04864597ed5b0fdc80fe26cf.ttf.gz
│   ├── cads-c2b3f17b3d29b4d02cc77ebe23677db5ba63d2244272f5652b95065e8cd3727e.woff
│   ├── cads-c84380ecca9e8171e86947af64e7ae132c747401d2759413af09f36dfd374fdc.svg
│   ├── cads-c84380ecca9e8171e86947af64e7ae132c747401d2759413af09f36dfd374fdc.svg.gz
│   ├── manifest-04024382391bb910584145d8113cf35ef376b55d125bb4516cebeb14ce788597.js
│   ├── manifest-04024382391bb910584145d8113cf35ef376b55d125bb4516cebeb14ce788597.js.gz
│   ├── open-sans-v26-latin-700-c12de74c75388b99217911061da4f485071392d528338b1f7052007ac0eb396b.woff2
│   ├── open-sans-v26-latin-700-c38bf4cc3dbdb0cfcdf27774e9b9ccbc58bace1597fa450a15b9e04aabc7f24f.woff
│   ├── open-sans-v26-latin-regular-21463e822c091d3350603d57f83c01f777c95280f399ed2ec3a427ce959d9327.woff
│   ├── open-sans-v26-latin-regular-2d8f2b8387a095f3e77a79e59b6026ce3ec5a3f02a62ffafd652496d0e331006.woff2
│   ├── previews-02c789845af6a3e980702f4d711002e25cb67c37c0f50d71d0d66d2c2fcdd533.css
│   └── previews-02c789845af6a3e980702f4d711002e25cb67c37c0f50d71d0d66d2c2fcdd533.css.gz
```

This is what we want, fonts making their way into the asset pipeline, but it's not enough for Rails to correctly replace the asset url as the hard-coded path points elsewhere.

We can provide a configuration option (as `$cads-font-path`) to allow customising this to the needs of the application. In the example above the following works:

```scss
$cads-font-path: ".";

@import "@citizensadvice/design-system/scss/lib";
```

I've also tested this using propshaft by following https://github.com/rails/propshaft/blob/main/UPGRADING.md#3-migrate-from-sprockets-to-propshaft which works too as it's a largely drop-in replacement.

## Changes

The upshot is that we provide a new `$cads-font-path` configuration option. The rest of the changes are in documenting and testing that this works in a standard Rails context.

I've also bundled a change from https://github.com/citizensadvice/design-system/pull/3262 to allow disabling icon fonts.