### PR TITLE
NAT-1249: change the default skip links to skip to only skip to the header component by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 **New**
 
 - Officially support ViewComponent 4
+- Header: by default there is now only a single skip link (to the main content), following [best practice accessility guidance](https://webaim.org/techniques/skipnav/#multiple).
 
 ## v8.1.0
 

--- a/demo/cypress/e2e/skip-links.cy.js
+++ b/demo/cypress/e2e/skip-links.cy.js
@@ -3,21 +3,9 @@ describe('Skip links', () => {
     cy.visit('/content-sample');
   });
 
-  it('allows skipping to navigation', () => {
-    clickSkipLink('Skip to navigation');
-    cy.scrolledIntoView('#cads-navigation');
-  });
-
   it('allows skipping to content', () => {
     clickSkipLink('Skip to main content');
     cy.scrolledIntoView('#cads-main-content');
-  });
-
-  it('allows skipping to footer', () => {
-    // Test at a smaller viewport to make scroll test simpler.
-    cy.viewport('iphone-8', 'portrait');
-    clickSkipLink('Skip to footer');
-    cy.scrolledIntoView('#cads-footer');
   });
 
   function clickSkipLink(name) {

--- a/design-system-docs/src/_component_docs/header.md
+++ b/design-system-docs/src/_component_docs/header.md
@@ -66,7 +66,7 @@ Or by passing a custom block to render your own HTML:
 
 ### Skip links
 
-Skip links are optional. We provide a default set for you but you can provide your own.
+Skip links are optional. We provide a default for you to skip to the main content, but you can provide your own. [Having a single skip link in the header is usually sufficient](https://webaim.org/techniques/skipnav/#multiple).
 
 ```erb
 <%%= render CitizensAdviceComponents::Header.new do |c|
@@ -77,7 +77,7 @@ Skip links are optional. We provide a default set for you but you can provide yo
 end %>
 ```
 
-If you use the defaults you'll need to be using the `Navigation` and `Footer` components and add a `#cads-main-content` ID to your main content area.
+If you use the defaults you'll need to add a `#cads-main-content` ID to your main content area.
 
 ### Header links
 

--- a/engine/app/components/citizens_advice_components/header.rb
+++ b/engine/app/components/citizens_advice_components/header.rb
@@ -28,16 +28,8 @@ module CitizensAdviceComponents
     def fallback_skip_links
       [
         SkipLink.new(
-          title: t("citizens_advice_components.header.skip_to_navigation"),
-          url: "#cads-navigation"
-        ),
-        SkipLink.new(
           title: t("citizens_advice_components.header.skip_to_content"),
           url: "#cads-main-content"
-        ),
-        SkipLink.new(
-          title: t("citizens_advice_components.header.skip_to_footer"),
-          url: "#cads-footer"
         )
       ]
     end

--- a/engine/config/locales/cy.yml
+++ b/engine/config/locales/cy.yml
@@ -17,8 +17,6 @@ cy:
       close_search: Cau Chwilio
       open_search: Ymchwiliad agored
       skip_to_content: Neidio i’r prif gynnwys
-      skip_to_footer: Neidio i’r troedyn
-      skip_to_navigation: Neidio i’r llywio
     navigation:
       dropdown_label: Mwy
       dropdown_label_close: Cau

--- a/engine/config/locales/en.yml
+++ b/engine/config/locales/en.yml
@@ -17,8 +17,6 @@ en:
       close_search: Close search
       open_search: Open search
       skip_to_content: Skip to main content
-      skip_to_footer: Skip to footer
-      skip_to_navigation: Skip to navigation
     navigation:
       dropdown_label: More
       dropdown_label_close: Close

--- a/engine/spec/components/citizens_advice_components/header_spec.rb
+++ b/engine/spec/components/citizens_advice_components/header_spec.rb
@@ -43,10 +43,8 @@ RSpec.describe CitizensAdviceComponents::Header, type: :component do
         end
       end
 
-      it { is_expected.to have_css ".cads-skip-links a", count: 3 }
-      it { is_expected.to have_link "Skip to navigation", href: "#cads-navigation" }
+      it { is_expected.to have_css ".cads-skip-links a", count: 1 }
       it { is_expected.to have_link "Skip to main content", href: "#cads-main-content" }
-      it { is_expected.to have_link "Skip to footer", href: "#cads-footer" }
     end
 
     context "with custom skip links" do


### PR DESCRIPTION
This is because the intent of skip links are to "skip blocks of content repeated between pages" and the navigation and footer are usually repeated between pages therefore it's unnecessary to include them in the skip links in order to satisfy that WCAG criteron. See https://webaim.org/techniques/skipnav/#multiple for more info.