### PR TITLE
Fix/radio button group errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@
   initNavigation();
   ```
 
+**Fix**
+- Improves screen reader experience when interacting with checkbox and radio groups in an error state
+
 ## v6.3.0
 
 ### 5 December 2024

--- a/engine/app/components/citizens_advice_components/checkable/base.rb
+++ b/engine/app/components/citizens_advice_components/checkable/base.rb
@@ -38,8 +38,7 @@ module CitizensAdviceComponents
 
       def error_attributes
         {
-          "aria-describedby": "#{@name}-error",
-          "aria-invalid": true
+          "aria-describedby": "#{@name}-error"
         }
       end
 

--- a/engine/app/components/citizens_advice_components/checkable/base.rb
+++ b/engine/app/components/citizens_advice_components/checkable/base.rb
@@ -38,7 +38,8 @@ module CitizensAdviceComponents
 
       def error_attributes
         {
-          "aria-describedby": "#{@name}-error"
+          "aria-describedby": "#{@name}-error",
+          "aria-invalid": true
         }
       end
 

--- a/engine/app/components/citizens_advice_components/form_group.html.erb
+++ b/engine/app/components/citizens_advice_components/form_group.html.erb
@@ -15,11 +15,11 @@
       <p class="cads-form-field__hint"><%= hint %></p>
     <% end %>
     <% if error? %>
-      <p class="cads-form-field__error-message"><%= error_message %></p>
+      <p class="cads-form-field__error-message" <% if error? %> id="<%= error_id %>"<% end %>><%= error_message %></p>
     <% end %>
     <% inputs.each_with_index do |input, index| %>
       <div class="cads-form-group__item">
-        <%= tag.input(class: "cads-form-group__input", **input.attributes(name, id, index)) %>
+        <%= tag.input(class: "cads-form-group__input", **input.attributes(name, id, index, error: error?)) %>
         <label class="cads-form-group__label" for="<%= input.attributes(name, id, index)[:id] %>">
           <%= input.label %>
         </label>

--- a/engine/app/components/citizens_advice_components/form_group.rb
+++ b/engine/app/components/citizens_advice_components/form_group.rb
@@ -42,6 +42,10 @@ module CitizensAdviceComponents
       @error_message.present?
     end
 
+    def error_id
+      "#{name}-error"
+    end
+
     def optional?
       @optional.present?
     end

--- a/engine/spec/components/citizens_advice_components/checkbox_group_spec.rb
+++ b/engine/spec/components/citizens_advice_components/checkbox_group_spec.rb
@@ -91,6 +91,9 @@ RSpec.describe CitizensAdviceComponents::CheckboxGroup, type: :component do
 
     it { is_expected.to have_css ".cads-form-field--has-error" }
     it { is_expected.to have_text "This is the error message" }
+    it { is_expected.to have_css "[aria-describedby='checkboxes-error']" }
+    it { is_expected.to have_css "#checkboxes-error" }
+    it { is_expected.to have_css "input[aria-invalid]", count: 2 }
   end
 
   context "when an hint text is provided" do

--- a/engine/spec/components/citizens_advice_components/radio_group_spec.rb
+++ b/engine/spec/components/citizens_advice_components/radio_group_spec.rb
@@ -77,6 +77,9 @@ RSpec.describe CitizensAdviceComponents::RadioGroup, type: :component do
 
     it { is_expected.to have_css ".cads-form-field--has-error" }
     it { is_expected.to have_text "This is the error message" }
+    it { is_expected.to have_css "[aria-describedby='radio-group-error']" }
+    it { is_expected.to have_css "#radio-group-error" }
+    it { is_expected.to have_css "input[aria-invalid]", count: 2 }
   end
 
   context "when an hint text is provided" do


### PR DESCRIPTION
At the moment, when a checkbox or radio input in a fieldset with an error gets focus, there is nothing that announces the error message if a keyboard user is just tabbing through the interactive elements of a form.

This PR changes how the error message and the radio button and checkbox groups are rendered to make sure that `aria-describedby` and `aria-invalid` are added to the inputs, programatically linking the error message to the inputs.

This means that the group error message is announced when an input in a group with an error gets focus.  This was discussed in the accessibility working group as part of @danielnissenbaum's discussion about error summaries and the screen reader journey from error to input.

Using https://russmaxdesign.github.io/accessible-forms/fieldset-error04.html for testing, this seems to be the pattern that work best across the different screen readers.

Interested to know what others think and this isn't something that gov.uk do in their design system.