### PR TITLE
Fix JS documentation for `ErrorSummary` component

### DIFF
--- a/design-system-docs/src/_component_docs/error-summary.md
+++ b/design-system-docs/src/_component_docs/error-summary.md
@@ -48,7 +48,7 @@ If users correct some of the errors on the page but not all, update the error su
 Error summary requires some additional JavaScript behaviour which can be initialised with:
 
 ```js
-import { initErrorSummary } from '@citizensadvice/design-system';
+import initErrorSummary from '@citizensadvice/design-system/lib/error-summary';
 initErrorSummary();
 ```
 


### PR DESCRIPTION
Update the code snippet for including the JS code to support the ErrorSummary component.

I tried the original snippet, and it didn't work for me. The corrected version is [currently in use here](https://github.com/citizensadvice/public-website/blob/bdf5b4331382fb165d707f4e2e97c5c5f5eb64e0/app/javascript/packs/public-advice.js#L4), among other places.