### PR TITLE
v6.0.0-alpha.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,6 @@
 ## v6.0.0-alpha.0
 
-### 18 April 2024
-
-## Unreleased
+18 April 2024
 
 ### Remove deprecations
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v6.0.0-alpha.0
+
+### 18 April 2024
+
 ## Unreleased
 
 ### Remove deprecations

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@citizensadvice/design-system",
-  "version": "5.8.1",
+  "version": "6.0.0-alpha.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@citizensadvice/design-system",
-      "version": "5.8.1",
+      "version": "6.0.0-alpha.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/preset-env": "^7.22.20",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@citizensadvice/design-system",
-  "version": "5.8.1",
+  "version": "6.0.0-alpha.0",
   "description": "Citizens Advice Design System",
   "repository": "https://github.com/citizensadvice/design-system",
   "author": "Citizens Advice",


### PR DESCRIPTION
We've not used pre-leases for a while but we're targeting v6 with the next release so it might be useful to do one. Helps us to test the font-loading changes in a deployed environment.