### PR TITLE
fix: ensure erroring radio buttons are described by the error message

### DIFF
--- a/engine/app/components/citizens_advice_components/checkable/base.rb
+++ b/engine/app/components/citizens_advice_components/checkable/base.rb
@@ -38,8 +38,7 @@ module CitizensAdviceComponents
 
       def error_attributes
         {
-          "aria-describedby": "#{@name}-error",
-          "aria-invalid": true
+          "aria-describedby": "#{@name}-error"
         }
       end
 

--- a/engine/app/components/citizens_advice_components/form_group.html.erb
+++ b/engine/app/components/citizens_advice_components/form_group.html.erb
@@ -15,11 +15,11 @@
       <p class="cads-form-field__hint"><%= hint %></p>
     <% end %>
     <% if error? %>
-      <p class="cads-form-field__error-message"><%= error_message %></p>
+      <p class="cads-form-field__error-message"<% if error? %>id=<%= error_id %> <% end %>><%= error_message %></p>
     <% end %>
     <% inputs.each_with_index do |input, index| %>
       <div class="cads-form-group__item">
-        <%= tag.input(class: "cads-form-group__input", **input.attributes(name, id, index)) %>
+        <%= tag.input(class: "cads-form-group__input", **input.attributes(name, id, index, error: error?)) %>
         <label class="cads-form-group__label" for="<%= input.attributes(name, id, index)[:id] %>">
           <%= input.label %>
         </label>

--- a/engine/app/components/citizens_advice_components/form_group.rb
+++ b/engine/app/components/citizens_advice_components/form_group.rb
@@ -42,6 +42,10 @@ module CitizensAdviceComponents
       @error_message.present?
     end
 
+    def error_id
+      "#{name}-error"
+    end
+
     def optional?
       @optional.present?
     end

--- a/engine/spec/components/citizens_advice_components/radio_group_spec.rb
+++ b/engine/spec/components/citizens_advice_components/radio_group_spec.rb
@@ -77,6 +77,8 @@ RSpec.describe CitizensAdviceComponents::RadioGroup, type: :component do
 
     it { is_expected.to have_css ".cads-form-field--has-error" }
     it { is_expected.to have_text "This is the error message" }
+    it { is_expected.to have_selector "[aria-describedby='radio-group-error']" }
+    it { is_expected.to have_selector "#radio-group-error" }
   end
 
   context "when an hint text is provided" do


### PR DESCRIPTION
Changes how the error message and the radio buttons are rendered to make sure that `aria-describedby` is added to the buttons and references the error message paragraph.  This means that the radio group error message is announced when a radio button in a group with an error gets focus, following the pattern here: https://russmaxdesign.github.io/accessible-forms/fieldset-error04.html.  This was discussed in the accessibilty working group as part of @danielnissenbaum discussion about error summaries and the screen reader journey from error to input.