### PR TITLE
Remove cads-sr-only-focusable class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+- Remove `.cads-sr-only-focusable` class. This has never been used in any internal design system or product code.
+
 ## v8.3.0
 
 ### 27 August 2025

--- a/scss/7-utilities/_visibility.scss
+++ b/scss/7-utilities/_visibility.scss
@@ -23,20 +23,6 @@
   @include visibility-tools.cads-visually-hidden;
 }
 
-// @define sr-only-focusable
-.cads-sr-only-focusable {
-  // @v6: deprecate this class, it is undocumented and never used
-  &:active,
-  &:focus {
-    position: static;
-    width: auto;
-    height: auto;
-    overflow: visible;
-    clip: auto; // stylelint-disable-line property-no-deprecated
-    white-space: normal;
-  }
-}
-
 // @define show-md-up
 .cads-show-md-up {
   display: none !important;

--- a/scss/__tests__/__snapshots__/utilities.test.js.snap
+++ b/scss/__tests__/__snapshots__/utilities.test.js.snap
@@ -31,15 +31,6 @@ exports[`visibility styles match snapshot 1`] = `
   width: 1px;
 }
 
-.cads-sr-only-focusable:active, .cads-sr-only-focusable:focus {
-  position: static;
-  width: auto;
-  height: auto;
-  overflow: visible;
-  clip: auto;
-  white-space: normal;
-}
-
 .cads-show-md-up {
   display: none !important;
 }


### PR DESCRIPTION
Has an old deprecation comment and a search confirms that we've never used this in any internal or product code.