### PR TITLE
Update deprecator horizon

### DIFF
--- a/engine/lib/citizens_advice_components.rb
+++ b/engine/lib/citizens_advice_components.rb
@@ -6,6 +6,6 @@ require "citizens_advice_components/version"
 module CitizensAdviceComponents
   def self.deprecator
     # https://api.rubyonrails.org/classes/ActiveSupport/Deprecation.html
-    @deprecator ||= ActiveSupport::Deprecation.new("7.0", "CitizensAdviceComponents")
+    @deprecator ||= ActiveSupport::Deprecation.new("8.0", "CitizensAdviceComponents")
   end
 end

--- a/engine/lib/citizens_advice_components/engine.rb
+++ b/engine/lib/citizens_advice_components/engine.rb
@@ -13,13 +13,10 @@ module CitizensAdviceComponents
     ]
 
     # Ensure that application level configuration settings apply to
-    # library specific deprecation warnings. Introduced in Rails 7.1
+    # library specific deprecation warnings.
     # https://api.rubyonrails.org/classes/ActiveSupport/Deprecation.html
-    # https://guides.rubyonrails.org/7_1_release_notes.html#add-rails-application-deprecators
-    if Rails.version.to_f >= 7.1
-      initializer "citizens_advice_components.deprecator" do |app|
-        app.deprecators[:citizens_advice_components] = CitizensAdviceComponents.deprecator
-      end
+    initializer "citizens_advice_components.deprecator" do |app|
+      app.deprecators[:citizens_advice_components] = CitizensAdviceComponents.deprecator
     end
   end
 end


### PR DESCRIPTION
Increase version to 8.0 now that we've released 7.0.0. Also remove a Rails version check as the minimum Rails versions supported is 7.1.0.