### PR TITLE
Prepare v6.3.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v6.3.0
+
+### 5 December 2024
+
 
 **New**
 - Add support for Rails 8

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@citizensadvice/design-system",
-  "version": "6.2.0",
+  "version": "6.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@citizensadvice/design-system",
-      "version": "6.2.0",
+      "version": "6.3.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/preset-env": "^7.22.20",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@citizensadvice/design-system",
-  "version": "6.2.0",
+  "version": "6.3.0",
   "description": "Citizens Advice Design System",
   "repository": "https://github.com/citizensadvice/design-system",
   "author": "Citizens Advice",


### PR DESCRIPTION
Adds support for Rails 8 and removes support for EOL Rails 6.1.

There's an argument removing support for Rails 6.1 is a breaking change but we have no consumers using this version so recommending we do this as a minor version as there are otherwise no other changes.