### PR TITLE
Add missing no-js toggle to component examples

### DIFF
--- a/website/app/views/layouts/component_example.html.erb
+++ b/website/app/views/layouts/component_example.html.erb
@@ -6,6 +6,7 @@
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
     <%= stylesheet_link_tag "standalone", media: "all" %>
+    <script>document.querySelector('html').classList.remove('no-js');</script>
   </head>
   <body class="component-example-<%= params[:category] %> component-example-<%= params[:category] %>-<%= params[:slug] %>">
     <%= yield %>


### PR DESCRIPTION
Spotted one more small regression in the docs website, missing the no-js toggle code for component examples (especially when iframed)