### PR TITLE
Setup improvements

### DIFF
--- a/demo/Gemfile.lock
+++ b/demo/Gemfile.lock
@@ -163,6 +163,8 @@ GEM
     nokogiri (1.18.3)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
+    nokogiri (1.18.3-arm64-darwin)
+      racc (~> 1.4)
     parallel (1.24.0)
     parser (3.3.0.5)
       ast (~> 2.4.1)
@@ -292,7 +294,14 @@ GEM
     zeitwerk (2.7.2)
 
 PLATFORMS
+  aarch64-linux
+  arm-linux
+  arm64-darwin
+  arm64-darwin-24
   ruby
+  x86-linux
+  x86_64-darwin
+  x86_64-linux
 
 DEPENDENCIES
   byebug

--- a/demo/package-lock.json
+++ b/demo/package-lock.json
@@ -25,7 +25,7 @@
     },
     "..": {
       "name": "@citizensadvice/design-system",
-      "version": "6.4.1",
+      "version": "6.4.2",
       "dev": true,
       "license": "Apache-2.0",
       "devDependencies": {

--- a/design-system-docs/Gemfile.lock
+++ b/design-system-docs/Gemfile.lock
@@ -112,8 +112,13 @@ GEM
       faraday (>= 1, < 3)
     faraday-net_http (3.4.0)
       net-http (>= 0.5.0)
-    ffi (1.17.0)
-    ffi (1.17.0-x86_64-darwin)
+    ffi (1.17.1)
+    ffi (1.17.1-aarch64-linux-gnu)
+    ffi (1.17.1-arm-linux-gnu)
+    ffi (1.17.1-arm64-darwin)
+    ffi (1.17.1-x86-linux-gnu)
+    ffi (1.17.1-x86_64-darwin)
+    ffi (1.17.1-x86_64-linux-gnu)
     hash_with_dot_access (1.2.0)
       activesupport (>= 5.0.0, < 8.0)
     htmlbeautifier (1.4.3)
@@ -146,7 +151,15 @@ GEM
     nokogiri (1.18.3)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
+    nokogiri (1.18.3-aarch64-linux-gnu)
+      racc (~> 1.4)
+    nokogiri (1.18.3-arm-linux-gnu)
+      racc (~> 1.4)
+    nokogiri (1.18.3-arm64-darwin)
+      racc (~> 1.4)
     nokogiri (1.18.3-x86_64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.18.3-x86_64-linux-gnu)
       racc (~> 1.4)
     parallel (1.26.3)
     parser (3.3.6.0)
@@ -249,8 +262,14 @@ GEM
     zeitwerk (2.7.1)
 
 PLATFORMS
+  aarch64-linux
+  arm-linux
+  arm64-darwin
+  arm64-darwin-24
   ruby
-  x86_64-darwin-20
+  x86-linux
+  x86_64-darwin
+  x86_64-linux
 
 DEPENDENCIES
   bridgetown (~> 1.3)

--- a/design-system-docs/package-lock.json
+++ b/design-system-docs/package-lock.json
@@ -30,7 +30,7 @@
     },
     "..": {
       "name": "@citizensadvice/design-system",
-      "version": "6.4.1",
+      "version": "6.4.2",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/preset-env": "^7.22.20",

--- a/engine/Gemfile.lock
+++ b/engine/Gemfile.lock
@@ -120,6 +120,8 @@ GEM
     nokogiri (1.18.3)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
+    nokogiri (1.18.3-arm64-darwin)
+      racc (~> 1.4)
     parallel (1.26.3)
     parser (3.3.7.0)
       ast (~> 2.4.1)
@@ -238,7 +240,14 @@ GEM
     zeitwerk (2.7.2)
 
 PLATFORMS
+  aarch64-linux
+  arm-linux
+  arm64-darwin
+  arm64-darwin-24
   ruby
+  x86-linux
+  x86_64-darwin
+  x86_64-linux
 
 DEPENDENCIES
   actionpack (~> 8.0.0)

--- a/setup
+++ b/setup
@@ -11,7 +11,7 @@ cd "$(dirname "$0")"
 
 function setup_npm_package() {
   echo_task "Installing and setting up the npm package"
-  npm ci
+  npm install
   npm run build
 }
 
@@ -26,7 +26,7 @@ function setup_demo_app() {
   echo_task "Setting up the demo app"
   pushd demo
   bundle install
-  npm ci
+  npm install
   bin/rails log:clear tmp:clear
   bin/rails restart
   popd
@@ -36,7 +36,7 @@ function setup_docs_website() {
   echo_task "Setting up the documentation website"
   pushd design-system-docs
   bundle install
-  npm ci
+  npm install
   popd
 }
 


### PR DESCRIPTION
- Ensure that we're consistently able to install the native gem version of nokogiri across platforms
- Run npm install in the setup script rather than npm ci as this is a development script and we want it to apply any updates to lockfiles e.g. when updating the package.json version