### PR TITLE
Docs website: Upgrade view_component with patch

### DIFF
--- a/design-system-docs/Gemfile
+++ b/design-system-docs/Gemfile
@@ -16,8 +16,7 @@ gem "citizens_advice_components", path: "../engine"
 # citizens_advice_components bundles view component but we
 # also use this to write docs components so explicitly
 # name it as a dependency.
-# Pin version until https://github.com/citizensadvice/design-system/pull/3503 is merged
-gem "view_component", "3.14.0"
+gem "view_component", "~> 3.16"
 
 group :development, :test do
   gem "citizens-advice-style",

--- a/design-system-docs/Gemfile.lock
+++ b/design-system-docs/Gemfile.lock
@@ -233,7 +233,7 @@ GEM
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.5.0)
     uri (0.13.0)
-    view_component (3.14.0)
+    view_component (3.17.0)
       activesupport (>= 5.2.0, < 8.0)
       concurrent-ruby (~> 1.0)
       method_source (~> 1.0)
@@ -253,7 +253,7 @@ DEPENDENCIES
   htmlbeautifier
   nokogiri
   puma
-  view_component (= 3.14.0)
+  view_component (~> 3.16)
 
 BUNDLED WITH
    2.5.9

--- a/design-system-docs/plugins/builders/cads_builder.rb
+++ b/design-system-docs/plugins/builders/cads_builder.rb
@@ -13,23 +13,15 @@ I18n.load_path << Dir[
 
 Time.zone = "London"
 
-# ViewComponent 3.9+ introduced a change which depends on there being an active Rails
-# request or controller in order to conditionally escape HTML. This causes an issue
-# when run in bridgetown as there's no request and we're always rendering static html.
-# Monkey patch the relevant method to remove the request format check.
-# https://github.com/citizensadvice/design-system/issues/3145
-# https://github.com/bridgetownrb/bridgetown-view-component/issues/8
+# Apply any additional patches to the ViewComponent::Base class
 module ViewComponent
   class Base
-    def maybe_escape_html(text)
-      return text if text.blank?
-
-      if text.html_safe?
-        text
-      else
-        yield
-        html_escape(text)
-      end
+    # ViewComponent depends on there being a Rails controller present.
+    # This causes an issue when run in a Bridgetown context.
+    # Define a view context and controller using ActionView::Base
+    def controller
+      view = ActionView::Base.new(ActionView::LookupContext.new([]), {}, nil)
+      view.controller
     end
   end
 end

--- a/design-system-docs/src/_components/foundations/borders_table.rb
+++ b/design-system-docs/src/_components/foundations/borders_table.rb
@@ -2,10 +2,6 @@
 
 module Foundations
   class BordersTable < ViewComponent::Base
-    include Bridgetown::ViewComponentHelpers
-
-    Bridgetown::ViewComponentHelpers.allow_rails_helpers :tag
-
     def call
       render(
         CitizensAdviceComponents::Table.new(

--- a/design-system-docs/src/_components/foundations/icon_grid.rb
+++ b/design-system-docs/src/_components/foundations/icon_grid.rb
@@ -2,8 +2,6 @@
 
 module Foundations
   class IconGrid < ViewComponent::Base
-    include Bridgetown::ViewComponentHelpers
-
     def icons
       [
         CitizensAdviceComponents::Icons::ArrowLeft,

--- a/design-system-docs/src/_components/foundations/spacing_table.rb
+++ b/design-system-docs/src/_components/foundations/spacing_table.rb
@@ -2,10 +2,6 @@
 
 module Foundations
   class SpacingTable < ViewComponent::Base
-    include Bridgetown::ViewComponentHelpers
-
-    Bridgetown::ViewComponentHelpers.allow_rails_helpers :tag
-
     def call
       render(
         CitizensAdviceComponents::Table.new(

--- a/design-system-docs/src/_components/shared/app_breadcrumbs.rb
+++ b/design-system-docs/src/_components/shared/app_breadcrumbs.rb
@@ -2,8 +2,6 @@
 
 module Shared
   class AppBreadcrumbs < ViewComponent::Base
-    include Bridgetown::ViewComponentHelpers
-
     def initialize(resource)
       @resource = resource
     end

--- a/design-system-docs/src/_components/shared/app_header.rb
+++ b/design-system-docs/src/_components/shared/app_header.rb
@@ -2,8 +2,6 @@
 
 module Shared
   class AppHeader < ViewComponent::Base
-    include Bridgetown::ViewComponentHelpers
-
     def initialize
       @site = Bridgetown::Current.site
     end

--- a/design-system-docs/src/_components/shared/arguments_table.rb
+++ b/design-system-docs/src/_components/shared/arguments_table.rb
@@ -2,10 +2,6 @@
 
 module Shared
   class ArgumentsTable < ViewComponent::Base
-    Bridgetown::ViewComponentHelpers.allow_rails_helpers :tag
-
-    include Bridgetown::ViewComponentHelpers
-
     def initialize(component_name)
       super
 

--- a/design-system-docs/src/_components/shared/colour_table.rb
+++ b/design-system-docs/src/_components/shared/colour_table.rb
@@ -2,10 +2,6 @@
 
 module Shared
   class ColourTable < ViewComponent::Base
-    Bridgetown::ViewComponentHelpers.allow_rails_helpers :tag
-
-    include Bridgetown::ViewComponentHelpers
-
     def initialize(colour_mappings)
       super
 

--- a/design-system-docs/src/_components/shared/component_example.rb
+++ b/design-system-docs/src/_components/shared/component_example.rb
@@ -2,8 +2,6 @@
 
 module Shared
   class ComponentExample < ViewComponent::Base
-    include Bridgetown::ViewComponentHelpers
-
     def initialize(category, slug)
       super
 

--- a/design-system-docs/src/_components/shared/component_example_source.rb
+++ b/design-system-docs/src/_components/shared/component_example_source.rb
@@ -2,8 +2,6 @@
 
 module Shared
   class ComponentExampleSource < ViewComponent::Base
-    include Bridgetown::ViewComponentHelpers
-
     def initialize(category, slug)
       super
 

--- a/design-system-docs/src/_components/shared/on_this_page.rb
+++ b/design-system-docs/src/_components/shared/on_this_page.rb
@@ -4,8 +4,6 @@ require "nokogiri"
 
 module Shared
   class OnThisPage < ViewComponent::Base
-    include Bridgetown::ViewComponentHelpers
-
     def initialize(source_doc)
       @doc = Nokogiri::HTML::DocumentFragment.parse(source_doc)
       @headings = extract_headings


### PR DESCRIPTION
Upgrades view_component in the docs website with an additional compatibility patch.

In version 3.15+ the docs build fails with the following error:

```sh
undefined method `controller' for an instance of Bridgetown::ERBView
```

This is similar to the error that was patched in #3362 but likely resurfacing because we applied the narrowest possible monkey patch originally.

Adjusts our patch for Bridgetown compatibility with view_component. Substituting in a controller covers what the library expects to be present.

Using `Bridgetown::ViewComponentHelpers` also conflicts with the presence of a `request` object. It turns out we don't need this for our use case so remove the include rather than attempting to patch around it.