### PR TITLE
Spike/automerge dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,8 +7,6 @@ updates:
     directory: '/'
     schedule:
       interval: weekly
-      day: tuesday
-      time: 09:00
 
   ##
   # Top-level package
@@ -17,8 +15,6 @@ updates:
     directory: '/'
     schedule:
       interval: weekly
-      day: tuesday
-      time: 09:00
     groups:
       # Group everything except major version updates and security vulnerabilities
       regular-updates:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -37,8 +37,6 @@ updates:
     directory: '/engine'
     schedule:
       interval: weekly
-      day: tuesday
-      time: 09:00
     groups:
       # Group everything except major version updates and security vulnerabilities
       regular-updates:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,8 @@ updates:
     directory: '/'
     schedule:
       interval: weekly
+      day: tuesday
+      time: 09:00
 
   ##
   # Top-level package
@@ -15,6 +17,8 @@ updates:
     directory: '/'
     schedule:
       interval: weekly
+      day: tuesday
+      time: 09:00
     groups:
       # Group everything except major version updates and security vulnerabilities
       regular-updates:
@@ -33,6 +37,8 @@ updates:
     directory: '/engine'
     schedule:
       interval: weekly
+      day: tuesday
+      time: 09:00
     groups:
       # Group everything except major version updates and security vulnerabilities
       regular-updates:

--- a/.github/workflows/block-merge-based-on-time.yml
+++ b/.github/workflows/block-merge-based-on-time.yml
@@ -17,13 +17,13 @@ jobs:
       pull-requests: read
       statuses: write
     steps:
-      - uses: yykamei/block-merge-based-on-time@main
+      - uses: yykamei/block-merge-based-on-time@v3
         id: block
         with:
           timezone: Europe/London
           after: '17:00'
           before: '09:00'
           base-branches: '(default)'
-          prohibited-days-dates: 'Saturday, Sunday, 2024-12-24/2025-01-01'
+          prohibited-days-dates: 'Saturday, Sunday'
       - run: echo pr-blocked=${{ steps.block.outputs.pr-blocked }}
         if: github.event_name == 'pull_request'

--- a/.github/workflows/block-merge-based-on-time.yml
+++ b/.github/workflows/block-merge-based-on-time.yml
@@ -1,0 +1,29 @@
+name: Block Merge Based on Time
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - labeled
+      - unlabeled
+
+jobs:
+  block:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.user.login == 'dependabot[bot]' && github.repository == 'citizensadvice/design-system'
+    permissions:
+      contents: read
+      pull-requests: read
+      statuses: write
+    steps:
+      - uses: yykamei/block-merge-based-on-time@main
+        id: block
+        with:
+          timezone: Europe/London
+          after: '17:00'
+          before: '09:00'
+          base-branches: '(default)'
+          prohibited-days-dates: 'Saturday, Sunday, 2024-12-24/2025-01-01'
+      - run: echo pr-blocked=${{ steps.block.outputs.pr-blocked }}
+        if: github.event_name == 'pull_request'

--- a/.github/workflows/dependabot-auto-approve.yml
+++ b/.github/workflows/dependabot-auto-approve.yml
@@ -1,0 +1,22 @@
+name: Dependabot auto-approve
+on: pull_request
+
+permissions:
+  pull-requests: write
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.user.login == 'dependabot[bot]' && github.repository == 'citizensadvice/design-system'
+    steps:
+      - name: Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+      - name: Approve a PR
+        if: steps.metadata.outputs.update-type == 'version-update:semver-patch' || (!contains(steps.metadata.outputs.dependency-names, 'rails') && steps.metadata.outputs.update-type == 'version-update:semver-minor')
+        run: gh pr review --approve "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GH_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,7 +1,8 @@
-name: Dependabot auto-approve
+name: Dependabot auto-merge
 on: pull_request
 
 permissions:
+  contents: write
   pull-requests: write
 
 jobs:
@@ -14,9 +15,9 @@ jobs:
         uses: dependabot/fetch-metadata@v2
         with:
           github-token: '${{ secrets.GITHUB_TOKEN }}'
-      - name: Approve a PR
+      - name: Enable auto-merge for Dependabot PRs
         if: steps.metadata.outputs.update-type == 'version-update:semver-patch' || (!contains(steps.metadata.outputs.dependency-names, 'rails') && steps.metadata.outputs.update-type == 'version-update:semver-minor')
-        run: gh pr review --approve "$PR_URL"
+        run: gh pr merge --auto --merge "$PR_URL"
         env:
           PR_URL: ${{github.event.pull_request.html_url}}
           GH_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/demo/package-lock.json
+++ b/demo/package-lock.json
@@ -25,7 +25,7 @@
     },
     "..": {
       "name": "@citizensadvice/design-system",
-      "version": "6.0.0",
+      "version": "6.1.0",
       "dev": true,
       "license": "Apache-2.0",
       "devDependencies": {
@@ -43,7 +43,7 @@
         "eslint-plugin-import": "^2.28.1",
         "git-state": "^4.1.0",
         "glob": "^11.0.0",
-        "inquirer": "^11.0.1",
+        "inquirer": "^12.0.0",
         "jest": "^29.7.0",
         "jest-environment-jsdom": "^29.7.0",
         "npm-run-all": "^4.1.5",

--- a/design-system-docs/package-lock.json
+++ b/design-system-docs/package-lock.json
@@ -30,7 +30,7 @@
     },
     "..": {
       "name": "@citizensadvice/design-system",
-      "version": "6.0.0",
+      "version": "6.1.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/preset-env": "^7.22.20",
@@ -47,7 +47,7 @@
         "eslint-plugin-import": "^2.28.1",
         "git-state": "^4.1.0",
         "glob": "^11.0.0",
-        "inquirer": "^8.2.5",
+        "inquirer": "^12.0.0",
         "jest": "^29.7.0",
         "jest-environment-jsdom": "^29.7.0",
         "npm-run-all": "^4.1.5",


### PR DESCRIPTION
We wanted to trial auto-approval & auto-merge of dependabot PRs to see if we can decrease the maintenance burden for developers. During a discussion in Content Platform Dev Refinement, @davidsauntson suggested that the `design-system` repo might be a possible place to test the automation.

An additional benefit might be that security patches get merged in more quickly.

This PR represents an initial draft at auto-approve and auto-merge workflows for dependabot PRs meeting the following criteria:
1. PR is raised by `dependabot [bot]`
2. PR is for a `patch` or `minor` version update only
3. PR is not for a `minor` version update to `rails`

We discussed the need to be able to restrict the times of day that auto-merge could happen, so that potentially-breaking changes wouldn't be merged in out of hours, and to allow for things like Epi-UAT not being available overnight. 

That is perhaps less of a problem for the `design-system`, I have included a restriction blocking dependabot PRs from being merged at weekends, just to confirm that the action works. For other repos we may also wish to block merging over public holidays. 

It is also possible to configure dependabot.yml to schedule the approximate time & day that it checks for updates, e.g.
```
    schedule:
      interval: weekly
      day: tuesday
      time: 09:00
```

The `dependabot-auto-merge.yml` workflow is bound by the usual branch protections for the repo, which probably means that it won't be able to merge any dependabot PRs that haven't also been approved by a code owner. But I think we could still test the overall process by manually approving the PRs too for a while.

N.B. The [GH action](https://github.com/yykamei/block-merge-based-on-time) that I've used to block out of hours merging _does_ have a bank holidays file, but it uses the holidays from Google Calendar API and so thinks that days like Valentine's Day are a bank holiday. We would likely need to manually add bank holidays if we wanted to block merging on those days in other repos.