### PR TITLE
Pin concurrent-ruby version for tests

### DIFF
--- a/engine/Gemfile
+++ b/engine/Gemfile
@@ -22,6 +22,12 @@ end
 # rubocop:enable Bundler/DuplicatedGem
 
 group :development, :test do
+  # Can be removed when either a Rails 7.0.x patch is released
+  # or we remove support for Rails 7.0.x whichever is sooner
+  # (likely the latter as it is near EOL)
+  # https://github.com/ruby-concurrency/concurrent-ruby/issues/1077
+  gem "concurrent-ruby", "1.3.4"
+
   gem "citizens-advice-style",
       github: "citizensadvice/citizens-advice-style-ruby",
       tag: "v11.0.0"

--- a/engine/Gemfile.lock
+++ b/engine/Gemfile.lock
@@ -238,6 +238,7 @@ DEPENDENCIES
   capybara
   citizens-advice-style!
   citizens_advice_components!
+  concurrent-ruby (= 1.3.4)
   erb_lint
   i18n-tasks
   railties (~> 7.2.0)


### PR DESCRIPTION
Workaround for
https://github.com/ruby-concurrency/concurrent-ruby/issues/1077 which is currently causing our Rails 7.0.x CI tests to fail.

This change shouldn't affect the published gem as this only controls what we install locally or in CI and consumers control their own application gem versions.

Can be removed when either a Rails 7.0.x patch is released or we remove support for Rails 7.0.x whichever is sooner (likely the latter as it is near EOL)