### PR TITLE
feat: allowing lang attribute to header links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- Header: allow `lang` attribute in the header links slot
+
 ## v6.0.0
 
 ### 11 July 2024

--- a/demo/spec/components/previews/header_preview.rb
+++ b/demo/spec/components/previews/header_preview.rb
@@ -68,7 +68,7 @@ class HeaderPreview < ViewComponent::Preview
     [
       { title: "Public site", url: "/", current_site: true },
       { title: "AdviserNet", url: "?advisernet" },
-      { title: "Cymraeg", url: "?lang=cy" }
+      { title: "Cymraeg", url: "?lang=cy", lang: "cy" }
     ]
   end
 

--- a/design-system-docs/src/_component_docs/header.md
+++ b/design-system-docs/src/_component_docs/header.md
@@ -81,14 +81,14 @@ If you use the defaults you'll need to be using the `Navigation` and `Footer` co
 
 ### Header links
 
-Header links can be configured either by passing a list of hashes to `header_links` or by calling `header_links` multiple times with a `title` and `url`. Header links also accept an optional `current_site` flag.
+Header links can be configured either by passing a list of hashes to `header_links` or by calling `header_links` multiple times with a `title` and `url`. There is also an optional `lang` attribute available. Header links also accept an optional `current_site` flag, which turns the link into a `span`.
 
 ```erb
 <%%= render CitizensAdviceComponents::Header.new do |c|
   c.with_header_links([
     { title: "Public site", url: "/", current_site: true },
     { title: "AdviserNet", url: "/advisernet" },
-    { title: "Cymraeg", url: "?lang=cy" }
+    { title: "Cymraeg", url: "?lang=cy", lang: "cy" }
   ])
 end %>
 ```

--- a/design-system-docs/src/_component_examples/_header/default.erb
+++ b/design-system-docs/src/_component_examples/_header/default.erb
@@ -13,7 +13,7 @@ title: default
     { title: "Public site", url: "#", current_site: true },
     { title: "AdviserNet", url: "#" },
     { title: "Intranet", url: "#" },
-    { title: "Cymraeg", url: "#" }
+    { title: "Cymraeg", url: "#", lang: "cy" },
   ])
   c.with_search_form(search_action_url: "/search")
   c.with_account_link(title: "Sign in", url: "/sign-in")

--- a/design-system-docs/src/_component_examples/_header/with_navigation.erb
+++ b/design-system-docs/src/_component_examples/_header/with_navigation.erb
@@ -13,7 +13,7 @@ title: with navigation
     { title: "Public site", url: "#", current_site: true },
     { title: "AdviserNet", url: "#" },
     { title: "Intranet", url: "#" },
-    { title: "Cymraeg", url: "#" }
+    { title: "Cymraeg", url: "#", lang: "cy" }
   ])
   c.with_search_form(search_action_url: "/search")
   c.with_account_link(title: "Sign in", url: "/sign-in")

--- a/engine/app/components/citizens_advice_components/header.rb
+++ b/engine/app/components/citizens_advice_components/header.rb
@@ -64,20 +64,21 @@ module CitizensAdviceComponents
     end
 
     class HeaderLink < Base
-      attr_reader :title, :url
+      attr_reader :title, :url, :lang
 
-      def initialize(title:, url:, current_site: false)
+      def initialize(title:, url:, current_site: false, lang: nil)
         super
         @title = title
         @url = url
         @current_site = current_site
+        @lang = lang
       end
 
       def call
         if current_site?
           tag.span(title, class: "cads-header__text")
         else
-          link_to title, url, class: "cads-header__hyperlink"
+          link_to title, url, class: "cads-header__hyperlink", lang: lang
         end
       end
 

--- a/engine/spec/components/citizens_advice_components/header_spec.rb
+++ b/engine/spec/components/citizens_advice_components/header_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe CitizensAdviceComponents::Header, type: :component do
         c.with_header_links([
           { title: "Public site", url: "/", current_site: true },
           { title: "Intranet", url: "/intranet" },
-          { title: "Cymraeg", url: "/cymraeg" }
+          { title: "Cymraeg", url: "/cymraeg", lang: "cy" }
         ])
       end
     end
@@ -78,6 +78,7 @@ RSpec.describe CitizensAdviceComponents::Header, type: :component do
     it { is_expected.to have_css "span", text: "Public site" }
     it { is_expected.to have_link "Intranet", href: "/intranet" }
     it { is_expected.to have_link "Cymraeg", href: "/cymraeg" }
+    it { is_expected.to have_css "a[lang='cy']" }
   end
 
   describe "account_link slot" do


### PR DESCRIPTION
This one came after an internal accessibility testing on the public site.
It was raised that:
> When scrolling the site with a screen reader (we did that with Jaws) the Cymraeg link at the top of the public website homepage is not specified as being in welsh language. As a result it is not read correctly.

I have checked with Voiceover screen reader on mac and even though the language is specified, it didn't change the pronunciation and unlike other languages, doesn't read numbers in the language specified. I would assume this is due to the Welsh language support on screenreaders - would be interesting to test with Jaws. I have still decided to raise a PR as I think it's a good practice to be able to pass the `lang` attribute.