### PR TITLE
Allow formatting lib directory

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -5,7 +5,6 @@ vendor/
 assets/
 CHANGELOG.md
 docs/
-lib/
 
 # Ignore Rails demo app files
 /demo/public/

--- a/lib/greedy-nav/GreedyNav.js
+++ b/lib/greedy-nav/GreedyNav.js
@@ -1,4 +1,4 @@
-import { initNavigation  } from '../navigation';
+import { initNavigation } from '../navigation';
 
 // Delegate to new navigation script for backwards compatibility
 const GreedyNav = {

--- a/lib/navigation/navigation.js
+++ b/lib/navigation/navigation.js
@@ -41,8 +41,7 @@ function getMainNavEl(containerEl) {
 }
 
 function extractDataAttributes(containerEl) {
-  const getData = (name) =>
-    containerEl.getAttribute(`data-dropdown-${name}`);
+  const getData = (name) => containerEl.getAttribute(`data-dropdown-${name}`);
 
   return {
     label: getData('label') || 'More',
@@ -305,9 +304,7 @@ function addEscapeKeyHandler(containerEl) {
 }
 
 export default function initNavigation() {
-  const containerEl = document.querySelector(
-    '.js-cads-greedy-nav',
-  );
+  const containerEl = document.querySelector('.js-cads-greedy-nav');
 
   if (containerEl) {
     prepareHtml(containerEl);


### PR DESCRIPTION
Since we removed the build step from our javascript modules we now include the lib directory directly in our source. This directory was still being excluded from prettier formatting, this commit fixes that.