### PR TITLE
Set engine version

### DIFF
--- a/contributing/04-release-process.md
+++ b/contributing/04-release-process.md
@@ -12,11 +12,17 @@ To perform a release you need:
 
 ## Prepare the release
 
+We provide a npm run-script to start the process of preparing a release:
+
 ```sh
 npm run release
 ```
 
-This prepares the release and puts it in a branch with the appropriate version name, which needs a pull request to be merged into main. Once that is merged you can then do the actual release.
+This will run some checks, prompt you to select a new package version, and prepares a branch with the appropriate version name.
+
+Once this is done you will need to update the `CitizensAdviceComponents::VERSION` engine constant to match. There is a spec which checks the versions match in case you forget to do this.
+
+From here you should create a new pull request from the release branch and request a review on #design-system-dev in Slack.
 
 ## Publish to npm
 

--- a/demo/Gemfile.lock
+++ b/demo/Gemfile.lock
@@ -12,7 +12,7 @@ GIT
 PATH
   remote: ../engine
   specs:
-    citizens_advice_components (6.4.0)
+    citizens_advice_components (6.4.1)
       actionpack (>= 7.0.0, < 9.0)
       railties (>= 7.0.0, < 9.0)
       view_component (>= 2.0.0, < 4.0)

--- a/demo/Gemfile.lock
+++ b/demo/Gemfile.lock
@@ -12,7 +12,7 @@ GIT
 PATH
   remote: ../engine
   specs:
-    citizens_advice_components (0.1.0)
+    citizens_advice_components (6.4.0)
       actionpack (>= 7.0.0, < 9.0)
       railties (>= 7.0.0, < 9.0)
       view_component (>= 2.0.0, < 4.0)

--- a/design-system-docs/Gemfile.lock
+++ b/design-system-docs/Gemfile.lock
@@ -12,7 +12,7 @@ GIT
 PATH
   remote: ../engine
   specs:
-    citizens_advice_components (6.4.0)
+    citizens_advice_components (6.4.1)
       actionpack (>= 7.0.0, < 9.0)
       railties (>= 7.0.0, < 9.0)
       view_component (>= 2.0.0, < 4.0)

--- a/design-system-docs/Gemfile.lock
+++ b/design-system-docs/Gemfile.lock
@@ -12,7 +12,7 @@ GIT
 PATH
   remote: ../engine
   specs:
-    citizens_advice_components (0.1.0)
+    citizens_advice_components (6.4.0)
       actionpack (>= 7.0.0, < 9.0)
       railties (>= 7.0.0, < 9.0)
       view_component (>= 2.0.0, < 4.0)

--- a/design-system-docs/src/_guides/overview.md
+++ b/design-system-docs/src/_guides/overview.md
@@ -33,7 +33,7 @@ The `@citizensadvice/design-system` package bundles the following:
 You can install the core package from npm. We recommend pinning to an exact version. If you are also using the Rails components these versions need to match.
 
 ```sh
-npm install --save-exact @citizensadvice/design-system@5.5.0
+npm install --save-exact @citizensadvice/design-system@<%= CitizensAdviceComponents::VERSION %>
 ```
 
 This package—alongside companion HTML patterns—is the minimum requirement when using the design system.
@@ -71,7 +71,7 @@ The Rails components can be installed by adding the following to your `Gemfile`:
 # Pin to the same version as the npm package
 gem "citizens_advice_components",
     github: "citizensadvice/design-system",
-    tag: "v5.5.0",
+    tag: "v<%= CitizensAdviceComponents::VERSION %>",
     glob: "engine/*.gemspec"
 
 # This line is optional. The citizens_advice_components gem is built

--- a/design-system-docs/src/_guides/using-with-rails.md
+++ b/design-system-docs/src/_guides/using-with-rails.md
@@ -71,7 +71,7 @@ The main component of the Design System is `@citizensadvice/design-system` which
 You can install the core package from npm. We'll also make sure to pin to an exact version. The npm package and the gem versions need to match so it's important to specify an exact version here.
 
 ```sh
-npm install --save-exact @citizensadvice/design-system@5.5.0
+npm install --save-exact @citizensadvice/design-system@<%= CitizensAdviceComponents::VERSION %>
 ```
 
 After you've done this you'll need to add the following to your `config/initializers/assets.rb` file:
@@ -159,7 +159,7 @@ The Rails components can be installed by adding the following to your `Gemfile`:
 # Pin to the same version as the npm package
 gem "citizens_advice_components",
     github: "citizensadvice/design-system",
-    tag: "v5.5.0",
+    tag: "v<%= CitizensAdviceComponents::VERSION %>",
     glob: "engine/*.gemspec"
 
 # This line is optional. The citizens_advice_components gem is built

--- a/engine/Gemfile.lock
+++ b/engine/Gemfile.lock
@@ -12,7 +12,7 @@ GIT
 PATH
   remote: .
   specs:
-    citizens_advice_components (6.4.0)
+    citizens_advice_components (6.4.1)
       actionpack (>= 7.0.0, < 9.0)
       railties (>= 7.0.0, < 9.0)
       view_component (>= 2.0.0, < 4.0)

--- a/engine/Gemfile.lock
+++ b/engine/Gemfile.lock
@@ -12,7 +12,7 @@ GIT
 PATH
   remote: .
   specs:
-    citizens_advice_components (0.1.0)
+    citizens_advice_components (6.4.0)
       actionpack (>= 7.0.0, < 9.0)
       railties (>= 7.0.0, < 9.0)
       view_component (>= 2.0.0, < 4.0)

--- a/engine/lib/citizens_advice_components.rb
+++ b/engine/lib/citizens_advice_components.rb
@@ -6,6 +6,6 @@ require "citizens_advice_components/version"
 module CitizensAdviceComponents
   def self.deprecator
     # https://api.rubyonrails.org/classes/ActiveSupport/Deprecation.html
-    @deprecator ||= ActiveSupport::Deprecation.new("6.0", "CitizensAdviceComponents")
+    @deprecator ||= ActiveSupport::Deprecation.new("7.0", "CitizensAdviceComponents")
   end
 end

--- a/engine/lib/citizens_advice_components/version.rb
+++ b/engine/lib/citizens_advice_components/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module CitizensAdviceComponents
-  VERSION = "0.1.0"
+  VERSION = "6.4.0"
 end

--- a/engine/lib/citizens_advice_components/version.rb
+++ b/engine/lib/citizens_advice_components/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module CitizensAdviceComponents
-  VERSION = "6.4.0"
+  VERSION = "6.4.1"
 end

--- a/engine/spec/lib/citizens_advice_components/version_spec.rb
+++ b/engine/spec/lib/citizens_advice_components/version_spec.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+RSpec.describe "CitizensAdviceComponents::VERSION" do
+  it "matches package version" do
+    package_json_path = CitizensAdviceComponents::Engine.root.join("../package.json")
+    package_json = JSON.parse(File.read(package_json_path))
+    expect(CitizensAdviceComponents::VERSION).to eq package_json["version"]
+  end
+end


### PR DESCRIPTION
We currently fix the engine version to 0.1.0 which prevents us from using things like the deprecator to log version warnings and is at best just a little confusing.

Set the engine version to match the package version and add a spec to require them to match when updating the version.