### PR TITLE
Patch bridgetown compatibility with view_component 3.9.0+

### DIFF
--- a/design-system-docs/Gemfile
+++ b/design-system-docs/Gemfile
@@ -13,8 +13,10 @@ gem "puma"
 
 gem "citizens_advice_components", path: "../engine"
 
-# https://github.com/citizensadvice/design-system/issues/3145
-gem "view_component", "3.8.0"
+# citizens_advice_components bundles view component but we
+# also use this to write docs components so explicitly
+# name it as a dependency.
+gem "view_component", "~> 3.9"
 
 group :development, :test do
   gem "citizens-advice-style",

--- a/design-system-docs/Gemfile.lock
+++ b/design-system-docs/Gemfile.lock
@@ -233,7 +233,7 @@ GEM
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.5.0)
     uri (0.13.0)
-    view_component (3.8.0)
+    view_component (3.12.1)
       activesupport (>= 5.2.0, < 8.0)
       concurrent-ruby (~> 1.0)
       method_source (~> 1.0)
@@ -253,7 +253,7 @@ DEPENDENCIES
   htmlbeautifier
   nokogiri
   puma
-  view_component (= 3.8.0)
+  view_component (~> 3.9)
 
 BUNDLED WITH
    2.5.9

--- a/design-system-docs/plugins/builders/cads_builder.rb
+++ b/design-system-docs/plugins/builders/cads_builder.rb
@@ -13,6 +13,27 @@ I18n.load_path << Dir[
 
 Time.zone = "London"
 
+# ViewComponent 3.9+ introduced a change which depends on there being an active Rails
+# request or controller in order to conditionally escape HTML. This causes an issue
+# when run in bridgetown as there's no request and we're always rendering static html.
+# Monkey patch the relevant method to remove the request format check.
+# https://github.com/citizensadvice/design-system/issues/3145
+# https://github.com/bridgetownrb/bridgetown-view-component/issues/8
+module ViewComponent
+  class Base
+    def maybe_escape_html(text)
+      return text if text.blank?
+
+      if text.html_safe?
+        text
+      else
+        yield
+        html_escape(text)
+      end
+    end
+  end
+end
+
 module Builders
   class CadsBuilder < SiteBuilder
     def build


### PR DESCRIPTION
ViewComponent 3.9+ introduced a change which depends on there being an active Rails request or controller in order to conditionally escape HTML. This causes an issue when run in bridgetown as there's no request and we're always rendering static html.

Whilst this is monkey patching an internal method this feels like the least worst approach as it removes just the single check that's dependent on the request whilst still keeping the underlying escaping.

(Temporarily) fixes #3145. Related issue: https://github.com/bridgetownrb/bridgetown-view-component/issues/8