### PR TITLE
Simplify date input interface

### DIFF
--- a/engine/app/components/citizens_advice_components/date_input.rb
+++ b/engine/app/components/citizens_advice_components/date_input.rb
@@ -1,17 +1,51 @@
 # frozen_string_literal: true
 
 module CitizensAdviceComponents
-  class DateInput < Input
-    attr_reader :name, :label, :errors, :values
+  class DateInput < Base
+    attr_reader(
+      :name,
+      :label,
+      :values,
+      :errors,
+      :error_message,
+      :hint
+    )
 
-    def initialize(values: nil, errors: nil, **args)
-      super(**args.merge({ type: :text }))
+    def initialize(name:, label:, values: nil, errors: nil, options: nil)
+      @name = name
+      @label = label
       @values = values
       @errors = errors
+
+      return if options.blank?
+
+      @error_message = options[:error_message]
+      @hint = options[:hint]
+      @optional = fetch_or_fallback_boolean(options[:optional], fallback: false)
+      @page_heading = fetch_or_fallback_boolean(options[:page_heading], fallback: false)
+    end
+
+    private
+
+    def optional?
+      @optional
+    end
+
+    def error?
+      @error_message.present?
+    end
+
+    def hint?
+      @hint.present?
+    end
+
+    def page_heading?
+      @page_heading
     end
 
     def input_attributes(timespan)
       {
+        type: "text",
         class: input_classes(timespan),
         name: input_id(timespan),
         id: input_id(timespan),
@@ -29,8 +63,6 @@ module CitizensAdviceComponents
         for: input_id(timespan)
       }
     end
-
-    private
 
     def value_for(timespan)
       return if values.blank?

--- a/website/config/data/component_arguments.yml
+++ b/website/config/data/component_arguments.yml
@@ -245,13 +245,13 @@ date_input:
     description: Optional, placeholder values
   - argument: options
     description: "Optional, a hash with one or more of the following values:"
-  - argument: page_heading
+  - argument: "options[:page_heading]"
     description: "→ Optional, boolean indicating the field label is a page heading"
-  - argument: hint
+  - argument: "options[:hint]"
     description: "→ Optional, hint text for the input"
-  - argument: error_message
+  - argument: "options[:error_message]"
     description: "→ Optional, an error message for the input"
-  - argument: optional
+  - argument: "options[:optional]"
     description: "→ Optional, boolean indicating the field is optional (ie not required)"
 select:
   - argument: name


### PR DESCRIPTION
Removes the dependency on the base Input component.

In it's previous form the field inherited from `Input` but needed to provide its own template and overrode almost all of the parent options. This makes sense as the date input isn't a single input, it's a group.

In practice the main way we use the date input is via `cads_date_field` which has a parallel implementation so keeping the two as legible as possible is important to avoid drift.

Our form components were written a long while before we introduced the form builder versions, now we have that we can stand to simplify the original interfaces a bit based on what we've learned.