### PR TITLE
Add Rails 7.2 to test matrix

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -26,10 +26,18 @@ jobs:
       matrix:
         # Active Ruby versions (https://endoflife.date/ruby)
         ruby_version: ['3.1', '3.2', '3.3']
-        # Last 3 major Rails releases
-        rails_version: ['~> 6.1', '~> 7.0.0', '~> 7.1.0']
+        # Active Rails versions (https://endoflife.date/rails)
+        rails_version: ['~> 7.0.0', '~> 7.1.0', '~> 7.2.0']
         # Any supported ViewComponent versions
-        view_component_version: ['~> 2.82', '~> 3']
+        view_component_version: ['~> 3']
+        # Explicitly test a "legacy" configuration using an older Ruby, Rails,
+        # and ViewComponent version to represent applications that have not been
+        # upgraded yet with the expectation that we'll drop Rails 6.1 along with
+        # ViewComponent 2.x when Rails 6.1 goes end-of-life on October 1st 2024.
+        include:
+          - ruby_version: '3.1'
+            rails_version: '~> 6.1'
+            view_component_version: '~> 2.82'
     env:
       RAILS_VERSION: ${{ matrix.rails_version }}
       VIEW_COMPONENT_VERSION: ${{ matrix.view_component_version }}


### PR DESCRIPTION
https://rubyonrails.org/2024/8/10/Rails-7-2-0-has-been-released

Updates our test matrix to include the new Rails 7.2 release and to account for the new Rails maintenance policy https://rubyonrails.org/maintenance

Explicitly test a "legacy" configuration using an older Ruby, Rails, and ViewComponent version to represent applications that have not been upgraded yet with the expectation that we'll drop Rails 6.1 along with ViewComponent 2.x when Rails 6.1 goes end-of-life on October 1st 2024.