### PR TITLE
Fix/import not use for grid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,9 @@ We historically bundled a compiled version of the CSS as lib.css in the distribu
 
 The new office address is now the default in the footer component and the old address has been removed.
 
+**Fix**
+- Make grid configurable by products
+
 ## v5.8.1
 
 ### 8 March 2024

--- a/scss/1-settings/_grid.scss
+++ b/scss/1-settings/_grid.scss
@@ -1,22 +1,22 @@
-@use '../1-settings/spacing-sizing' as spacing;
+@import '../1-settings/spacing-sizing';
 
 $cads-grid-columns: 12 !default;
 $cads-grid-breakpoint-gutters: (
   // 16px
-  sm: spacing.$cads-spacing-4,
+  sm: $cads-spacing-4,
   // 32px
-  md: spacing.$cads-spacing-6,
+  md: $cads-spacing-6,
   // 32px
-  lg: spacing.$cads-spacing-7
+  lg: $cads-spacing-7
 ) !default;
 $cads-nav-breakpoint-gutters: (
   // 0px
-  sm: spacing.$cads-spacing-2,
+  sm: $cads-spacing-2,
   // 16px
-  md: spacing.$cads-spacing-5,
+  md: $cads-spacing-5,
   // 16px
-  lg: spacing.$cads-spacing-6
+  lg: $cads-spacing-6
 ) !default;
 $cads-container-max-widths: (
-  lg: spacing.$cads-max-content-size,
+  lg: $cads-max-content-size,
 ) !default;

--- a/scss/1-settings/_spacing-sizing.scss
+++ b/scss/1-settings/_spacing-sizing.scss
@@ -1,4 +1,4 @@
-$cads-max-content-size: 1090px;
+$cads-max-content-size: 1090px !default;
 $cads-spacing-1: 0.25rem; // 4px
 $cads-spacing-2: 0.5rem; // 8px
 $cads-spacing-3: 0.75rem; // 12px

--- a/scss/2-tools/_spacing-sizing.scss
+++ b/scss/2-tools/_spacing-sizing.scss
@@ -1,22 +1,20 @@
 @use 'sass:math';
-@use '../1-settings/spacing-sizing' as sizing-settings;
-@use '../1-settings/typography' as typography-settings;
+@import '../1-settings/spacing-sizing';
+@import '../1-settings/typography';
 
 // Stop the container from going over the given size,
 // useful for header/footer that may sit outside a grid
 // (that is restricted in width)
-@mixin cads-restrict-content-width(
-  $size: sizing-settings.$cads-max-content-size
-) {
+@mixin cads-restrict-content-width($size: $cads-max-content-size) {
   margin-left: auto;
   margin-right: auto;
   max-width: $size;
 }
 
 @function cads-rem($pixels) {
-  @return #{math.div($pixels, typography-settings.$cads-font-size)}rem;
+  @return #{math.div($pixels, $cads-font-size)}rem;
 }
 
 @function cads-rem-to-px($rem) {
-  @return (math.div($rem, 1rem)) * typography-settings.$cads-font-size;
+  @return (math.div($rem, 1rem)) * $cads-font-size;
 }

--- a/scss/7-utilities/_sizing.scss
+++ b/scss/7-utilities/_sizing.scss
@@ -1,5 +1,5 @@
-@use '../2-tools/spacing-sizing' as sizing-tools;
+@import '../2-tools/spacing-sizing';
 
 .cads-max-content-width {
-  @include sizing-tools.cads-restrict-content-width;
+  @include cads-restrict-content-width;
 }


### PR DESCRIPTION
This makes overriding the grid settings possible in products that use the design system.  

At the moment, we are `@use` to import files at higher levels of the scss code, rather than `@import`ing them.  `@use` requires you to explicitly override variables when you import a module, rather than respecting what the global state of variables in the `@use`d file are.  This changes ensures that the global values of the grid are respected at all layers of the ITCSS triangle, allowing products to override the variables to make their own grids.

The wider issue might be affecting other areas of the code, but I'd like to keep this change small and limited to what I know isn't working at the moment.

See https://acab.slack.com/archives/C060YQ75MGD/p1716370930966639?thread_ts=1716291046.823689&cid=C060YQ75MGD.