### PR TITLE
Remove size-limit

### DIFF
--- a/demo/package-lock.json
+++ b/demo/package-lock.json
@@ -31,7 +31,6 @@
       "devDependencies": {
         "@babel/preset-env": "^7.26.7",
         "@eslint/js": "^9.28.0",
-        "@size-limit/file": "^11.0.0",
         "@testing-library/dom": "^10.0.0",
         "@testing-library/jest-dom": "^6.1.3",
         "@testing-library/user-event": "^14.5.1",
@@ -50,7 +49,6 @@
         "sass": "^1.69.0",
         "semver": "^7.3.8",
         "simple-git": "^3.18.0",
-        "size-limit": "^11.0.0",
         "stylelint": "^16.6.1",
         "stylelint-config-standard-scss": "^15.0.1",
         "stylelint-selector-bem-pattern": "^4.0.0"

--- a/design-system-docs/package-lock.json
+++ b/design-system-docs/package-lock.json
@@ -35,7 +35,6 @@
       "devDependencies": {
         "@babel/preset-env": "^7.26.7",
         "@eslint/js": "^9.28.0",
-        "@size-limit/file": "^11.0.0",
         "@testing-library/dom": "^10.0.0",
         "@testing-library/jest-dom": "^6.1.3",
         "@testing-library/user-event": "^14.5.1",
@@ -54,7 +53,6 @@
         "sass": "^1.69.0",
         "semver": "^7.3.8",
         "simple-git": "^3.18.0",
-        "size-limit": "^11.0.0",
         "stylelint": "^16.6.1",
         "stylelint-config-standard-scss": "^15.0.1",
         "stylelint-selector-bem-pattern": "^4.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
       "devDependencies": {
         "@babel/preset-env": "^7.26.7",
         "@eslint/js": "^9.28.0",
-        "@size-limit/file": "^11.0.0",
         "@testing-library/dom": "^10.0.0",
         "@testing-library/jest-dom": "^6.1.3",
         "@testing-library/user-event": "^14.5.1",
@@ -30,7 +29,6 @@
         "sass": "^1.69.0",
         "semver": "^7.3.8",
         "simple-git": "^3.18.0",
-        "size-limit": "^11.0.0",
         "stylelint": "^16.6.1",
         "stylelint-config-standard-scss": "^15.0.1",
         "stylelint-selector-bem-pattern": "^4.0.0"
@@ -3223,19 +3221,6 @@
         "@sinonjs/commons": "^3.0.0"
       }
     },
-    "node_modules/@size-limit/file": {
-      "version": "11.2.0",
-      "resolved": "https://registry.npmjs.org/@size-limit/file/-/file-11.2.0.tgz",
-      "integrity": "sha512-OZHE3putEkQ/fgzz3Tp/0hSmfVo3wyTpOJSRNm6AmcwX4Nm9YtTfbQQ/hZRwbBFR23S7x2Sd9EbqYzngKwbRoA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^18.0.0 || >=20.0.0"
-      },
-      "peerDependencies": {
-        "size-limit": "11.2.0"
-      }
-    },
     "node_modules/@testing-library/dom": {
       "version": "10.4.0",
       "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.0.tgz",
@@ -4139,15 +4124,6 @@
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "dev": true
-    },
-    "node_modules/bytes-iec": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/bytes-iec/-/bytes-iec-3.1.1.tgz",
-      "integrity": "sha512-fey6+4jDK7TFtFg/klGSvNKJctyU7n2aQdnM+CO0ruLPbqqMOM8Tio0Pc+deqUeVKX1tL5DQep1zQ7+37aTAsA==",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.8"
-      }
     },
     "node_modules/cacheable": {
       "version": "1.10.0",
@@ -7496,6 +7472,8 @@
       "integrity": "sha512-rg9zJN+G4n2nfJl5MW3BMygZX56zKPNVEYYqq7adpmMh4Jn2QNEwhvQlFy6jPVdcod7txZtKHWnyZiA3a0zP7A==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }
@@ -7676,19 +7654,6 @@
       },
       "engines": {
         "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/lilconfig": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
-      "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/antonk52"
       }
     },
     "node_modules/lines-and-columns": {
@@ -7969,16 +7934,6 @@
       },
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
-      }
-    },
-    "node_modules/nanospinner": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/nanospinner/-/nanospinner-1.2.2.tgz",
-      "integrity": "sha512-Zt/AmG6qRU3e+WnzGGLuMCEAO/dAu45stNbHY223tUxldaDAeE+FxSPsd9Q+j+paejmm0ZbrNVs5Sraqy3dRxA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "picocolors": "^1.1.1"
       }
     },
     "node_modules/natural-compare": {
@@ -9294,28 +9249,6 @@
       "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
       "dev": true
     },
-    "node_modules/size-limit": {
-      "version": "11.2.0",
-      "resolved": "https://registry.npmjs.org/size-limit/-/size-limit-11.2.0.tgz",
-      "integrity": "sha512-2kpQq2DD/pRpx3Tal/qRW1SYwcIeQ0iq8li5CJHQgOC+FtPn2BVmuDtzUCgNnpCrbgtfEHqh+iWzxK+Tq6C+RQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "bytes-iec": "^3.1.1",
-        "chokidar": "^4.0.3",
-        "jiti": "^2.4.2",
-        "lilconfig": "^3.1.3",
-        "nanospinner": "^1.2.2",
-        "picocolors": "^1.1.1",
-        "tinyglobby": "^0.2.11"
-      },
-      "bin": {
-        "size-limit": "bin.js"
-      },
-      "engines": {
-        "node": "^18.0.0 || >=20.0.0"
-      }
-    },
     "node_modules/slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -10014,51 +9947,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/tinyglobby": {
-      "version": "0.2.12",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.12.tgz",
-      "integrity": "sha512-qkf4trmKSIiMTs/E63cxH+ojC2unam7rJ0WrauAzpT3ECNTxGRMlaXxVbfxMUC/w0LaYk6jQ4y/nGR9uBO3tww==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fdir": "^6.4.3",
-        "picomatch": "^4.0.2"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/SuperchupuDev"
-      }
-    },
-    "node_modules/tinyglobby/node_modules/fdir": {
-      "version": "6.4.3",
-      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.3.tgz",
-      "integrity": "sha512-PMXmW2y1hDDfTSRc9gaXIuCCRpuoz3Kaz8cUelp3smouvfT632ozg2vrT6lJsHKKOF59YLbOGfAWGUcKEfRMQw==",
-      "dev": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "picomatch": "^3 || ^4"
-      },
-      "peerDependenciesMeta": {
-        "picomatch": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
-      "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/tmp": {
@@ -12791,13 +12679,6 @@
         "@sinonjs/commons": "^3.0.0"
       }
     },
-    "@size-limit/file": {
-      "version": "11.2.0",
-      "resolved": "https://registry.npmjs.org/@size-limit/file/-/file-11.2.0.tgz",
-      "integrity": "sha512-OZHE3putEkQ/fgzz3Tp/0hSmfVo3wyTpOJSRNm6AmcwX4Nm9YtTfbQQ/hZRwbBFR23S7x2Sd9EbqYzngKwbRoA==",
-      "dev": true,
-      "requires": {}
-    },
     "@testing-library/dom": {
       "version": "10.4.0",
       "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.0.tgz",
@@ -13452,12 +13333,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-      "dev": true
-    },
-    "bytes-iec": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/bytes-iec/-/bytes-iec-3.1.1.tgz",
-      "integrity": "sha512-fey6+4jDK7TFtFg/klGSvNKJctyU7n2aQdnM+CO0ruLPbqqMOM8Tio0Pc+deqUeVKX1tL5DQep1zQ7+37aTAsA==",
       "dev": true
     },
     "cacheable": {
@@ -15839,7 +15714,9 @@
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.4.2.tgz",
       "integrity": "sha512-rg9zJN+G4n2nfJl5MW3BMygZX56zKPNVEYYqq7adpmMh4Jn2QNEwhvQlFy6jPVdcod7txZtKHWnyZiA3a0zP7A==",
-      "dev": true
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "js-tokens": {
       "version": "4.0.0",
@@ -15974,12 +15851,6 @@
         "prelude-ls": "^1.2.1",
         "type-check": "~0.4.0"
       }
-    },
-    "lilconfig": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
-      "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
-      "dev": true
     },
     "lines-and-columns": {
       "version": "1.2.4",
@@ -16182,15 +16053,6 @@
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
       "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
       "dev": true
-    },
-    "nanospinner": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/nanospinner/-/nanospinner-1.2.2.tgz",
-      "integrity": "sha512-Zt/AmG6qRU3e+WnzGGLuMCEAO/dAu45stNbHY223tUxldaDAeE+FxSPsd9Q+j+paejmm0ZbrNVs5Sraqy3dRxA==",
-      "dev": true,
-      "requires": {
-        "picocolors": "^1.1.1"
-      }
     },
     "natural-compare": {
       "version": "1.4.0",
@@ -17100,21 +16962,6 @@
       "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
       "dev": true
     },
-    "size-limit": {
-      "version": "11.2.0",
-      "resolved": "https://registry.npmjs.org/size-limit/-/size-limit-11.2.0.tgz",
-      "integrity": "sha512-2kpQq2DD/pRpx3Tal/qRW1SYwcIeQ0iq8li5CJHQgOC+FtPn2BVmuDtzUCgNnpCrbgtfEHqh+iWzxK+Tq6C+RQ==",
-      "dev": true,
-      "requires": {
-        "bytes-iec": "^3.1.1",
-        "chokidar": "^4.0.3",
-        "jiti": "^2.4.2",
-        "lilconfig": "^3.1.3",
-        "nanospinner": "^1.2.2",
-        "picocolors": "^1.1.1",
-        "tinyglobby": "^0.2.11"
-      }
-    },
     "slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -17592,31 +17439,6 @@
             "once": "^1.3.0",
             "path-is-absolute": "^1.0.0"
           }
-        }
-      }
-    },
-    "tinyglobby": {
-      "version": "0.2.12",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.12.tgz",
-      "integrity": "sha512-qkf4trmKSIiMTs/E63cxH+ojC2unam7rJ0WrauAzpT3ECNTxGRMlaXxVbfxMUC/w0LaYk6jQ4y/nGR9uBO3tww==",
-      "dev": true,
-      "requires": {
-        "fdir": "^6.4.3",
-        "picomatch": "^4.0.2"
-      },
-      "dependencies": {
-        "fdir": {
-          "version": "6.4.3",
-          "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.3.tgz",
-          "integrity": "sha512-PMXmW2y1hDDfTSRc9gaXIuCCRpuoz3Kaz8cUelp3smouvfT632ozg2vrT6lJsHKKOF59YLbOGfAWGUcKEfRMQw==",
-          "dev": true,
-          "requires": {}
-        },
-        "picomatch": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
-          "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
-          "dev": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -20,19 +20,17 @@
   "scripts": {
     "release": "npm run lint && node ./scripts/release",
     "prepublishOnly": "npm run lint && node ./scripts/publish",
-    "size-limit": "size-limit",
     "format": "prettier --write .",
     "lint:format": "prettier --check .",
     "lint:css": "stylelint \"./scss/**/*.scss\"",
     "lint:js": "eslint .",
-    "lint": "npm-run-all lint:* size-limit",
+    "lint": "npm-run-all lint:*",
     "test": "jest",
     "test:watch": "jest --watch --notify"
   },
   "devDependencies": {
     "@babel/preset-env": "^7.26.7",
     "@eslint/js": "^9.28.0",
-    "@size-limit/file": "^11.0.0",
     "@testing-library/dom": "^10.0.0",
     "@testing-library/jest-dom": "^6.1.3",
     "@testing-library/user-event": "^14.5.1",
@@ -51,17 +49,10 @@
     "sass": "^1.69.0",
     "semver": "^7.3.8",
     "simple-git": "^3.18.0",
-    "size-limit": "^11.0.0",
     "stylelint": "^16.6.1",
     "stylelint-config-standard-scss": "^15.0.1",
     "stylelint-selector-bem-pattern": "^4.0.0"
   },
-  "size-limit": [
-    {
-      "path": "lib/**/*.js",
-      "limit": "16 kB"
-    }
-  ],
   "browserslist": [
     "IE 11",
     "last 2 Edge versions",


### PR DESCRIPTION
Since we removed the TypeScript build step[^1] and given we publish zero-dependency components the `size-limit` check doesn't provide much of a useful guardrail. Suggesting we remove this to further reduce our dependencies.

[^1]: https://github.com/citizensadvice/design-system/blob/main/contributing/adr/0010-remove-typescript-build-step.md