### PR TITLE
fix: default aria-label for footer feedback link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 ## Unreleased
 
+**New**
 - Header: allow `lang` attribute in the header links slot
+
+**Fix**
+- Footer: add default aria label fallback when no custom feedback link title is specified
 
 ## v6.0.0
 

--- a/engine/app/components/citizens_advice_components/footer.html.erb
+++ b/engine/app/components/citizens_advice_components/footer.html.erb
@@ -4,12 +4,22 @@
       <div class="cads-grid-row">
         <div class="cads-grid-col">
           <p class="cads-footer__feedback">
-            <%= link_to(
-              feedback_link.title || t("citizens_advice_components.footer.website_feedback"),
-              feedback_link.url,
-              class: "cads-footer__hyperlink js-cads-footer-feedback",
-              **feedback_link.new_tab_attributes
-            ) %>
+            <% if feedback_link.new_tab? %>
+              <%= link_to(
+                feedback_link.title || t("citizens_advice_components.footer.website_feedback"),
+                feedback_link.url,
+                class: "cads-footer__hyperlink js-cads-footer-feedback",
+                target: "_blank",
+                rel: "noopener",
+                aria: { label: "#{feedback_link.title || t('citizens_advice_components.footer.website_feedback')} (opens in a new tab)" }
+              ) %>
+            <% else %>
+              <%= link_to(
+                feedback_link.title || t("citizens_advice_components.footer.website_feedback"),
+                feedback_link.url,
+                class: "cads-footer__hyperlink js-cads-footer-feedback"
+              ) %>
+            <% end %>
           </p>
         </div>
       </div>

--- a/engine/app/components/citizens_advice_components/footer.rb
+++ b/engine/app/components/citizens_advice_components/footer.rb
@@ -57,16 +57,6 @@ module CitizensAdviceComponents
       def new_tab?
         @new_tab.present?
       end
-
-      def new_tab_attributes
-        return {} unless new_tab?
-
-        {
-          target: "_blank",
-          rel: "noopener",
-          "aria-label": "#{title} (opens in a new tab)"
-        }
-      end
     end
   end
 end

--- a/engine/spec/components/citizens_advice_components/footer_spec.rb
+++ b/engine/spec/components/citizens_advice_components/footer_spec.rb
@@ -100,11 +100,12 @@ RSpec.describe CitizensAdviceComponents::Footer, type: :component do
     context "with custom title" do
       before do
         render_inline(described_class.new) do |c|
-          c.with_feedback_link(title: "Custom link title", url: "https://example.com/")
+          c.with_feedback_link(title: "Custom link title", url: "https://example.com/", new_tab: true)
         end
       end
 
       it { is_expected.to have_link "Custom link title", href: "https://example.com/" }
+      it { is_expected.to have_css "a[aria-label='Custom link title (opens in a new tab)']" }
     end
 
     context "with new_tab set to true" do
@@ -115,6 +116,8 @@ RSpec.describe CitizensAdviceComponents::Footer, type: :component do
       end
 
       it { is_expected.to have_css "[target=_blank]", text: default_text }
+      it { is_expected.to have_css "[rel=noopener]" }
+      it { is_expected.to have_css "a[aria-label='Is there anything wrong with this page? Let us know (opens in a new tab)']" }
     end
 
     context "with URI builder object" do


### PR DESCRIPTION
Currently, if no feedback link title is specified and the feedback link is set to open in a new tab, the `aria-label` is " (opens in a new tab)".
This PR fixes this by using the default feedback link title as an `aria-label` fallback.