### PR TITLE
Release/v7.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v7.0.0
+
+### 25 March 2025
+
 **New**
 
 - Remove support for end-of-life Ruby 3.0.x versions

--- a/demo/Gemfile.lock
+++ b/demo/Gemfile.lock
@@ -12,7 +12,7 @@ GIT
 PATH
   remote: ../engine
   specs:
-    citizens_advice_components (6.4.2)
+    citizens_advice_components (7.0.0)
       actionpack (>= 7.1.0, < 9.0)
       actionview (>= 7.1.0, < 9.0)
       activemodel (>= 7.1.0, < 9.0)

--- a/demo/package-lock.json
+++ b/demo/package-lock.json
@@ -25,7 +25,7 @@
     },
     "..": {
       "name": "@citizensadvice/design-system",
-      "version": "6.4.2",
+      "version": "7.0.0",
       "dev": true,
       "license": "Apache-2.0",
       "devDependencies": {

--- a/design-system-docs/Gemfile.lock
+++ b/design-system-docs/Gemfile.lock
@@ -12,7 +12,7 @@ GIT
 PATH
   remote: ../engine
   specs:
-    citizens_advice_components (6.4.2)
+    citizens_advice_components (7.0.0)
       actionpack (>= 7.1.0, < 9.0)
       actionview (>= 7.1.0, < 9.0)
       activemodel (>= 7.1.0, < 9.0)

--- a/design-system-docs/package-lock.json
+++ b/design-system-docs/package-lock.json
@@ -30,7 +30,7 @@
     },
     "..": {
       "name": "@citizensadvice/design-system",
-      "version": "6.4.2",
+      "version": "7.0.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/preset-env": "^7.22.20",

--- a/engine/Gemfile.lock
+++ b/engine/Gemfile.lock
@@ -12,7 +12,7 @@ GIT
 PATH
   remote: .
   specs:
-    citizens_advice_components (6.4.2)
+    citizens_advice_components (7.0.0)
       actionpack (>= 7.1.0, < 9.0)
       actionview (>= 7.1.0, < 9.0)
       activemodel (>= 7.1.0, < 9.0)

--- a/engine/lib/citizens_advice_components/version.rb
+++ b/engine/lib/citizens_advice_components/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module CitizensAdviceComponents
-  VERSION = "6.4.2"
+  VERSION = "7.0.0"
 end

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@citizensadvice/design-system",
-  "version": "6.4.2",
+  "version": "7.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@citizensadvice/design-system",
-      "version": "6.4.2",
+      "version": "7.0.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/preset-env": "^7.22.20",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@citizensadvice/design-system",
-  "version": "6.4.2",
+  "version": "7.0.0",
   "description": "Citizens Advice Design System",
   "repository": "https://github.com/citizensadvice/design-system",
   "author": "Citizens Advice",


### PR DESCRIPTION
Calling this a major version release as the Ruby and Rails version changes are technically breaking and whilst the new form builder can co-exist with the existing library and we won't archive that until all projects are moved across together they feel like enough of a trigger for a major version bump.