### PR TITLE
Add character count component

### DIFF
--- a/demo/app/assets/javascript/application.js
+++ b/demo/app/assets/javascript/application.js
@@ -5,6 +5,7 @@ import {
   initOnThisPage,
   initDisclosure,
   initErrorSummary,
+  initCharacterCount
 } from '@citizensadvice/design-system';
 
 initHeader();
@@ -13,3 +14,4 @@ initTargetedContent();
 initOnThisPage();
 initDisclosure();
 initErrorSummary();
+initCharacterCount();

--- a/demo/cypress/e2e/character-count.cy.js
+++ b/demo/cypress/e2e/character-count.cy.js
@@ -1,33 +1,68 @@
 describe('Character count', () => {
-  it('has a character counter', () => {
-    cy.visitComponentUrl('textarea/with_character_count');
-    cy.findByTestId('character-count').should(
-      'have.text',
-      'You have 1000 characters remaining',
-    );
-  });
-
-  it('counts characters as the user types', () => {
-    cy.visitComponentUrl('textarea/with_character_count');
-    cy.findByLabelText('Example input').type('Some initial text.');
-
-    cy.findByTestId('character-count').should(
-      'have.text',
-      'You have 982 characters remaining',
-    );
-  });
-
-  it('displays the amount over if exceeding the limit', () => {
-    cy.visitComponentUrl('textarea/with_character_count');
-
-    cy.findByLabelText('Example input').type(tooMuchText().trim(), {
-      delay: 0,
+  describe('english language', () => {
+    it('has a character counter', () => {
+      cy.visitComponentUrl('textarea/with_character_count');
+      cy.findByTestId('character-count').should(
+        'have.text',
+        'You have 1000 characters remaining',
+      );
     });
 
-    cy.findByTestId('character-count').should(
-      'have.text',
-      'You have 412 characters too many',
-    );
+    it('counts characters as the user types', () => {
+      cy.visitComponentUrl('textarea/with_character_count');
+      cy.findByLabelText('Example input').type('Some initial text.');
+
+      cy.findByTestId('character-count').should(
+        'have.text',
+        'You have 982 characters remaining',
+      );
+    });
+
+    it('displays the amount over if exceeding the limit', () => {
+      cy.visitComponentUrl('textarea/with_character_count');
+
+      cy.findByLabelText('Example input').type(tooMuchText().trim(), {
+        delay: 0,
+      });
+
+      cy.findByTestId('character-count').should(
+        'have.text',
+        'You have 412 characters too many',
+      );
+    });
+  });
+
+  describe('welsh language', () => {
+    it('has a character counter', () => {
+      cy.visitComponentUrl('textarea/with_character_count?locale=cy');
+      cy.findByTestId('character-count').should(
+        'have.text',
+        'You have 1000 characters remaining (cy)',
+      );
+    });
+
+    it('counts characters as the user types', () => {
+      cy.visitComponentUrl('textarea/with_character_count?locale=cy');
+      cy.findByLabelText('Example input').type('Some initial text.');
+
+      cy.findByTestId('character-count').should(
+        'have.text',
+        'You have 982 characters remaining (cy)',
+      );
+    });
+
+    it('displays the amount over if exceeding the limit', () => {
+      cy.visitComponentUrl('textarea/with_character_count?locale=cy');
+
+      cy.findByLabelText('Example input').type(tooMuchText().trim(), {
+        delay: 0,
+      });
+
+      cy.findByTestId('character-count').should(
+        'have.text',
+        'You have 412 characters too many (cy)',
+      );
+    });
   });
 
   function tooMuchText() {

--- a/demo/cypress/e2e/character-count.cy.js
+++ b/demo/cypress/e2e/character-count.cy.js
@@ -1,0 +1,53 @@
+describe('Character count', () => {
+  it('has a character counter', () => {
+    cy.visitComponentUrl('textarea/with_character_count');
+    cy.findByTestId('character-count').should(
+      'have.text',
+      'You have 1000 characters remaining',
+    );
+  });
+
+  it('counts characters as the user types', () => {
+    cy.visitComponentUrl('textarea/with_character_count');
+    cy.findByLabelText('Example input').type('Some initial text.');
+
+    cy.findByTestId('character-count').should(
+      'have.text',
+      'You have 982 characters remaining',
+    );
+  });
+
+  it('displays the amount over if exceeding the limit', () => {
+    cy.visitComponentUrl('textarea/with_character_count');
+
+    cy.findByLabelText('Example input').type(tooMuchText().trim(), {
+      delay: 0,
+    });
+
+    cy.findByTestId('character-count').should(
+      'have.text',
+      'You have 412 characters too many',
+    );
+  });
+
+  function tooMuchText() {
+    return `Alice was beginning to get very tired of sitting by her sister on the bank,
+      and of having nothing to do: once or twice she had peeped into the book her sister was reading,
+      but it had no pictures or conversations in it, “and what is the use of a book,” thought Alice
+      “without pictures or conversations?”
+
+      So she was considering in her own mind (as well as she could, for the hot day made her feel very
+      sleepy and stupid), whether the pleasure of making a daisy-chain would be worth the trouble of
+      getting up and picking the daisies, when suddenly a White Rabbit with pink eyes ran close by her.
+
+      There was nothing so very remarkable in that; nor did Alice think it so very much out of the way
+      to hear the Rabbit say to itself, “Oh dear! Oh dear! I shall be late!” (when she thought it over
+      afterwards, it occurred to her that she ought to have wondered at this, but at the time it all
+      seemed quite natural); but when the Rabbit actually took a watch out of its waistcoat-pocket,
+      and looked at it, and then hurried on, Alice started to her feet, for it flashed across her mind
+      that she had never before seen a rabbit with either a waistcoat-pocket, or a watch to take out of it,
+      and burning with curiosity, she ran across the field after it, and fortunately was just in time to see
+      it pop down a large rabbit-hole under the hedge.
+    `;
+  }
+});

--- a/demo/spec/components/previews/textarea_preview.rb
+++ b/demo/spec/components/previews/textarea_preview.rb
@@ -41,6 +41,19 @@ class TextareaPreview < ViewComponent::Preview
     )
   end
 
+  def with_character_count
+    render(
+      CitizensAdviceComponents::Textarea.new(
+        name: "example-input-character-count",
+        label: "Example input",
+        type: :text,
+        options: {
+          character_count: 1000
+        }
+      )
+    )
+  end
+
   def error
     render(
       CitizensAdviceComponents::Textarea.new(

--- a/design-system-docs/frontend/javascript/standalone.js
+++ b/design-system-docs/frontend/javascript/standalone.js
@@ -13,6 +13,7 @@ import {
   initTargetedContent,
   initDisclosure,
   initOnThisPage,
+  initCharacterCount,
 } from '@citizensadvice/design-system';
 
 try {
@@ -21,6 +22,7 @@ try {
   initTargetedContent();
   initDisclosure();
   initOnThisPage();
+  initCharacterCount();
 } catch (error) {
   document.querySelector('html').classList.add('no-js');
   throw error;

--- a/design-system-docs/frontend/javascript/theme.js
+++ b/design-system-docs/frontend/javascript/theme.js
@@ -10,6 +10,7 @@ import {
   initTargetedContent,
   initDisclosure,
   initOnThisPage,
+  initCharacterCount,
 } from '@citizensadvice/design-system';
 
 import initCodeCopy from './components/code-copy';
@@ -22,6 +23,7 @@ try {
   initTargetedContent();
   initDisclosure();
   initOnThisPage();
+  initCharacterCount();
   initCodeCopy();
   initSampleCode();
   initComponentExamples();

--- a/design-system-docs/src/_component_docs/textarea.md
+++ b/design-system-docs/src/_component_docs/textarea.md
@@ -12,10 +12,6 @@ title: Textarea
 
 <%= render(Shared::ComponentExample.new(:textarea, :optional)) %>
 
-### Page heading
-
-<%= render(Shared::ComponentExample.new(:textarea, :page_heading)) %>
-
 ### With hint
 
 <%= render(Shared::ComponentExample.new(:textarea, :with_hint)) %>
@@ -33,6 +29,14 @@ title: Textarea
 By default the id is based on the `name`. This can be customised by passing an `id` argument.
 
 <%= render(Shared::ComponentExample.new(:textarea, :with_custom_id)) %>
+
+### With character count
+
+<%= render(Shared::ComponentExample.new(:textarea, :with_character_count)) %>
+
+### Page heading
+
+<%= render(Shared::ComponentExample.new(:textarea, :page_heading)) %>
 
 ## Using with Rails
 

--- a/design-system-docs/src/_component_examples/_textarea/with_character_count.erb
+++ b/design-system-docs/src/_component_examples/_textarea/with_character_count.erb
@@ -1,0 +1,11 @@
+---
+title: with character count
+---
+
+<%= render(CitizensAdviceComponents::Textarea.new(
+  name: "example-textarea-character-count",
+  label: "Example textarea (with character count)",
+  options: {
+    character_count: 500
+  }
+))%>

--- a/engine/app/components/citizens_advice_components/input.rb
+++ b/engine/app/components/citizens_advice_components/input.rb
@@ -111,10 +111,14 @@ module CitizensAdviceComponents
     end
 
     def described_by
+      described_by_ids.present? ? described_by_ids.join(" ") : nil
+    end
+
+    def described_by_ids
       ids = []
       ids << error_id if error?
       ids << hint_id if hint?
-      ids.present? ? ids.join(" ") : nil
+      ids
     end
 
     def input_attributes

--- a/engine/app/components/citizens_advice_components/textarea.html.erb
+++ b/engine/app/components/citizens_advice_components/textarea.html.erb
@@ -2,7 +2,7 @@
   <%= content_tag(:textarea, value, class: ["cads-textarea", ("js-cads-character-count" if character_count?)], **input_attributes) %>
   <% if character_count? %>
     <div id="<%= character_count_id %>" class="cads-character-count js-cads-character-count-fallback">
-      You can enter up to <%= character_count %> characters
+      <%= t("citizens_advice_components.character_count.fallback", character_count: character_count) %>
     </div>
   <% end %>
 <% end %>

--- a/engine/app/components/citizens_advice_components/textarea.html.erb
+++ b/engine/app/components/citizens_advice_components/textarea.html.erb
@@ -1,0 +1,8 @@
+<%= render CitizensAdviceComponents::Input.new(**base_input_args) do %>
+  <%= content_tag(:textarea, value, class: ["cads-textarea", ("js-cads-character-count" if character_count?)], **input_attributes) %>
+  <% if character_count? %>
+    <div id="<%= character_count_id %>" class="cads-character-count js-cads-character-count-fallback">
+      You can enter up to <%= character_count %> characters
+    </div>
+  <% end %>
+<% end %>

--- a/engine/app/components/citizens_advice_components/textarea.rb
+++ b/engine/app/components/citizens_advice_components/textarea.rb
@@ -33,7 +33,19 @@ module CitizensAdviceComponents
     end
 
     def base_input_attributes
-      super.merge(rows: @rows, value: nil, "data-character-count": character_count.presence)
+      if character_count.present?
+        super.merge(
+          rows: @rows,
+          value: nil,
+          "data-character-count": character_count.presence,
+          "data-character-count-over-limit": t("citizens_advice_components.character_count.over_limit"),
+          "data-character-count-remaining-zero": t("citizens_advice_components.character_count.remaining_zero"),
+          "data-character-count-remaining-one": t("citizens_advice_components.character_count.remaining_one"),
+          "data-character-count-remaining-other": t("citizens_advice_components.character_count.remaining_other")
+        )
+      else
+        super.merge(rows: @rows, value: nil)
+      end
     end
   end
 end

--- a/engine/app/components/citizens_advice_components/textarea.rb
+++ b/engine/app/components/citizens_advice_components/textarea.rb
@@ -2,20 +2,30 @@
 
 module CitizensAdviceComponents
   class Textarea < Input
-    attr_reader :base_input_args
+    attr_reader :base_input_args, :character_count
 
     DEFAULT_ROWS = 8
 
     def initialize(rows: DEFAULT_ROWS, **args)
       @rows = format_rows(rows)
       @base_input_args = args.merge(type: nil)
+      @character_count = args.dig(:options, :character_count)
       super(**@base_input_args)
     end
 
-    def call
-      render CitizensAdviceComponents::Input.new(**base_input_args) do
-        content_tag(:textarea, value, class: "cads-textarea", **input_attributes)
-      end
+    private
+
+    def character_count?
+      character_count.present?
+    end
+
+    def described_by_ids
+      super << character_count_id if character_count?
+      super
+    end
+
+    def character_count_id
+      "#{general_id}-info"
     end
 
     def format_rows(rows)
@@ -23,7 +33,7 @@ module CitizensAdviceComponents
     end
 
     def base_input_attributes
-      super.merge(rows: @rows, value: nil)
+      super.merge(rows: @rows, value: nil, "data-character-count": character_count.presence)
     end
   end
 end

--- a/engine/app/lib/citizens_advice_components/elements/text_area.rb
+++ b/engine/app/lib/citizens_advice_components/elements/text_area.rb
@@ -4,22 +4,31 @@ module CitizensAdviceComponents
   module Elements
     class TextArea < Base
       def render
-        component = CitizensAdviceComponents::Textarea.new(
+        component.render_in(@template)
+      end
+
+      private
+
+      def component
+        CitizensAdviceComponents::Textarea.new(
           name: field_name,
           id: field_id,
           label: label,
           rows: options[:rows],
-          options: {
-            hint: hint,
-            optional: optional,
-            value: current_value,
-            error_message: error_message,
-            additional_attributes: options[:additional_attributes],
-            page_heading: options[:page_heading].present?
-          }
+          options: component_options
         )
+      end
 
-        component.render_in(@template)
+      def component_options
+        {
+          hint: hint,
+          optional: optional,
+          value: current_value,
+          error_message: error_message,
+          additional_attributes: options[:additional_attributes],
+          page_heading: options[:page_heading].present?,
+          character_count: options[:character_count]
+        }
       end
     end
   end

--- a/engine/config/locales/cy.yml
+++ b/engine/config/locales/cy.yml
@@ -26,6 +26,12 @@ cy:
       dropdown_aria_label_close: Cau llywio
     input:
       optional: dewisol
+    character_count:
+      fallback: You can enter up to %{character_count} characters (cy)
+      over_limit: You have CHARACTER_COUNT characters too many (cy)
+      remaining_zero: You have 0 characters remaining (cy)
+      remaining_one: You have 1 character remaining (cy)
+      remaining_other: You have CHARACTER_COUNT characters remaining (cy)
     date_input:
       year: Blwyddyn
       month: Mis

--- a/engine/config/locales/en.yml
+++ b/engine/config/locales/en.yml
@@ -26,6 +26,12 @@ en:
       dropdown_aria_label_close: Close navigation
     input:
       optional: optional
+    character_count:
+      fallback: You can enter up to %{character_count} characters
+      over_limit: You have CHARACTER_COUNT characters too many
+      remaining_zero: You have 0 characters remaining
+      remaining_one: You have 1 character remaining
+      remaining_other: You have CHARACTER_COUNT characters remaining
     date_input:
       year: Year
       month: Month

--- a/engine/spec/components/citizens_advice_components/textarea_spec.rb
+++ b/engine/spec/components/citizens_advice_components/textarea_spec.rb
@@ -210,4 +210,24 @@ RSpec.describe CitizensAdviceComponents::Textarea, type: :component do
       expect(page).to have_css "textarea[rows=8]"
     end
   end
+
+  context "when a character count is provided" do
+    before do
+      render_inline described_class.new(
+        name: "example-textarea",
+        label: "Example textarea",
+        options: { character_count: 500 }
+      )
+    end
+
+    let(:rows) { "banana" }
+
+    it "passes the character count onto the component" do
+      expect(page).to have_css "textarea[data-character-count=500]"
+    end
+
+    it "displays a fallback character count message" do
+      expect(page).to have_text "You can enter up to 500 characters"
+    end
+  end
 end

--- a/engine/spec/components/citizens_advice_components/textarea_spec.rb
+++ b/engine/spec/components/citizens_advice_components/textarea_spec.rb
@@ -229,5 +229,13 @@ RSpec.describe CitizensAdviceComponents::Textarea, type: :component do
     it "displays a fallback character count message" do
       expect(page).to have_text "You can enter up to 500 characters"
     end
+
+    context "when welsh language" do
+      around { |example| I18n.with_locale(:cy) { example.run } }
+
+      it "displays a welsh language fallback character count message" do
+        expect(page).to have_text "You can enter up to 500 characters (cy)"
+      end
+    end
   end
 end

--- a/engine/spec/features/text_area_spec.rb
+++ b/engine/spec/features/text_area_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe "text areas" do
     end
   end
 
-  it "renders a page heading" do
+  it "renders a character count" do
     within "#character_count_text_area" do
       expect(page).to have_css "textarea[data-character-count=500]"
       expect(page).to have_text "You can enter up to 500 characters"

--- a/engine/spec/features/text_area_spec.rb
+++ b/engine/spec/features/text_area_spec.rb
@@ -25,4 +25,11 @@ RSpec.describe "text areas" do
       expect(page).to have_css("h1.cads-page-title label", text: "Address")
     end
   end
+
+  it "renders a page heading" do
+    within "#character_count_text_area" do
+      expect(page).to have_css "textarea[data-character-count=500]"
+      expect(page).to have_text "You can enter up to 500 characters"
+    end
+  end
 end

--- a/engine/spec/lib/citizens_advice_components/elements/text_area_spec.rb
+++ b/engine/spec/lib/citizens_advice_components/elements/text_area_spec.rb
@@ -69,6 +69,14 @@ RSpec.describe CitizensAdviceComponents::Elements::TextArea do
       end
     end
 
+    context "with 'character_count' parameter" do
+      it "passes hint to the text input component" do
+        builder.cads_text_area(:name, character_count: 500)
+
+        expect(component).to have_received(:new).with(hash_including(options: hash_including(character_count: 500)))
+      end
+    end
+
     context "when there is a validation error" do
       it "sets 'error_message'" do
         model.errors.add(:address, :presence, message: "is required")

--- a/engine/spec/test_app/app/views/elements/text_areas.html.erb
+++ b/engine/spec/test_app/app/views/elements/text_areas.html.erb
@@ -10,4 +10,8 @@
   <div id="page_heading_text_area">
     <%= f.cads_text_area :address, page_heading: true %>
   </div>
+
+  <div id="character_count_text_area">
+    <%= f.cads_text_area :address, character_count: 500 %>
+  </div>
 <% end %>

--- a/lib/character-count/character-count.js
+++ b/lib/character-count/character-count.js
@@ -12,33 +12,62 @@ function getMaxCountFor(inputEl) {
   return maxCount;
 }
 
-function buildMessageFor(currentCount) {
-  if (currentCount < 0) {
-    return `You have ${Math.abs(currentCount)} characters too many`;
-  } else {
-    return `You have ${currentCount} ${currentCount === 1 ? 'character' : 'characters'} remaining`;
-  }
+function getI18nFor(inputEl) {
+  const getData = (name) =>
+    inputEl.getAttribute(`data-character-count-${name}`);
+
+  return {
+    overLimit:
+      getData('over-limit') || 'You have CHARACTER_COUNT characters too many',
+    remainingZero:
+      getData('remaining-zero') || 'You have 0 characters remaining',
+    remainingOne: getData('remaining-one') || 'You have 1 character remaining',
+    remainingOther:
+      getData('remaining-other') ||
+      'You have CHARACTER_COUNT character remaining',
+  };
 }
 
-function buildCounterEl(initialCount) {
+function buildMessageFor(elementCache, currentCount) {
+  if (currentCount < 0) {
+    return elementCache.i18n.overLimit.replace(
+      'CHARACTER_COUNT',
+      Math.abs(currentCount),
+    );
+  }
+
+  if (currentCount === 0) {
+    return elementCache.i18n.remainingZero;
+  }
+
+  if (currentCount === 1) {
+    return elementCache.i18n.remainingOne;
+  }
+
+  return elementCache.i18n.remainingOther.replace(
+    'CHARACTER_COUNT',
+    currentCount,
+  );
+}
+
+function buildCounterEl() {
   // Create a visible element which is live updated on every keystroke,
   // and a *screen reader* specific element which is updated less frequently.
   // https://dav-idc.com/making-a-character-count-component-more-accessible/
   return `<div class="cads-character-count js-cads-character-count-visible"
     aria-hidden=true data-testid="character-count"
-  >
-    ${buildMessageFor(initialCount)}
-  </div>
+  ></div>
   <div class="cads-character-count-sr cads-visually-hidden js-cads-character-count-sr"
     aria-live="polite"
-  >
-    ${buildMessageFor(initialCount)}
-  </div>`;
+  ></div>`;
 }
 
 function updateVisibleCountMessage(elementCache, maxCount) {
   const newCount = maxCount - (elementCache.input.value || '').length;
-  elementCache.counterVisible.textContent = buildMessageFor(newCount);
+  elementCache.counterVisible.textContent = buildMessageFor(
+    elementCache,
+    newCount,
+  );
   elementCache.counterVisible.setAttribute(
     'data-character-count-state',
     newCount < 0 ? 'invalid' : 'valid',
@@ -47,7 +76,10 @@ function updateVisibleCountMessage(elementCache, maxCount) {
 
 function updateScreenReaderCountMessage(elementCache, maxCount) {
   const newCount = maxCount - (elementCache.input.value || '').length;
-  elementCache.counterScreenReader.textContent = buildMessageFor(newCount);
+  elementCache.counterScreenReader.textContent = buildMessageFor(
+    elementCache,
+    newCount,
+  );
 }
 
 function updateCountMessage(elementCache, maxCount) {
@@ -108,10 +140,11 @@ function init(inputEl) {
   const fallback = parentEl.querySelector('.js-cads-character-count-fallback');
   fallback.classList.add('cads-visually-hidden');
 
-  inputEl.insertAdjacentHTML('afterend', buildCounterEl(maxCount));
+  inputEl.insertAdjacentHTML('afterend', buildCounterEl());
 
   const elementCache = {
     input: inputEl,
+    i18n: getI18nFor(inputEl),
     fallback: parentEl.querySelector('.js-cads-character-count-fallback'),
     counterVisible: parentEl.querySelector('.js-cads-character-count-visible'),
     counterScreenReader: parentEl.querySelector('.js-cads-character-count-sr'),

--- a/lib/character-count/character-count.js
+++ b/lib/character-count/character-count.js
@@ -25,7 +25,7 @@ function buildCounterEl(initialCount) {
   // and a *screen reader* specific element which is updated less frequently.
   // https://dav-idc.com/making-a-character-count-component-more-accessible/
   return `<div class="cads-character-count js-cads-character-count-visible"
-    aria-hidden=true
+    aria-hidden=true data-testid="character-count"
   >
     ${buildMessageFor(initialCount)}
   </div>

--- a/lib/character-count/character-count.js
+++ b/lib/character-count/character-count.js
@@ -1,0 +1,160 @@
+function getMaxCountFor(inputEl) {
+  // We don't use the maxlength attribute as:
+  //
+  // 1. This truncates text when pasting, causing data-loss
+  // 2. Products may prefer to treat character counts as an
+  //    enhancement, or to implement a slightly higher
+  //    actual limit server side.
+  //
+  // https://adamsilver.io/blog/dont-use-the-maxlength-attribute-to-stop-users-from-exceeding-the-limit/
+  const maxCountAttr = inputEl.getAttribute('data-character-count');
+  const maxCount = maxCountAttr ? parseInt(maxCountAttr, 10) : Infinity;
+  return maxCount;
+}
+
+function buildMessageFor(currentCount) {
+  if (currentCount < 0) {
+    return `You have ${Math.abs(currentCount)} characters too many`;
+  } else {
+    return `You have ${currentCount} ${currentCount === 1 ? 'character' : 'characters'} remaining`;
+  }
+}
+
+function buildCounterEl(initialCount) {
+  // Create a visible element which is live updated on every keystroke,
+  // and a *screen reader* specific element which is updated less frequently.
+  // https://dav-idc.com/making-a-character-count-component-more-accessible/
+  return `<div class="cads-character-count js-cads-character-count-visible"
+    aria-hidden=true
+  >
+    ${buildMessageFor(initialCount)}
+  </div>
+  <div class="cads-character-count-sr cads-visually-hidden js-cads-character-count-sr"
+    aria-live="polite"
+  >
+    ${buildMessageFor(initialCount)}
+  </div>`;
+}
+
+function updateVisibleCountMessage(elementCache, maxCount) {
+  const newCount = maxCount - (elementCache.input.value || '').length;
+  elementCache.counterVisible.textContent = buildMessageFor(newCount);
+  elementCache.counterVisible.setAttribute(
+    'data-character-count-state',
+    newCount < 0 ? 'invalid' : 'valid',
+  );
+}
+
+function updateScreenReaderCountMessage(elementCache, maxCount) {
+  const newCount = maxCount - (elementCache.input.value || '').length;
+  elementCache.counterScreenReader.textContent = buildMessageFor(newCount);
+}
+
+function updateCountMessage(elementCache, maxCount) {
+  updateVisibleCountMessage(elementCache, maxCount);
+  updateScreenReaderCountMessage(elementCache, maxCount);
+}
+
+function updateIfValueChanged(elementCache, maxCount, lastInputValue) {
+  if (elementCache.input.value !== lastInputValue) {
+    lastInputValue = elementCache.input.value;
+    updateCountMessage(elementCache, maxCount);
+  }
+}
+
+function handleKeyup(elementCache, maxCount, lastInputTimestamp) {
+  updateVisibleCountMessage(elementCache, maxCount);
+  lastInputTimestamp = Date.now();
+  return lastInputTimestamp;
+}
+
+function handleFocus(
+  elementCache,
+  maxCount,
+  lastInputTimestamp,
+  lastInputValue,
+  valueChecker,
+) {
+  valueChecker = window.setInterval(() => {
+    if (!lastInputTimestamp || Date.now() - 500 >= lastInputTimestamp) {
+      updateIfValueChanged(elementCache, maxCount, lastInputValue);
+    }
+  }, 1000);
+
+  return valueChecker;
+}
+
+// Cancel value checking on blur
+function handleBlur(valueChecker) {
+  if (valueChecker) {
+    window.clearInterval(valueChecker);
+  }
+}
+
+function init(inputEl) {
+  let lastInputTimestamp, lastInputValue, valueChecker;
+
+  // Base the parent on the closest form-field
+  const parentEl = inputEl.closest('.cads-form-field');
+
+  if (!parentEl) {
+    return;
+  }
+
+  const maxCount = getMaxCountFor(inputEl);
+
+  // Mark fallback character count text as visibly hidden
+  // https://dav-idc.com/making-a-character-count-component-more-accessible/
+  const fallback = parentEl.querySelector('.js-cads-character-count-fallback');
+  fallback.classList.add('cads-visually-hidden');
+
+  inputEl.insertAdjacentHTML('afterend', buildCounterEl(maxCount));
+
+  const elementCache = {
+    input: inputEl,
+    fallback: parentEl.querySelector('.js-cads-character-count-fallback'),
+    counterVisible: parentEl.querySelector('.js-cads-character-count-visible'),
+    counterScreenReader: parentEl.querySelector('.js-cads-character-count-sr'),
+  };
+
+  //Attach event listeners to dynamically update remaining characters
+  inputEl.addEventListener('keyup', () =>
+    handleKeyup(elementCache, maxCount, lastInputTimestamp),
+  );
+
+  // // Bind focus/blur events to start/stop polling
+  inputEl.addEventListener('focus', () =>
+    handleFocus(
+      elementCache,
+      maxCount,
+      lastInputTimestamp,
+      lastInputValue,
+      valueChecker,
+    ),
+  );
+
+  inputEl.addEventListener('blur', () => handleBlur(valueChecker));
+
+  // When the page is restored after navigating 'back' in some browsers the
+  // state of form controls is not restored until *after* the DOMContentLoaded
+  // event is fired, so we need to sync after the pageshow event.
+  window.addEventListener('pageshow', () =>
+    updateCountMessage(elementCache, maxCount),
+  );
+
+  // Initialize the character count
+  updateCountMessage(elementCache, maxCount);
+}
+
+/**
+ * Character counter component. Based on:
+ * 1. https://github.com/alphagov/govuk-frontend/blob/main/packages/govuk-frontend/src/govuk/components/character-count/character-count.mjs
+ * 2. https://dav-idc.com/making-a-character-count-component-more-accessible/
+ * 3. https://adamsilver.io/blog/dont-use-the-maxlength-attribute-to-stop-users-from-exceeding-the-limit/
+ */
+export default function initCharacterCount() {
+  const els = document.querySelectorAll('.js-cads-character-count');
+  els.forEach((inputEl) => {
+    init(inputEl);
+  });
+}

--- a/lib/character-count/index.js
+++ b/lib/character-count/index.js
@@ -1,0 +1,4 @@
+import initCharacterCount from './character-count';
+
+export { initCharacterCount };
+export default initCharacterCount;

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -6,4 +6,5 @@ declare module '@citizensadvice/design-system' {
   export function initNavigation(): void;
   export function initOnThisPage(): void;
   export function initTargetedContent(): void;
+  export function initCharacterCount(): void;
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -5,6 +5,7 @@ import { initGreedyNav } from './greedy-nav';
 import { initNavigation } from './navigation';
 import { initOnThisPage } from './on-this-page';
 import { initTargetedContent } from './targeted-content';
+import { initCharacterCount } from './character-count';
 
 export {
   initDisclosure,
@@ -14,4 +15,5 @@ export {
   initNavigation,
   initOnThisPage,
   initTargetedContent,
+  initCharacterCount,
 };

--- a/scss/6-components/forms/text-area.scss
+++ b/scss/6-components/forms/text-area.scss
@@ -23,3 +23,15 @@
     line-height: 1.75rem;
   }
 }
+
+/** @define character-count */
+.cads-character-count {
+  margin-top: $cads-spacing-2;
+  color: $cads-palette__dark-grey;
+  text-align: right;
+
+  &[data-character-count-state='invalid'] {
+    color: $cads-language__warning-colour;
+    font-weight: $cads-font-weight__bold;
+  }
+}


### PR DESCRIPTION
## Background

We currently have a basic character counter in use on the referrals application. It's general enough and we have an open issue (#1691) that suggests it's worth making this available through the design system itself.

## Changes

Adds the scaffolding for a character count component supported by textareas. Takes care to follow the same accessibility patterns as the GOV.UK equivalent which has recently undergone some major accessibility improvements[^1].

This version also differs from the current version in our products in that it doesn't use `maxlength` as the limit. This is deliberate to avoid data-loss when pasting text[^2].

As a result this version has the following additional states:

1. A no-js fallback state
2. A error state when exceeding the character limit
3. A screen-reader only version of the character count which updates at a slower rate.

## Screenshots

Empty state:

<img width="605" alt="character-count-empty" src="https://github.com/user-attachments/assets/c9aab3a7-ad37-4310-acef-9f39b60cfd92" />

Partial state:


<img width="610" alt="character-count-partial" src="https://github.com/user-attachments/assets/23f49023-697c-407c-bfe5-d7a9875c72e3" />

Error state:

<img width="609" alt="character-count-error" src="https://github.com/user-attachments/assets/07f269e7-d95a-4394-b58c-182469fb2e04" />

Fallback (no-js) state:

<img width="607" alt="character-count-fallback" src="https://github.com/user-attachments/assets/dad9cec2-ada2-4761-bc0d-614abf4d91cc" />


## Caveats

The current implementation doesn't have any tests (neither rspec updates or Cypress tests), no documentation, nor is the text localised.

- [x] Update specs for engine code
- [x] Add Cypress tests for interaction behaviour
- [x] Implement welsh language capability for the character counter
- [ ] Provide translated text
- [x] Update documentation

Using this as a starting point to validate against the current implementation.

[^1]: https://dav-idc.com/making-a-character-count-component-more-accessible/
[^2]: https://adamsilver.io/blog/dont-use-the-maxlength-attribute-to-stop-users-from-exceeding-the-limit/