### PR TITLE
Simplify select interface

### DIFF
--- a/demo/spec/components/previews/select_preview.rb
+++ b/demo/spec/components/previews/select_preview.rb
@@ -2,32 +2,46 @@
 
 class SelectPreview < ViewComponent::Preview
   def default
-    render CitizensAdviceComponents::Select.new(select_options: options, name: "product", label: "Choose a product", type: :text)
+    render CitizensAdviceComponents::Select.new(
+      select_options: options, name: "product", label: "Choose a product"
+    )
   end
 
   def error
-    render CitizensAdviceComponents::Select.new(select_options: options, name: "product", label: "Choose a product", type: :text,
-                                                options: { error_message: "Select a product" })
+    render CitizensAdviceComponents::Select.new(
+      select_options: options,
+      name: "product",
+      label: "Choose a product",
+      options: { error_message: "Select a product" }
+    )
   end
 
   def hint
-    render CitizensAdviceComponents::Select.new(select_options: options, name: "product", label: "Choose a product", type: :text,
-                                                options: { hint: "Choose a product from the list below" })
+    render CitizensAdviceComponents::Select.new(
+      select_options: options, name: "product",
+      label: "Choose a product",
+      options: { hint: "Choose a product from the list below" }
+    )
   end
 
   def value
-    render CitizensAdviceComponents::Select.new(select_options: options, name: "product", label: "Choose a product", type: :text,
-                                                options: { value: "FYLCA", hint: "Choose a product from the list below" })
+    render CitizensAdviceComponents::Select.new(
+      select_options: options,
+      name: "product",
+      label: "Choose a product",
+      options: { value: "FYLCA", hint: "Choose a product from the list below" }
+    )
   end
 
   def optional
-    render CitizensAdviceComponents::Select.new(select_options: options,
-                                                name: "product",
-                                                label: "Choose a product",
-                                                type: :text,
-                                                options: {
-                                                  optional: true
-                                                })
+    render CitizensAdviceComponents::Select.new(
+      select_options: options,
+      name: "product",
+      label: "Choose a product",
+      options: {
+        optional: true
+      }
+    )
   end
 
   private

--- a/engine/.rubocop.yml
+++ b/engine/.rubocop.yml
@@ -24,6 +24,10 @@ Style/HashSyntax:
   # encourages greater readability so support either style
   EnforcedShorthandSyntax: "either"
 
+Metrics/ParameterLists:
+  # Prefer explicit parameters over compact interfaces
+  Max: 8
+
 RSpec/ExampleLength:
   Max: 12
   CountAsOne: ["array", "hash"]

--- a/engine/app/components/citizens_advice_components/select.html.erb
+++ b/engine/app/components/citizens_advice_components/select.html.erb
@@ -1,0 +1,23 @@
+<div class="cads-form-field<% if error? %> cads-form-field--has-error<% end %>">
+  <% if error? %><div class="cads-form-field__error-marker"></div><% end %>
+  <div class="cads-form-field__content">
+    <label class="cads-form-field__label" id="<%= label_id %>" for="<%= input_id %>">
+      <%= label %>
+      <% if optional? %>
+        <span class="cads-form-field__optional"><%= "(#{t('citizens_advice_components.input.optional')})" %></span>
+      <% end %>
+    </label>
+
+    <% if hint? %>
+      <p class="cads-form-field__hint" id="<%= hint_id %>" data-testid="hint-message"><%= hint %></p>
+    <% end %>
+    <% if error? %>
+      <p class="cads-form-field__error-message" id="<%= error_id %>" data-testid="error-message">
+        <%= error_message %>
+      </p>
+    <% end %>
+    <%= tag.select(class: "cads-select cads-input", **input_attributes) do %>
+      <%= render_select_options %>
+    <% end %>
+  </div>
+</div>

--- a/engine/app/components/citizens_advice_components/select.rb
+++ b/engine/app/components/citizens_advice_components/select.rb
@@ -1,36 +1,100 @@
 # frozen_string_literal: true
 
 module CitizensAdviceComponents
-  class Select < CitizensAdviceComponents::Input
-    attr_reader :base_input_args, :select_options, :value
+  class Select < Base
+    attr_reader :name, :label, :select_options, :id, :error_message, :hint, :value
 
-    def initialize(select_options:, **args)
+    def initialize(name:, label:, select_options:, grouped: false, id: nil, options: nil)
+      @name = name
+      @label = label
       @select_options = select_options
-      @base_input_args = args.merge(type: nil)
-      super(**@base_input_args)
+      @grouped = fetch_or_fallback_boolean(grouped, fallback: false)
+      @id = id
+
+      set_options(options)
     end
 
-    def call
-      render CitizensAdviceComponents::Input.new(**base_input_args) do
-        tag.select(class: select_classes, **input_attributes) do
-          tag
-          options_for_select(select_options, value)
-        end
-      end
+    def render_select_options
+      options_for_select(select_options, value)
     end
 
     private
 
-    def select_classes
-      %w[
-        cads-select
-        cads-input
-      ]
+    def set_options(options)
+      return if options.blank?
+
+      @value = options[:value]
+      @hint = options[:hint]
+      @error_message = options[:error_message]
+      @optional = fetch_or_fallback_boolean(options[:optional], fallback: false)
+      @additional_attributes = options[:additional_attributes]
+    end
+
+    def grouped?
+      @grouped
+    end
+
+    def optional?
+      @optional
+    end
+
+    def required?
+      !optional?
+    end
+
+    def error?
+      @error_message.present?
+    end
+
+    def hint?
+      @hint.present?
+    end
+
+    def general_id
+      return id if @id.present?
+
+      name
+    end
+
+    def label_id
+      "#{general_id}-label"
+    end
+
+    def input_id
+      "#{general_id}-input"
+    end
+
+    def error_id
+      "#{general_id}-error"
+    end
+
+    def hint_id
+      "#{general_id}-hint"
     end
 
     def base_input_attributes
-      # selects do not control their current value with the `value` attribute
-      super.reject { |k| k == :value }
+      {
+        id: input_id,
+        name: name,
+        "aria-required": required?,
+        "aria-invalid": error?,
+        "aria-describedby": described_by
+      }
+    end
+
+    def described_by
+      ids = []
+      ids << error_id if error?
+      ids << hint_id if hint?
+      ids.present? ? ids.join(" ") : nil
+    end
+
+    def input_attributes
+      if @additional_attributes.present?
+        base_input_attributes.merge @additional_attributes
+      else
+        base_input_attributes
+      end
     end
   end
 end


### PR DESCRIPTION
Another component where inheritance complicates the interface.

Like with a textarea a select has subtle differences from an input (no type, value handled differently).

Includes a public `render_select_options` method to make it easier for consumers to sub-in things like `grouped_options_for_select`. We could probably support that as a first-class feature but would need more updates to the form builder for that to work properly so just introducing a seam to do it for now.