### PR TITLE
Experimental:  Migrate rails form builder to design system engine

### DIFF
--- a/demo/Gemfile.lock
+++ b/demo/Gemfile.lock
@@ -14,6 +14,10 @@ PATH
   specs:
     citizens_advice_components (6.4.2)
       actionpack (>= 7.1.0, < 9.0)
+      actionview (>= 7.1.0, < 9.0)
+      activemodel (>= 7.1.0, < 9.0)
+      activerecord (>= 7.1.0, < 9.0)
+      activesupport (>= 7.1.0, < 9.0)
       railties (>= 7.1.0, < 9.0)
       view_component (>= 2.0.0, < 4.0)
 

--- a/demo/app/controllers/application_controller.rb
+++ b/demo/app/controllers/application_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class ApplicationController < ActionController::Base
+  default_form_builder CitizensAdviceComponents::FormBuilder
+
   around_action :with_locale
 
   def with_locale(&)

--- a/demo/app/controllers/example_form_controller.rb
+++ b/demo/app/controllers/example_form_controller.rb
@@ -17,11 +17,12 @@ class ExampleFormController < ApplicationController
   def success; end
 
   def form_params
-    params.permit(
+    params.require(:example_form).permit(
       :first_name,
       :last_name,
       :your_enquiry,
       :total_amount,
+      :date_of_purchase,
       :contacted_trader,
       :trader_response
     )

--- a/demo/app/models/example_form.rb
+++ b/demo/app/models/example_form.rb
@@ -1,17 +1,22 @@
 # frozen_string_literal: true
 
+require "active_record/attribute_assignment"
+
 class ExampleForm
   include ActiveModel::Model
+  include ActiveModel::Attributes
+  include ActiveRecord::AttributeAssignment
 
   attr_accessor(
     :first_name,
     :last_name,
     :your_enquiry,
     :total_amount,
-    :date_of_purchase,
     :contacted_trader,
     :trader_response
   )
+
+  attribute :date_of_purchase, :date
 
   validates(
     :first_name,
@@ -35,7 +40,8 @@ class ExampleForm
 
   validates(
     :date_of_purchase,
-    presence: { message: "Tell us the date you purchased the goods or services" }
+    presence: { message: "Tell us the date you purchased the goods or services" },
+    comparison: { less_than: Time.zone.today, message: "Date of purchase must be in the past" }
   )
 
   validates(
@@ -46,23 +52,4 @@ class ExampleForm
       message: "Tell us if you have contacted the trader about this complaint"
     }
   )
-
-  def formatted_errors
-    errors.attribute_names.map do |attr|
-      { href: id_for(attr), message: errors[attr].first }
-    end
-  end
-
-  private
-
-  def id_for(attr)
-    case attr
-    when :contacted_trader
-      "##{attr}-0"
-    when :date_of_purchase
-      "##{attr}-day"
-    else
-      "##{attr}-input"
-    end
-  end
 end

--- a/demo/app/views/example_form/new.html.erb
+++ b/demo/app/views/example_form/new.html.erb
@@ -4,73 +4,66 @@
 ) %>
 <%= render PageLayoutComponent.new do |c| %>
   <% c.with_main do %>
-    <%= render CitizensAdviceComponents::ErrorSummary.new do |c| %>
-      <% c.with_errors(@form.formatted_errors) %>
-    <% end %>
+    <%= form_with model: @form, url: example_form_create_path, method: :post do |f| %>
+      <%= f.cads_error_summary %>
 
-    <h1 class="cads-page-title">Consumer Query</h1>
+      <h1 class="cads-page-title">Consumer Query</h1>
 
-    <div class="cads-prose">
-      <p>From 1 April 2019 we are only able to provide general consumer advice to residents of England and Wales. If you are resident in Scotland and have a general consumer enquiry please contact Advice Direct Scotland / 0808 164 6000</p>
-    </div>
+      <div class="cads-prose">
+        <p>From 1 April 2019 we are only able to provide general consumer advice to residents of England and Wales. If you are resident in Scotland and have a general consumer enquiry please contact Advice Direct Scotland / 0808 164 6000</p>
+      </div>
 
-    <%= form_tag(example_form_create_path, novalidate: true) do %>
-      <%= render CitizensAdviceComponents::TextInput.new(
-        type: :text,
-        name: :first_name,
+      <%= f.cads_text_field(
+        :first_name,
         label: "First name",
+        required: true,
         width: :sixteen_chars
       ) %>
 
-      <%= render CitizensAdviceComponents::TextInput.new(
-        type: :text,
-        name: :last_name,
+      <%= f.cads_text_field(
+        :last_name,
         label: "Last name",
+        required: true,
         width: :sixteen_chars
       ) %>
 
-      <%= render CitizensAdviceComponents::Textarea.new(
-        name: :your_enquiry,
+      <%= f.cads_text_area(
+        :your_enquiry,
         label: "Your complaint or enquiry",
-        options: {
-          hint: "Please provide details of your complaint or enquiry."
-        }
+        hint: "Please provide details of your complaint or enquiry.",
+        required: true,
       ) %>
 
-      <%= render CitizensAdviceComponents::TextInput.new(
-        type: :text,
-        name: :total_amount,
+      <%= f.cads_text_field(
+        :total_amount,
         label: "What was the total amount paid for the goods or services?",
-        width: :four_chars,
-        options: {
-          hint: "Enter a value in pounds and pence only e.g. £112.00"
-        }
+        hint: "Enter a value in pounds and pence only e.g. £112.00",
+        required: true,
+        width: :four_chars
       ) %>
 
-      <%= render CitizensAdviceComponents::DateInput.new(name: :date_of_purchase, label: "When did you purchase the goods or services?") %>
+      <%= f.cads_date_field(
+        :date_of_purchase,
+        label: "When did you purchase the goods or services?",
+        required: true
+      ) %>
 
-      <%= render CitizensAdviceComponents::RadioGroup.new(
-        legend: "Have you contacted the trader about this complaint?",
-        name: :contacted_trader
-      ) do |c| %>
-        <% c.with_input(label: "Yes", value: "yes") %>
-        <% c.with_input(label: "No", value: "no") %>
-      <% end %>
+      <%= f.cads_collection_radio_buttons(
+        :contacted_trader,
+        label: "Have you contacted the trader about this complaint?",
+        collection: [["Yes", "yes"], ["No", "no"]],
+        text_method: :first,
+        value_method: :last,
+        required: true
+      ) %>
 
-      <%= render CitizensAdviceComponents::Textarea.new(
-        name: :trader_response,
+      <%= f.cads_text_area(
+        :trader_response,
         label: "Outline the trader's response to the complaint, if any",
-        options: {
-          optional: true
-        }
+        required: false,
       ) %>
 
-      <%= render CitizensAdviceComponents::Button.new(variant: :primary, type: :submit) do |c| %>
-        Submit complaint
-        <% c.with_icon_right do %>
-          <%= render CitizensAdviceComponents::Icons::ArrowRight.new %>
-        <% end %>
-      <% end %>
+      <%= f.cads_button "Submit complaint", icon_right: :arrow_right %>
     <% end %>
   <% end %>
 <% end  %>

--- a/demo/config/locales/en.yml
+++ b/demo/config/locales/en.yml
@@ -1,3 +1,4 @@
 ---
 en:
-  hello: Hello world
+  errors:
+    format: '%{message}'

--- a/demo/package-lock.json
+++ b/demo/package-lock.json
@@ -25,7 +25,7 @@
     },
     "..": {
       "name": "@citizensadvice/design-system",
-      "version": "6.4.1",
+      "version": "6.4.2",
       "dev": true,
       "license": "Apache-2.0",
       "devDependencies": {

--- a/design-system-docs/Gemfile.lock
+++ b/design-system-docs/Gemfile.lock
@@ -14,6 +14,10 @@ PATH
   specs:
     citizens_advice_components (6.4.2)
       actionpack (>= 7.1.0, < 9.0)
+      actionview (>= 7.1.0, < 9.0)
+      activemodel (>= 7.1.0, < 9.0)
+      activerecord (>= 7.1.0, < 9.0)
+      activesupport (>= 7.1.0, < 9.0)
       railties (>= 7.1.0, < 9.0)
       view_component (>= 2.0.0, < 4.0)
 
@@ -39,6 +43,10 @@ GEM
       rails-html-sanitizer (~> 1.6)
     activemodel (7.2.2.1)
       activesupport (= 7.2.2.1)
+    activerecord (7.2.2.1)
+      activemodel (= 7.2.2.1)
+      activesupport (= 7.2.2.1)
+      timeout (>= 0.4.0)
     activesupport (7.2.2.1)
       base64
       benchmark (>= 0.3)
@@ -235,6 +243,7 @@ GEM
     stringio (3.1.2)
     thor (1.3.2)
     tilt (2.4.0)
+    timeout (0.4.3)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unicode-display_width (3.1.2)

--- a/engine/.rubocop.yml
+++ b/engine/.rubocop.yml
@@ -28,3 +28,9 @@ Rails/RakeEnvironment:
   Exclude:
     # Gem Rakefile is not used in a Rails context
     - 'Rakefile'
+
+RSpec/MultipleExpectations:
+  Max: 4
+  Exclude:
+    # Feature tests deliberately use multiple expectations
+    - 'spec/features/**/*.rb'

--- a/engine/Gemfile.lock
+++ b/engine/Gemfile.lock
@@ -14,6 +14,10 @@ PATH
   specs:
     citizens_advice_components (6.4.2)
       actionpack (>= 7.1.0, < 9.0)
+      actionview (>= 7.1.0, < 9.0)
+      activemodel (>= 7.1.0, < 9.0)
+      activerecord (>= 7.1.0, < 9.0)
+      activesupport (>= 7.1.0, < 9.0)
       railties (>= 7.1.0, < 9.0)
       view_component (>= 2.0.0, < 4.0)
 
@@ -38,6 +42,10 @@ GEM
       rails-html-sanitizer (~> 1.6)
     activemodel (8.0.1)
       activesupport (= 8.0.1)
+    activerecord (8.0.1)
+      activemodel (= 8.0.1)
+      activesupport (= 8.0.1)
+      timeout (>= 0.4.0)
     activesupport (8.0.1)
       base64
       benchmark (>= 0.3)
@@ -224,6 +232,7 @@ GEM
     terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)
     thor (1.3.2)
+    timeout (0.4.3)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.6.0)

--- a/engine/app/helpers/citizens_advice_components/form_builder.rb
+++ b/engine/app/helpers/citizens_advice_components/form_builder.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+module CitizensAdviceComponents
+  class FormBuilder < ActionView::Helpers::FormBuilder
+    def cads_text_field(attribute, label: nil, hint: nil, required: false, **)
+      Elements::TextInput.new(@template, object, attribute, label: label, required: required, hint: hint, **).render
+    end
+
+    def cads_text_area(attribute, label: nil, hint: nil, required: false, **)
+      Elements::TextArea.new(@template, object, attribute, label: label, required: required, hint: hint, **).render
+    end
+
+    def cads_date_field(attribute, label: nil, hint: nil, required: false, **)
+      Elements::DateInput.new(@template, object, attribute, label: label, required: required, hint: hint, **).render
+    end
+
+    def cads_collection_radio_buttons(attribute, label: nil, hint: nil, required: false, **)
+      Elements::Collections::RadioButtons.new(@template, object, attribute, label: label, hint: hint, required: required, **).render
+    end
+
+    def cads_collection_check_boxes(attribute, label: nil, hint: nil, required: false, **)
+      Elements::Collections::CheckBoxes.new(@template, object, attribute, label: label, hint: hint, required: required, **).render
+    end
+
+    def cads_collection_select(attribute, label: nil, hint: nil, required: false, **)
+      Elements::Collections::Select.new(@template, object, attribute, label: label, hint: hint, required: required, **).render
+    end
+
+    def cads_button(button_text = "Save changes", **)
+      Elements::Button.new(@template, object, button_text: button_text, **).render
+    end
+
+    def cads_error_summary
+      Elements::ErrorSummary.new(@template, object, :unused).render
+    end
+
+    def cads_check_box(attribute, label: nil, **)
+      Elements::CheckBox.new(@template, object, attribute, label: label, **).render
+    end
+  end
+end

--- a/engine/app/lib/citizens_advice_components/elements/base.rb
+++ b/engine/app/lib/citizens_advice_components/elements/base.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+require "active_support/core_ext/module/delegation"
+
+module CitizensAdviceComponents
+  module Elements
+    class Base
+      include ActionView::Context
+
+      delegate :content_tag, :tag, :safe_join, :link_to, :capture, to: :@template
+
+      attr_reader :template, :object, :attribute
+      attr_accessor :options
+
+      def initialize(template, object, attribute, **kwargs)
+        @template = template
+        @object = object
+        @attribute = attribute
+
+        @options = kwargs.with_defaults(default_options)
+      end
+
+      def render
+        # NO OP
+      end
+
+      private
+
+      def current_value
+        object.send(attribute)
+      end
+
+      def default_options
+        {}
+      end
+
+      def error_message
+        object.errors.full_messages_for(attribute)&.first
+      end
+
+      def object_name
+        object.to_model.model_name.singular
+      end
+
+      def field_name
+        template.field_name(object_name, attribute)
+      end
+
+      def field_id
+        template.field_id(object_name, attribute)
+      end
+
+      def label
+        options[:label] || object.class.human_attribute_name(attribute)
+      end
+
+      def hint
+        options[:hint]
+      end
+
+      def optional
+        !!!options[:required]
+      end
+
+      def error?
+        error_message.present?
+      end
+
+      def error_marker
+        return "" unless error?
+
+        tag.div(class: "cads-form-field__error-marker")
+      end
+
+      def form_field_classes
+        class_names("cads-form-field", "cads-form-field--has-error": error?)
+      end
+    end
+  end
+end

--- a/engine/app/lib/citizens_advice_components/elements/button.rb
+++ b/engine/app/lib/citizens_advice_components/elements/button.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+module CitizensAdviceComponents
+  module Elements
+    class Button < Base
+      def initialize(template, object, button_text: nil, **)
+        super(template, object, nil, **)
+
+        @button_text = button_text
+        @icon_left = options[:icon_left]
+        @icon_right = options[:icon_right]
+
+        @options.except!(:icon_left, :icon_right)
+      end
+
+      def render
+        component = CitizensAdviceComponents::Button.new(**options)
+        component.with_content(@button_text)
+
+        add_icon_left(component) if @icon_left
+        add_icon_right(component) if @icon_right
+
+        component.render_in(@template)
+      end
+
+      private
+
+      def default_options
+        { type: :submit, variant: :primary }
+      end
+
+      def add_icon_left(component)
+        component.with_icon_left do
+          icon_left_class.new.render_in(@template)
+        end
+      end
+
+      def add_icon_right(component)
+        component.with_icon_right do
+          icon_right_class.new.render_in(@template)
+        end
+      end
+
+      def icon_left_class
+        "CitizensAdviceComponents::Icons::#{@icon_left.to_s.camelize}".constantize
+      end
+
+      def icon_right_class
+        "CitizensAdviceComponents::Icons::#{@icon_right.to_s.camelize}".constantize
+      end
+    end
+  end
+end

--- a/engine/app/lib/citizens_advice_components/elements/check_box.rb
+++ b/engine/app/lib/citizens_advice_components/elements/check_box.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module CitizensAdviceComponents
+  module Elements
+    class CheckBox < Base
+      def render
+        safe_join([hidden_field, checkbox_field])
+      end
+
+      private
+
+      def checkbox_field
+        component = CitizensAdviceComponents::CheckboxSingle.new(
+          name: field_name,
+          id: field_id,
+          error_message: error_message
+        )
+        component.with_checkbox(label: label,
+                                value: "1",
+                                checked: current_value,
+                                additional_attributes: options[:additional_attributes])
+
+        component.render_in(@template)
+      end
+
+      def hidden_field
+        tag.input(
+          type: "hidden",
+          name: field_name,
+          value: "0"
+        )
+      end
+    end
+  end
+end

--- a/engine/app/lib/citizens_advice_components/elements/collections/base.rb
+++ b/engine/app/lib/citizens_advice_components/elements/collections/base.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+module CitizensAdviceComponents
+  module Elements
+    module Collections
+      class Base < CitizensAdviceComponents::Elements::Base
+        include ActionView::Helpers::FormOptionsHelper
+
+        private
+
+        def text_method
+          @options[:text_method]
+        end
+
+        def value_method
+          @options[:value_method] || text_method
+        end
+
+        def legend_html
+          tag.legend(class: "cads-form-field__label") { safe_join([label, " ", optional_html]) }
+        end
+
+        def hint_html
+          return if hint.nil?
+
+          tag.p(class: "cads-form-field__hint") { hint }
+        end
+
+        def error_message_html
+          return unless error?
+
+          tag.p(class: "cads-form-field__error-message") { error_message }
+        end
+
+        def optional_html
+          return unless optional
+
+          tag.span(class: "cads-form-field__optional") { "(optional)" }
+        end
+
+        def item_id(index)
+          if index.zero?
+            "#{field_id}-input"
+          else
+            "#{field_id}-#{index}"
+          end
+        end
+      end
+    end
+  end
+end

--- a/engine/app/lib/citizens_advice_components/elements/collections/check_boxes.rb
+++ b/engine/app/lib/citizens_advice_components/elements/collections/check_boxes.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+module CitizensAdviceComponents
+  module Elements
+    module Collections
+      class CheckBoxes < Base
+        def render
+          tag.div(class: form_field_classes) do
+            safe_join([
+              error_marker,
+              tag.fieldset(class: "cads-form-field__content cads-form-group cads-form-group--checkbox") do
+                safe_join([legend_html, hint_html, error_message_html, checkboxes_html])
+              end
+            ])
+          end
+        end
+
+        private
+
+        def items
+          @options[:collection].map do |item|
+            label = value_for_collection(item, text_method)
+            value = value_for_collection(item, value_method)
+            checked = Array(current_value).include?(value)
+
+            {
+              name: field_name,
+              label: label,
+              value: value,
+              checked: checked
+            }
+          end
+        end
+
+        # rubocop:disable Metrics/AbcSize
+        def checkboxes_html
+          checkboxes = items.map.with_index do |item, index|
+            tag.div(class: "cads-form-group__item") do
+              tag.input(
+                class: "cads-form-group__input",
+                type: "checkbox",
+                id: item_id(index),
+                name: "#{field_name}[]",
+                value: item[:value],
+                checked: item[:checked]
+              ) +
+                tag.label(class: "cads-form-group__label", for: item_id(index)) { item[:label] }
+            end
+          end
+
+          safe_join([checkboxes, hidden_field])
+        end
+        # rubocop:enable Metrics/AbcSize
+
+        def hidden_field
+          tag.input(
+            type: "hidden",
+            name: "#{field_name}[]",
+            value: ""
+          )
+        end
+      end
+    end
+  end
+end

--- a/engine/app/lib/citizens_advice_components/elements/collections/radio_buttons.rb
+++ b/engine/app/lib/citizens_advice_components/elements/collections/radio_buttons.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+module CitizensAdviceComponents
+  module Elements
+    module Collections
+      class RadioButtons < Base
+        def render
+          tag.div(class: form_field_classes) do
+            safe_join([
+              error_marker,
+              tag.fieldset(class: "cads-form-field__content cads-form-group cads-form-group--radio") do
+                safe_join([legend_html, hint_html, error_message_html, radios_html])
+              end
+            ])
+          end
+        end
+
+        private
+
+        def items
+          @options[:collection].map do |item|
+            label = value_for_collection(item, text_method)
+            value = value_for_collection(item, value_method)
+            checked = value.eql?(current_value)
+
+            {
+              name: field_name,
+              label: label,
+              value: value,
+              checked: checked
+            }
+          end
+        end
+
+        # rubocop:disable Metrics/AbcSize
+        def radios_html
+          radios = items.map.with_index do |item, index|
+            tag.div(class: "cads-form-group__item") do
+              tag.input(
+                class: "cads-form-group__input",
+                type: "radio",
+                id: item_id(index),
+                name: field_name.to_s,
+                value: item[:value],
+                checked: item[:checked]
+              ) +
+                tag.label(class: "cads-form-group__label", for: item_id(index)) { item[:label] }
+            end
+          end
+
+          safe_join(radios)
+        end
+        # rubocop:enable Metrics/AbcSize
+      end
+    end
+  end
+end

--- a/engine/app/lib/citizens_advice_components/elements/collections/select.rb
+++ b/engine/app/lib/citizens_advice_components/elements/collections/select.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module CitizensAdviceComponents
+  module Elements
+    module Collections
+      class Select < Base
+        def render
+          component = CitizensAdviceComponents::Select.new(
+            select_options: items,
+            name: field_id,
+            label: label,
+            options: {
+              hint: hint,
+              optional: optional,
+              error_message: error_message,
+              value: current_value,
+              additional_attributes: { name: field_name }
+            }
+          )
+
+          component.render_in(@template)
+        end
+
+        private
+
+        def items
+          @options[:collection].map do |item|
+            label = value_for_collection(item, text_method)
+            value = value_for_collection(item, value_method)
+
+            [label, value]
+          end
+        end
+      end
+    end
+  end
+end

--- a/engine/app/lib/citizens_advice_components/elements/date_input.rb
+++ b/engine/app/lib/citizens_advice_components/elements/date_input.rb
@@ -1,0 +1,117 @@
+# frozen_string_literal: true
+
+module CitizensAdviceComponents
+  module Elements
+    class DateInput < Base
+      include ActionView::Helpers::TagHelper
+
+      def render
+        tag.div(class: form_field_classes) do
+          safe_join([
+            error_marker,
+            tag.div(class: "cads-form-field__content") do
+              tag.fieldset(class: "cads-form-group") do
+                safe_join([legend_html, hint_html, error_message_html, date_inputs])
+              end
+            end
+          ])
+        end
+      end
+
+      private
+
+      def legend_html
+        tag.legend(class: "cads-form-field__label") { safe_join([label, " ", optional_html]) }
+      end
+
+      def hint_html
+        return if hint.nil?
+
+        tag.p(class: "cads-form-field__hint") { hint }
+      end
+
+      def error_message_html
+        return unless error?
+
+        tag.p(class: "cads-form-field__error-message") { error_message }
+      end
+
+      def optional_html
+        return unless optional
+
+        tag.span(class: "cads-form-field__optional") { "(optional)" }
+      end
+
+      def date_inputs
+        tag.div(class: "cads-date-input") do
+          safe_join([day_input, month_input, year_input])
+        end
+      end
+
+      def day_input
+        tag.div(class: "cads-date-input") do
+          tag.div(class: "cads-date-input__item") do
+            tag.label(class: "cads-form-field__label", for: "#{field_id}-input") { "Day" } +
+              tag.input(
+                class: class_names("cads-input", "cads-input--2ch", "cads-input--error": error?),
+                name: date_field_name("3i"),
+                id: "#{field_id}-input",
+                inputmode: "numeric",
+                value: day_value
+              )
+          end
+        end
+      end
+
+      def month_input
+        tag.div(class: "cads-date-input") do
+          tag.div(class: "cads-date-input__item") do
+            tag.label(class: "cads-form-field__label", for: date_field_id("2i")) { "Month" } +
+              tag.input(
+                class: class_names("cads-input", "cads-input--2ch", "cads-input--error": error?),
+                name: date_field_name("2i"),
+                id: date_field_id("2i"),
+                inputmode: "numeric",
+                value: month_value
+              )
+          end
+        end
+      end
+
+      def year_input
+        tag.div(class: "cads-date-input") do
+          tag.div(class: "cads-date-input__item") do
+            tag.label(class: "cads-form-field__label", for: date_field_id("1i")) { "Year" } +
+              tag.input(
+                class: class_names("cads-input", "cads-input--4ch", "cads-input--error": error?),
+                name: date_field_name("1i"),
+                id: date_field_id("1i"),
+                inputmode: "numeric",
+                value: year_value
+              )
+          end
+        end
+      end
+
+      def date_field_name(suffix)
+        @template.field_name(object_name, "#{attribute}(#{suffix})")
+      end
+
+      def date_field_id(suffix)
+        "#{field_id}_#{suffix}"
+      end
+
+      def day_value
+        current_value.day if current_value.is_a?(Date)
+      end
+
+      def month_value
+        current_value.month if current_value.is_a?(Date)
+      end
+
+      def year_value
+        current_value.year if current_value.is_a?(Date)
+      end
+    end
+  end
+end

--- a/engine/app/lib/citizens_advice_components/elements/error_summary.rb
+++ b/engine/app/lib/citizens_advice_components/elements/error_summary.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module CitizensAdviceComponents
+  module Elements
+    class ErrorSummary < Base
+      def render
+        component = CitizensAdviceComponents::ErrorSummary.new
+        component.with_errors(error_messages)
+
+        component.render_in(@template)
+      end
+
+      private
+
+      def error_messages
+        object.errors.group_by_attribute.map do |attr, errors|
+          {
+            href: "##{field_id_for(attr)}-input",
+            message: errors.first.full_message
+          }
+        end
+      end
+
+      def field_id_for(attribute)
+        @template.field_id(object_name, attribute)
+      end
+    end
+  end
+end

--- a/engine/app/lib/citizens_advice_components/elements/text_area.rb
+++ b/engine/app/lib/citizens_advice_components/elements/text_area.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module CitizensAdviceComponents
+  module Elements
+    class TextArea < Base
+      def render
+        component = CitizensAdviceComponents::Textarea.new(
+          name: field_name,
+          id: field_id,
+          label: label,
+          rows: options[:rows],
+          options: {
+            hint: hint,
+            optional: optional,
+            value: current_value,
+            error_message: error_message,
+            additional_attributes: options[:additional_attributes]
+          }
+        )
+
+        component.render_in(@template)
+      end
+    end
+  end
+end

--- a/engine/app/lib/citizens_advice_components/elements/text_input.rb
+++ b/engine/app/lib/citizens_advice_components/elements/text_input.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module CitizensAdviceComponents
+  module Elements
+    class TextInput < Base
+      def render
+        component = CitizensAdviceComponents::TextInput.new(
+          name: field_name,
+          id: field_id,
+          label: label,
+          type: :text,
+          width: options[:width],
+          options: {
+            hint: hint,
+            optional: optional,
+            value: current_value,
+            error_message: error_message,
+            additional_attributes: options[:additional_attributes]
+          }
+        )
+
+        component.render_in(@template)
+      end
+    end
+  end
+end

--- a/engine/citizens_advice_components.gemspec
+++ b/engine/citizens_advice_components.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
 
   spec.files = Dir["{app,config,lib}/**/*", "README.md"]
 
-  %w[actionpack railties].each do |rails_lib|
+  %w[actionpack actionview activemodel activerecord activesupport railties].each do |rails_lib|
     spec.add_dependency rails_lib, [">= 7.1.0", "< 9.0"]
   end
 

--- a/engine/lib/citizens_advice_components/engine.rb
+++ b/engine/lib/citizens_advice_components/engine.rb
@@ -9,6 +9,7 @@ module CitizensAdviceComponents
 
     config.autoload_paths = %W[
       #{CitizensAdviceComponents::Engine.root.join('app/components')}
+      #{CitizensAdviceComponents::Engine.root.join('app/helpers')}
       #{CitizensAdviceComponents::Engine.root.join('app/lib')}
     ]
 

--- a/engine/spec/features/button_spec.rb
+++ b/engine/spec/features/button_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+RSpec.describe "buttons" do
+  before do
+    visit element_path("buttons")
+  end
+
+  it "renders a default button" do
+    expect(page).to have_css(".cads-button__primary", text: "Default")
+  end
+
+  it "renders a secondary button" do
+    expect(page).to have_css(".cads-button__secondary", text: "Secondary")
+  end
+
+  it "renders a button with type button" do
+    expect(page).to have_css(".cads-button__primary[type=button]", text: "Button")
+  end
+
+  context "with icons" do
+    it "renders icon on the left side of button" do
+      within "#icon_left" do
+        expect(page).to have_css("span.cads-button__icon-left")
+        expect(page).to have_css("svg.cads-icon--arrow-left")
+      end
+    end
+
+    it "renders icon on the right side of button" do
+      within "#icon_right" do
+        expect(page).to have_css("span.cads-button__icon-right")
+        expect(page).to have_css("svg.cads-icon--arrow-right")
+      end
+    end
+  end
+end

--- a/engine/spec/features/check_box_spec.rb
+++ b/engine/spec/features/check_box_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+RSpec.describe "single check boxes" do
+  before do
+    visit element_path("check_box")
+  end
+
+  it "renders the visible unchecked checkbox" do
+    expect(page).to have_unchecked_field("person[opted_in]", type: "checkbox", with: "1")
+  end
+
+  it "renders the label" do
+    expect(page).to have_text("Opted in")
+  end
+
+  it "renders the hidden field which defaults to false" do
+    expect(page).to have_field("person[opted_in]", type: "hidden", with: "0")
+  end
+
+  it "renders the visible checked checkbox" do
+    expect(page).to have_checked_field("person[account_active]", type: "checkbox", with: "1")
+  end
+end

--- a/engine/spec/features/collection_check_boxes_spec.rb
+++ b/engine/spec/features/collection_check_boxes_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+RSpec.describe "collection check boxes" do
+  before do
+    visit element_path("collection_check_boxes")
+  end
+
+  it "renders a number of check boxes" do
+    expect(page).to have_unchecked_field("person[pizza_toppings][]", type: "checkbox", with: "Anchovies")
+    expect(page).to have_unchecked_field("person[pizza_toppings][]", type: "checkbox", with: "Cheese")
+    expect(page).to have_unchecked_field("person[pizza_toppings][]", type: "checkbox", with: "Pepperoni")
+    expect(page).to have_unchecked_field("person[pizza_toppings][]", type: "checkbox", with: "Olives")
+  end
+
+  it "includes a hidden field to allow 'all unchecked' state to persist" do
+    expect(page).to have_field("person[pizza_toppings][]", type: "hidden", with: "")
+  end
+
+  it "uses an id for the first item that can be targetted by cads_error_summary" do
+    expect(page).to have_field("person_pizza_toppings-input")
+  end
+
+  # rubocop:disable RSpec/ExampleLength
+  it "remembers the selected values" do
+    check "Cheese"
+    check "Pepperoni"
+    click_button
+
+    expect(page).to have_checked_field("person[pizza_toppings][]", type: "checkbox", with: "Cheese")
+    expect(page).to have_checked_field("person[pizza_toppings][]", type: "checkbox", with: "Pepperoni")
+
+    expect(page).to have_unchecked_field("person[pizza_toppings][]", type: "checkbox", with: "Anchovies")
+    expect(page).to have_unchecked_field("person[pizza_toppings][]", type: "checkbox", with: "Olives")
+  end
+  # rubocop:enable RSpec/ExampleLength
+end

--- a/engine/spec/features/collection_radio_buttons_spec.rb
+++ b/engine/spec/features/collection_radio_buttons_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+RSpec.describe "collection radio buttons" do
+  before do
+    visit element_path("collection_radio_buttons")
+  end
+
+  it "renders a number of radio buttons" do
+    within "#default_collection_radio_buttons" do
+      expect(page).to have_unchecked_field("person[favourite_drink]", type: "radio", with: "0001")
+      expect(page).to have_unchecked_field("person[favourite_drink]", type: "radio", with: "0000")
+      expect(page).to have_unchecked_field("person[favourite_drink]", type: "radio", with: "8888")
+    end
+  end
+
+  it "uses an id for the first item that can be targetted by cads_error_summary" do
+    within "#default_collection_radio_buttons" do
+      expect(page).to have_field("person_favourite_drink-input")
+    end
+  end
+end

--- a/engine/spec/features/collection_select_spec.rb
+++ b/engine/spec/features/collection_select_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+RSpec.describe "collection radio buttons" do
+  before do
+    visit element_path("collection_select")
+  end
+
+  it "renders a number of radio buttons" do
+    within "#default_collection_select" do
+      expect(page).to have_select("Favourite ice cream",
+                                  options: ["Vanilla", "Chocolate", "Strawberry", "Pistachio", "Cookie dough", "Salted caramel"])
+    end
+  end
+end

--- a/engine/spec/features/date_input_spec.rb
+++ b/engine/spec/features/date_input_spec.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+RSpec.describe "date inputs" do
+  before do
+    visit element_path("date_inputs")
+  end
+
+  context "with the default date input" do
+    it "renders the 'day' input field" do
+      within "#default_date_input" do
+        expect(page).to have_css("label[for=person_date_of_birth-input]", text: "Day")
+        expect(page).to have_field("person[date_of_birth(3i)]")
+      end
+    end
+
+    it "renders the 'month' input field" do
+      within "#default_date_input" do
+        expect(page).to have_css("label[for=person_date_of_birth_2i]", text: "Month")
+        expect(page).to have_field("person[date_of_birth(2i)]")
+      end
+    end
+
+    it "renders the 'year' input field" do
+      within "#default_date_input" do
+        expect(page).to have_css("label[for=person_date_of_birth_1i]", text: "Year")
+        expect(page).to have_field("person[date_of_birth(1i)]")
+      end
+    end
+
+    it "indicates the fields are optional" do
+      within "#default_date_input" do
+        expect(page).to have_css(".cads-form-field__optional", text: "(optional)")
+      end
+    end
+
+    it "doesn't include a hint" do
+      within "#default_date_input" do
+        expect(page).to have_no_css("p.cads-form-field__hint")
+      end
+    end
+  end
+
+  it "renders a hint" do
+    within "#date_input_with_hint" do
+      expect(page).to have_css("p.cads-form-field__hint", text: "Hint text")
+    end
+  end
+
+  # rubocop:disable RSpec/ExampleLength
+  it "stores and retrieves the day, month and year values in a Rails-compatible way" do
+    within "#default_date_input" do
+      fill_in "person[date_of_birth(3i)]", with: 13
+      fill_in "person[date_of_birth(2i)]", with: 12
+      fill_in "person[date_of_birth(1i)]", with: 2005
+    end
+
+    click_button
+
+    expect(page).to have_field("person[date_of_birth(3i)]", with: "13")
+    expect(page).to have_field("person[date_of_birth(2i)]", with: "12")
+    expect(page).to have_field("person[date_of_birth(1i)]", with: "2005")
+  end
+  # rubocop:enable RSpec/ExampleLength
+
+  context "with a required field" do
+    it "doesn't add the 'optional' label text" do
+      within "#required_date_input" do
+        expect(page).to have_no_css(".cads-form-field__optional")
+      end
+    end
+  end
+
+  context "with a validation error" do
+    # rubocop:disable RSpec/ExampleLength
+    it "renders the error message" do
+      within "#default_date_input" do
+        fill_in "person[date_of_birth(3i)]", with: 25
+        fill_in "person[date_of_birth(2i)]", with: 12
+        fill_in "person[date_of_birth(1i)]", with: 3000
+      end
+
+      click_button
+
+      within "#default_date_input" do
+        expect(page).to have_css("div.cads-form-field.cads-form-field--has-error")
+        expect(page).to have_css("div.cads-form-field__error-marker")
+        expect(page).to have_css("p.cads-form-field__error-message")
+
+        expect(page).to have_css("#person_date_of_birth-input.cads-input--error")
+        expect(page).to have_css("#person_date_of_birth_2i.cads-input--error")
+        expect(page).to have_css("#person_date_of_birth_1i.cads-input--error")
+      end
+    end
+    # rubocop:enable RSpec/ExampleLength
+  end
+end

--- a/engine/spec/features/error_summary_spec.rb
+++ b/engine/spec/features/error_summary_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+RSpec.describe "error summary" do
+  before do
+    visit element_path("error_summary")
+  end
+
+  it "doesn't show the error summary if there are no errors" do
+    expect(page).to have_no_css("div.cads-error-summary")
+  end
+
+  context "with validation errors" do
+    before { click_button }
+
+    it "shows errors within an error summary component" do
+      error_summaries = page.find_all(".cads-error-summary__list a")
+      error_hrefs = error_summaries.pluck("href")
+      error_messages = error_summaries.map(&:text)
+
+      expect(error_hrefs).to contain_exactly("#person_first_name-input", "#person_date_of_birth-input")
+      expect(error_messages).to contain_exactly("First name can't be blank", "Date of birth can't be blank")
+    end
+  end
+end

--- a/engine/spec/features/form_spec.rb
+++ b/engine/spec/features/form_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+RSpec.describe "example forms" do
+  # rubocop:disable RSpec/ExampleLength
+  it "renders the people form" do
+    visit example_forms_path
+
+    # Submit empty form
+    click_button "Save"
+
+    # "first_name" is required
+    expect(page).to have_css("p#person_first_name-error")
+
+    # Fill in form fields
+    fill_in "First name", with: "Francis"
+    fill_in "Last name", with: "Example"
+
+    # Submit form
+    click_button "Save"
+
+    expect(page).to have_field("person[first_name]", with: "Francis")
+    expect(page).to have_field("person[last_name]", with: "Example")
+
+    expect(page).to have_button("Save")
+  end
+  # rubocop:enable RSpec/ExampleLength
+end

--- a/engine/spec/features/text_area_spec.rb
+++ b/engine/spec/features/text_area_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+RSpec.describe "text areas" do
+  before do
+    visit element_path("text_areas")
+  end
+
+  it "renders a default text area, with 'name' and 'id' set correctly" do
+    within "#default_text_area" do
+      textarea = page.first("textarea")
+
+      expect(textarea["name"]).to eql "person[address]"
+      expect(textarea["id"]).to eql "person_address-input"
+    end
+  end
+
+  it "renders a text area with a custom number of rows" do
+    within "#custom_rows_text_area" do
+      expect(page).to have_css("textarea[rows=12]")
+    end
+  end
+end

--- a/engine/spec/features/text_input_spec.rb
+++ b/engine/spec/features/text_input_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+RSpec.describe "text inputs" do
+  before do
+    visit element_path("text_inputs")
+  end
+
+  it "renders a default text input, with 'id' and 'name' set correctly" do
+    within "#default_text_field" do
+      input = page.first("input")
+
+      expect(input["name"]).to eql "person[first_name]"
+      expect(input["id"]).to eql "person_first_name-input"
+    end
+  end
+
+  describe "width attributes" do
+    it "renders the associated width input" do
+      within "#text_field_with_width" do
+        expect(page).to have_css ".cads-input--four-chars"
+      end
+    end
+  end
+
+  describe "additional attributes" do
+    it "renders additional attributes passed to the field" do
+      within "#text_field_with_additional_attributes" do
+        expect(page).to have_css "input[data-example='custom-attribute']"
+      end
+    end
+  end
+end

--- a/engine/spec/lib/citizens_advice_components/elements/button_spec.rb
+++ b/engine/spec/lib/citizens_advice_components/elements/button_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+RSpec.describe CitizensAdviceComponents::Elements::Button do
+  include_context "with view component"
+
+  let(:component) { CitizensAdviceComponents::Button }
+  let(:model) { nil } # Buttons don't use model
+
+  describe "#render" do
+    it "calls the button component with default parameters" do
+      builder.cads_button
+
+      expect(component).to have_received(:new).with(type: :submit, variant: :primary)
+      expect(component_double).to have_received(:with_content).with("Save changes")
+    end
+
+    it "calls the button component with a custom label text" do
+      builder.cads_button "Next"
+
+      expect(component_double).to have_received(:with_content).with("Next")
+    end
+  end
+end

--- a/engine/spec/lib/citizens_advice_components/elements/collections/select_spec.rb
+++ b/engine/spec/lib/citizens_advice_components/elements/collections/select_spec.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+class ExampleForm
+  include ActiveModel::Model
+
+  attr_accessor :ice_cream
+end
+
+RSpec.describe CitizensAdviceComponents::Elements::Collections::Select do
+  include_context "with view component"
+
+  let(:component) { CitizensAdviceComponents::Select }
+  let(:component_double) { instance_double(component, render_in: nil) }
+  let(:model) { ExampleForm.new(ice_cream: "0002") }
+
+  describe "#render" do
+    let(:ice_cream) { Struct.new(:reference, :colour, :name) }
+
+    let(:collection) do
+      [
+        ice_cream.new("0001", "Blue", "Bubble gum"),
+        ice_cream.new("0002", "Green", "Pistachio"),
+        ice_cream.new("0003", "Pink", "Strawberry")
+      ]
+    end
+
+    it "passes the attribute name to the radio group component" do
+      builder.cads_collection_select(:ice_cream, collection: collection, text_method: :name, value_method: :reference)
+
+      expect(component).to have_received(:new).with(hash_including(name: "example_form_ice_cream"))
+    end
+
+    it "passes the collection, reformatted with 'label', 'value' and 'checked' keys to the radio group component" do
+      builder.cads_collection_select(:ice_cream, collection: collection, text_method: :name, value_method: :reference)
+
+      expect(component).to have_received(:new).with(hash_including(select_options: [["Bubble gum", "0001"], ["Pistachio", "0002"],
+                                                                                    ["Strawberry", "0003"]]))
+    end
+
+    it "sets 'optional' to 'true' by default" do
+      builder.cads_collection_select(:ice_cream, collection: collection, text_method: :name, value_method: :reference)
+
+      expect(component).to have_received(:new).with(hash_including(options: hash_including(optional: true)))
+    end
+
+    context "with 'required' parameter" do
+      it "sets 'optional' to 'false' when true" do
+        builder.cads_collection_select(
+          :ice_cream,
+          collection: collection,
+          text_method: :name,
+          value_method: :reference,
+          required: true
+        )
+
+        expect(component).to have_received(:new).with(hash_including(options: hash_including(optional: false)))
+      end
+
+      it "sets 'optional' to 'true' when false" do
+        builder.cads_collection_select(
+          :ice_cream,
+          collection: collection,
+          text_method: :name,
+          value_method: :reference,
+          required: false
+        )
+
+        expect(component).to have_received(:new).with(hash_including(options: hash_including(optional: true)))
+      end
+    end
+
+    context "with 'hint' parameter" do
+      it "passes hint to the text input component" do
+        builder.cads_collection_select(
+          :ice_cream,
+          collection: collection,
+          text_method: :name,
+          value_method: :reference,
+          hint: "Example hint"
+        )
+
+        expect(component).to have_received(:new).with(hash_including(options: hash_including(hint: "Example hint")))
+      end
+    end
+
+    context "when there is a validation error" do
+      it "sets 'error_message'" do
+        model.errors.add(:ice_cream, :example, message: "has an example error")
+
+        builder.cads_collection_select(:ice_cream, collection: collection, text_method: :name, value_method: :reference)
+
+        expect(component).to have_received(:new).with(
+          hash_including(options: hash_including(error_message: "Ice cream has an example error"))
+        )
+      end
+    end
+  end
+end

--- a/engine/spec/lib/citizens_advice_components/elements/text_area_spec.rb
+++ b/engine/spec/lib/citizens_advice_components/elements/text_area_spec.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+class ExampleForm
+  include ActiveModel::Model
+
+  attr_accessor :address
+end
+
+RSpec.describe CitizensAdviceComponents::Elements::TextArea do
+  include_context "with view component"
+
+  let(:component) { CitizensAdviceComponents::Textarea }
+  let(:model) { ExampleForm.new(address: "example address") }
+
+  describe "#render" do
+    it "passes the attribute name to the component" do
+      builder.cads_text_area(:address)
+
+      expect(component).to have_received(:new).with(hash_including(name: "example_form[address]"))
+    end
+
+    it "passes the existing value to the component" do
+      builder.cads_text_area(:address)
+
+      expect(component).to have_received(:new).with(hash_including(options: hash_including(value: "example address")))
+    end
+
+    it "sets 'optional' to 'true' by default" do
+      builder.cads_text_area(:address)
+
+      expect(component).to have_received(:new).with(hash_including(options: hash_including(optional: true)))
+    end
+
+    context "with 'required' parameter" do
+      it "sets 'optional' to 'false' when true" do
+        builder.cads_text_area(:address, required: true)
+
+        expect(component).to have_received(:new).with(hash_including(options: hash_including(optional: false)))
+      end
+
+      it "sets 'optional' to 'true' when false" do
+        builder.cads_text_area(:address, required: false)
+
+        expect(component).to have_received(:new).with(hash_including(options: hash_including(optional: true)))
+      end
+    end
+
+    context "with 'hint' parameter" do
+      it "passes hint to the component" do
+        builder.cads_text_area(:address, hint: "Example hint")
+
+        expect(component).to have_received(:new).with(hash_including(options: hash_including(hint: "Example hint")))
+      end
+    end
+
+    context "with 'rows' parameter" do
+      it "passes rows to the component" do
+        builder.cads_text_area(:address, rows: 4)
+
+        expect(component).to have_received(:new).with(hash_including(rows: 4))
+      end
+    end
+
+    context "when there is a validation error" do
+      it "sets 'error_message'" do
+        model.errors.add(:address, :presence, message: "is required")
+
+        builder.cads_text_area(:address)
+
+        expect(component).to have_received(:new).with(hash_including(options: hash_including(error_message: "Address is required")))
+      end
+    end
+  end
+end

--- a/engine/spec/lib/citizens_advice_components/elements/text_input_spec.rb
+++ b/engine/spec/lib/citizens_advice_components/elements/text_input_spec.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+class ExampleForm
+  include ActiveModel::Model
+
+  attr_accessor :name, :required_field
+
+  validates :required_field, presence: true
+end
+
+RSpec.describe CitizensAdviceComponents::Elements::TextInput do
+  include_context "with view component"
+
+  let(:component) { CitizensAdviceComponents::TextInput }
+  let(:model) { ExampleForm.new(name: "Fred Flintstone") }
+
+  describe "#render" do
+    it "passes the attribute name to the text input component" do
+      builder.cads_text_field(:name)
+
+      expect(component).to have_received(:new).with(hash_including(name: "example_form[name]"))
+    end
+
+    it "passes the attribute's existing value to the text input component" do
+      builder.cads_text_field(:name)
+
+      expect(component).to have_received(:new).with(hash_including(options: hash_including(value: "Fred Flintstone")))
+    end
+
+    it "passes custom label text to the text input component" do
+      builder.cads_text_field(:name, label: "First name")
+
+      expect(component).to have_received(:new).with(hash_including(label: "First name"))
+    end
+
+    it "passes additional attributes to the text input component" do
+      builder.cads_text_field(:name, additional_attributes: { "data-example": "custom-attribute" })
+
+      expect(component).to have_received(:new).with(
+        hash_including(options: hash_including(additional_attributes: { "data-example": "custom-attribute" }))
+      )
+    end
+
+    it "sets 'optional' to 'true' by default" do
+      builder.cads_text_field(:name)
+
+      expect(component).to have_received(:new).with(hash_including(options: hash_including(optional: true)))
+    end
+
+    context "with 'required' parameter" do
+      it "sets 'optional' to 'false' when true" do
+        builder.cads_text_field(:name, required: true)
+
+        expect(component).to have_received(:new).with(hash_including(options: hash_including(optional: false)))
+      end
+
+      it "sets 'optional' to 'true' when false" do
+        builder.cads_text_field(:name, required: false)
+
+        expect(component).to have_received(:new).with(hash_including(options: hash_including(optional: true)))
+      end
+    end
+
+    context "with 'hint' parameter" do
+      it "passes hint to the text input component" do
+        builder.cads_text_field(:name, hint: "Example hint")
+
+        expect(component).to have_received(:new).with(hash_including(options: hash_including(hint: "Example hint")))
+      end
+    end
+
+    context "when there is a validation error" do
+      it "sets 'error_message'" do
+        model.errors.add(:name, :example, message: "has an example error")
+
+        builder.cads_text_field(:name)
+
+        expect(component).to have_received(:new).with(hash_including(options: hash_including(error_message: "Name has an example error")))
+      end
+    end
+  end
+end

--- a/engine/spec/spec_helper.rb
+++ b/engine/spec/spec_helper.rb
@@ -10,6 +10,8 @@ require "capybara/rspec"
 require "rspec/rails"
 require "view_component/test_helpers"
 
+Dir[File.join("./spec", "support", "**", "*.rb")].each { |file| require file }
+
 module TestHelpers
   # For components using fetch_or_fallback,
   # we want to ensure that the correct

--- a/engine/spec/support/with_view_component.rb
+++ b/engine/spec/support/with_view_component.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+RSpec.shared_context "with view component" do
+  let(:controller) { ActionController::Base.new }
+  let(:lookup_context) { ActionView::LookupContext.new(nil) }
+  let(:template) { ActionView::Base.new(lookup_context, {}, controller) }
+  let(:builder) { CitizensAdviceComponents::FormBuilder.new(:form, model, template, {}) }
+  let(:component_double) { instance_double(component, with_content: nil, render_in: nil) }
+
+  before { allow(component).to receive(:new).and_return(component_double) }
+end

--- a/engine/spec/test_app/app/controllers/application_controller.rb
+++ b/engine/spec/test_app/app/controllers/application_controller.rb
@@ -1,3 +1,5 @@
 # frozen_string_literal: true
 
-class ApplicationController < ActionController::Base; end
+class ApplicationController < ActionController::Base
+  default_form_builder CitizensAdviceComponents::FormBuilder
+end

--- a/engine/spec/test_app/app/controllers/elements_controller.rb
+++ b/engine/spec/test_app/app/controllers/elements_controller.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+class ElementsController < ApplicationController
+  def index
+    @person = Person.new
+
+    render params[:element]
+  end
+
+  def create
+    @person = Person.new(person_params)
+    @person.valid?
+
+    render params[:element]
+  end
+
+  private
+
+  def person_params
+    params.require(:person).permit!
+  end
+end

--- a/engine/spec/test_app/app/controllers/example_forms_controller.rb
+++ b/engine/spec/test_app/app/controllers/example_forms_controller.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class ExampleFormsController < ApplicationController
+  def index
+    @person = Person.new
+  end
+
+  def create
+    @person = Person.new(person_params)
+    @person.valid?
+
+    render :index
+  end
+
+  private
+
+  def person_params
+    params.require(:person).permit(:first_name, :last_name)
+  end
+end

--- a/engine/spec/test_app/app/models/person.rb
+++ b/engine/spec/test_app/app/models/person.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require "active_record/attribute_assignment"
+
+class Person
+  include ActiveModel::Model
+  include ActiveModel::Attributes
+  include ActiveRecord::AttributeAssignment
+
+  attr_accessor :first_name, :last_name, :address, :date_with_hint, :required_date, :favourite_drink, :pizza_toppings, :ice_cream
+
+  attribute :date_of_birth, :date
+  attribute :pizza_toppings, array: true
+  attribute :opted_in, :boolean
+  attribute :account_active, :boolean, default: true
+
+  validates :first_name, presence: true
+
+  # Rails 7.1 provides a comparisson validator, but as we support Rails 6.1 use a simpler method as a check
+  # validates :date_of_birth, comparison: { less_than: Time.zone.today }
+  validates :date_of_birth, presence: true
+  validate :date_must_be_in_the_past
+
+  private
+
+  def date_must_be_in_the_past
+    errors.add(:date_of_birth, "can't be in the future!") if date_of_birth&.future?
+  end
+end

--- a/engine/spec/test_app/app/views/elements/buttons.html.erb
+++ b/engine/spec/test_app/app/views/elements/buttons.html.erb
@@ -1,0 +1,21 @@
+<%= form_with do |f| %>
+  <div id="default_button">
+    <%= f.cads_button "Default" %>
+  </div>
+
+  <div id="secondary_button">
+    <%= f.cads_button "Secondary", variant: :secondary %>
+  </div>
+
+  <div id="button_type">
+    <%= f.cads_button "Button", type: :button %>
+  </div>
+
+  <div id="icon_left">
+    <%= f.cads_button "Button", icon_left: :arrow_left %>
+  </div>
+
+  <div id="icon_right">
+    <%= f.cads_button "Icon Right", icon_right: :arrow_right %>
+  </div>
+<% end %>

--- a/engine/spec/test_app/app/views/elements/check_box.html.erb
+++ b/engine/spec/test_app/app/views/elements/check_box.html.erb
@@ -1,0 +1,9 @@
+<%= form_with model: @person, url: request.path do |f| %>
+  <div id="default_check_box">
+    <%= f.cads_check_box :opted_in, label: "Opted in" %>
+  </div>
+
+  <div id="checked_check_box">
+    <%= f.cads_check_box :account_active, label: "Account active" %>
+  </div>
+<% end %>

--- a/engine/spec/test_app/app/views/elements/collection_check_boxes.erb
+++ b/engine/spec/test_app/app/views/elements/collection_check_boxes.erb
@@ -1,0 +1,7 @@
+<%= form_with model: @person, url: request.path do |f| %>
+  <div id="default_collection_check_boxes">
+    <%= f.cads_collection_check_boxes :pizza_toppings, collection: ["Anchovies", "Cheese", "Pepperoni", "Olives"], text_method: :itself %>
+  </div>
+
+  <%= f.cads_button %>
+<% end %>

--- a/engine/spec/test_app/app/views/elements/collection_radio_buttons.erb
+++ b/engine/spec/test_app/app/views/elements/collection_radio_buttons.erb
@@ -1,0 +1,5 @@
+<%= form_with model: @person, url: request.path do |f| %>
+  <div id="default_collection_radio_buttons">
+    <%= f.cads_collection_radio_buttons :favourite_drink, label: "Favourite drink", collection: [["Tea", "0001"], ["Water", "0000"], ["Grog", "8888"]], text_method: :first, value_method: :last %>
+  </div>
+<% end %>

--- a/engine/spec/test_app/app/views/elements/collection_select.erb
+++ b/engine/spec/test_app/app/views/elements/collection_select.erb
@@ -1,0 +1,5 @@
+<%= form_with model: @person, url: request.path do |f| %>
+  <div id="default_collection_select">
+    <%= f.cads_collection_select :ice_cream, label: "Favourite ice cream", collection: [["Vanilla", "0000"], ["Chocolate", "0001"], ["Strawberry", "0002"], ["Pistachio", "0003"], ["Cookie dough", "0004"], ["Salted caramel", "0005"]], text_method: :first, value_method: :last %>
+  </div>
+<% end %>

--- a/engine/spec/test_app/app/views/elements/date_inputs.html.erb
+++ b/engine/spec/test_app/app/views/elements/date_inputs.html.erb
@@ -1,0 +1,15 @@
+<%= form_with model: @person, url: request.path do |f| %>
+  <div id="default_date_input">
+    <%= f.cads_date_field :date_of_birth %>
+  </div>
+
+  <div id="date_input_with_hint">
+    <%= f.cads_date_field :date_with_hint, hint: "Hint text" %>
+  </div>
+
+  <div id="required_date_input">
+    <%= f.cads_date_field :required_date, required: true %>
+  </div>
+
+  <%= f.submit %>
+<% end %>

--- a/engine/spec/test_app/app/views/elements/error_summary.html.erb
+++ b/engine/spec/test_app/app/views/elements/error_summary.html.erb
@@ -1,0 +1,8 @@
+<%= form_with model: @person, url: request.path do |f| %>
+  <%= f.cads_error_summary %>
+
+  <%= f.cads_text_field :first_name, required: true %>
+  <%= f.cads_date_field :date_of_birth, required: true %>
+
+  <%= f.submit %>
+<% end %>

--- a/engine/spec/test_app/app/views/elements/text_areas.html.erb
+++ b/engine/spec/test_app/app/views/elements/text_areas.html.erb
@@ -1,0 +1,9 @@
+<%= form_with model: @person, url: request.path do |f| %>
+  <div id="default_text_area">
+    <%= f.cads_text_area :address %>
+  </div>
+
+  <div id="custom_rows_text_area">
+    <%= f.cads_text_area :address, rows: 12 %>
+  </div>
+<% end %>

--- a/engine/spec/test_app/app/views/elements/text_inputs.html.erb
+++ b/engine/spec/test_app/app/views/elements/text_inputs.html.erb
@@ -1,0 +1,13 @@
+<%= form_with model: @person, url: request.path do |f| %>
+  <div id="default_text_field">
+    <%= f.cads_text_field :first_name %>
+  </div>
+
+  <div id="text_field_with_width">
+    <%= f.cads_text_field :first_name, width: :four_chars %>
+  </div>
+
+  <div id="text_field_with_additional_attributes">
+    <%= f.cads_text_field :first_name, additional_attributes: { "data-example": "custom-attribute" } %>
+  </div>
+<% end %>

--- a/engine/spec/test_app/app/views/example_forms/index.html.erb
+++ b/engine/spec/test_app/app/views/example_forms/index.html.erb
@@ -1,0 +1,9 @@
+<h1>Example form</h1>
+
+<%= form_with model: @person, url: example_forms_path, method: :post do |f| %>
+  <%= f.cads_error_summary %>
+
+  <%= f.cads_text_field :first_name %>
+  <%= f.cads_text_field :last_name %>
+  <%= f.cads_button "Save" %>
+<% end %>

--- a/engine/spec/test_app/config/routes.rb
+++ b/engine/spec/test_app/config/routes.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+Rails.application.routes.draw do
+  resources :example_forms, only: %i[index create]
+
+  get "/elements/:element", to: "elements#index", as: :element
+  post "/elements/:element", to: "elements#create"
+end


### PR DESCRIPTION
This is an experiment to migrated the https://github.com/citizensadvice/rails-form-builder code into the main design system code base. Given we're now using this code in production at scale and the design system engine both contains the source components and is intended to house any related Rails code it makes sense to try merging these two together.

This is mostly a lift-and-shift of the existing code with the addition of some auto-loading simplifications thanks to embedding this code in an engine (the current library is a plain ruby gem).

Otherwise I've updated the demo app example form to use the form builder with relatively minimal changes.

Consider this a draft PR to get early review, to do this for real we'd want to write and agree an ADR for this as well as writing a companion guide to https://citizens-advice-design-system.netlify.app/guides/using-with-rails/ to cover using the form builder in your application.