### PR TITLE
Deprecate type option on Textarea and Select components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+**New**
+
+- Log a deprecation warning when using the `type` argument for `Textarea` and `Select` components. Neither textarea nor select elements accept a type. This argument will be removed in a future version.
+
 ## v8.3.2
 
 ### 25 September 2025

--- a/demo/spec/components/previews/select_preview.rb
+++ b/demo/spec/components/previews/select_preview.rb
@@ -2,32 +2,46 @@
 
 class SelectPreview < ViewComponent::Preview
   def default
-    render CitizensAdviceComponents::Select.new(select_options: options, name: "product", label: "Choose a product", type: :text)
+    render CitizensAdviceComponents::Select.new(
+      select_options: options, name: "product", label: "Choose a product"
+    )
   end
 
   def error
-    render CitizensAdviceComponents::Select.new(select_options: options, name: "product", label: "Choose a product", type: :text,
-                                                options: { error_message: "Select a product" })
+    render CitizensAdviceComponents::Select.new(
+      select_options: options,
+      name: "product",
+      label: "Choose a product",
+      options: { error_message: "Select a product" }
+    )
   end
 
   def hint
-    render CitizensAdviceComponents::Select.new(select_options: options, name: "product", label: "Choose a product", type: :text,
-                                                options: { hint: "Choose a product from the list below" })
+    render CitizensAdviceComponents::Select.new(
+      select_options: options, name: "product",
+      label: "Choose a product",
+      options: { hint: "Choose a product from the list below" }
+    )
   end
 
   def value
-    render CitizensAdviceComponents::Select.new(select_options: options, name: "product", label: "Choose a product", type: :text,
-                                                options: { value: "FYLCA", hint: "Choose a product from the list below" })
+    render CitizensAdviceComponents::Select.new(
+      select_options: options,
+      name: "product",
+      label: "Choose a product",
+      options: { value: "FYLCA", hint: "Choose a product from the list below" }
+    )
   end
 
   def optional
-    render CitizensAdviceComponents::Select.new(select_options: options,
-                                                name: "product",
-                                                label: "Choose a product",
-                                                type: :text,
-                                                options: {
-                                                  optional: true
-                                                })
+    render CitizensAdviceComponents::Select.new(
+      select_options: options,
+      name: "product",
+      label: "Choose a product",
+      options: {
+        optional: true
+      }
+    )
   end
 
   private

--- a/demo/spec/components/previews/textarea_preview.rb
+++ b/demo/spec/components/previews/textarea_preview.rb
@@ -2,92 +2,80 @@
 
 class TextareaPreview < ViewComponent::Preview
   def basic
-    render(
-      CitizensAdviceComponents::Textarea.new(name: "example-input-basic", label: "Example input")
+    render CitizensAdviceComponents::Textarea.new(
+      name: "example-input-basic",
+      label: "Example input"
     )
   end
 
   def value
     copy = "Amet parturient platea augue natoque vitae sem parturient senectus nisi sit nascetur penatibus neque scelerisque rutrum nisl amet odio adipiscing.Ad consectetur quam taciti faucibus etiam parturient a sed."
-    render(
-      CitizensAdviceComponents::Textarea.new(name: "example-input-value", label: "Example input",
-                                             options: { value: copy })
+    render CitizensAdviceComponents::Textarea.new(
+      name: "example-input-value",
+      label: "Example input",
+      options: { value: copy }
     )
   end
 
   def hint
-    render(
-      CitizensAdviceComponents::Textarea.new(
-        name: "example-input-with-hint",
-        label: "Example input with hint",
-        type: :text,
-        options: {
-          hint: "This is the hint for the input"
-        }
-      )
+    render CitizensAdviceComponents::Textarea.new(
+      name: "example-input-with-hint",
+      label: "Example input with hint",
+      options: {
+        hint: "This is the hint for the input"
+      }
     )
   end
 
   def optional
-    render(
-      CitizensAdviceComponents::Textarea.new(
-        name: "example-input-optional",
-        label: "Example input",
-        type: :text,
-        options: {
-          optional: true
-        }
-      )
+    render CitizensAdviceComponents::Textarea.new(
+      name: "example-input-optional",
+      label: "Example input",
+      options: {
+        optional: true
+      }
     )
   end
 
   def error
-    render(
-      CitizensAdviceComponents::Textarea.new(
-        name: "example-input-error",
-        label: "Email address",
-        type: :text,
-        options: {
-          error_message: "Enter a valid email address, like name@example.com"
-        }
-      )
+    render CitizensAdviceComponents::Textarea.new(
+      name: "example-input-error",
+      label: "Email address",
+      options: {
+        error_message: "Enter a valid email address, like name@example.com"
+      }
     )
   end
 
   def page_heading
-    render(
-      CitizensAdviceComponents::Textarea.new(
-        name: "example-textarea-page-heading",
-        label: "Example text area with page heading",
-        options: {
-          page_heading: true,
-          hint: "This is the hint for the input"
-        }
-      )
+    render CitizensAdviceComponents::Textarea.new(
+      name: "example-textarea-page-heading",
+      label: "Example text area with page heading",
+      options: {
+        page_heading: true,
+        hint: "This is the hint for the input"
+      }
     )
   end
 
   def additional_attributes
-    additional_attributes = {
-      spellcheck: "true"
-    }
-
-    render(
-      CitizensAdviceComponents::Textarea.new(
-        name: "example-input-attrs",
-        label: "Example input",
-        type: :text,
-        options: {
-          hint: "This input has additional attributes (spellcheck)",
-          additional_attributes:
+    render CitizensAdviceComponents::Textarea.new(
+      name: "example-input-attrs",
+      label: "Example input",
+      options: {
+        hint: "This input has additional attributes (spellcheck)",
+        additional_attributes: {
+          spellcheck: "true"
         }
-      )
+      }
     )
   end
 
   def custom_id
-    render(
-      CitizensAdviceComponents::Textarea.new(name: "example-input[basic]", id: "test-id", label: "Example input")
+    render CitizensAdviceComponents::Textarea.new(
+      name: "example-input[basic]",
+      id: "test-id",
+      label: "Example input"
     )
   end
 end

--- a/engine/.rubocop.yml
+++ b/engine/.rubocop.yml
@@ -16,6 +16,10 @@ Style/HashSyntax:
   # encourages greater readability so support either style
   EnforcedShorthandSyntax: "either"
 
+Metrics/ParameterLists:
+  # Prefer explicit parameters over compact interfaces
+  Max: 8
+
 RSpec/ExampleLength:
   Max: 12
   CountAsOne: ["array", "hash"]

--- a/engine/app/components/citizens_advice_components/select.html.erb
+++ b/engine/app/components/citizens_advice_components/select.html.erb
@@ -1,0 +1,23 @@
+<div class="cads-form-field<% if error? %> cads-form-field--has-error<% end %>">
+  <% if error? %><div class="cads-form-field__error-marker"></div><% end %>
+  <div class="cads-form-field__content">
+    <label class="cads-form-field__label" id="<%= label_id %>" for="<%= input_id %>">
+      <%= label %>
+      <% if optional? %>
+        <span class="cads-form-field__optional"><%= "(#{t('citizens_advice_components.input.optional')})" %></span>
+      <% end %>
+    </label>
+
+    <% if hint? %>
+      <p class="cads-form-field__hint" id="<%= hint_id %>" data-testid="hint-message"><%= hint %></p>
+    <% end %>
+    <% if error? %>
+      <p class="cads-form-field__error-message" id="<%= error_id %>" data-testid="error-message">
+        <%= error_message %>
+      </p>
+    <% end %>
+    <%= tag.select(class: "cads-select cads-input", **input_attributes) do %>
+      <%= render_select_options %>
+    <% end %>
+  </div>
+</div>

--- a/engine/app/components/citizens_advice_components/textarea.html.erb
+++ b/engine/app/components/citizens_advice_components/textarea.html.erb
@@ -1,0 +1,27 @@
+<div class="cads-form-field<% if error? %> cads-form-field--has-error<% end %>">
+  <% if error? %><div class="cads-form-field__error-marker"></div><% end %>
+  <div class="cads-form-field__content">
+    <% if page_heading? %>
+      <h1 class="cads-page-title">
+        <label id="<%= label_id %>" for="<%= input_id %>"><%= label %></label>
+      </h1>
+    <% else %>
+      <label class="cads-form-field__label" id="<%= label_id %>" for="<%= input_id %>">
+        <%= label %>
+        <% if optional? %>
+          <span class="cads-form-field__optional"><%= "(#{t('citizens_advice_components.input.optional')})" %></span>
+        <% end %>
+      </label>
+    <% end %>
+
+    <% if hint? %>
+      <p class="cads-form-field__hint" id="<%= hint_id %>" data-testid="hint-message"><%= hint %></p>
+    <% end %>
+    <% if error? %>
+      <p class="cads-form-field__error-message" id="<%= error_id %>" data-testid="error-message">
+        <%= error_message %>
+      </p>
+    <% end %>
+    <%= content_tag(:textarea, value, class: "cads-textarea", **input_attributes) %>
+  </div>
+</div>

--- a/engine/app/components/citizens_advice_components/textarea.rb
+++ b/engine/app/components/citizens_advice_components/textarea.rb
@@ -1,29 +1,115 @@
 # frozen_string_literal: true
 
 module CitizensAdviceComponents
-  class Textarea < Input
-    attr_reader :base_input_args
-
+  class Textarea < Base
     DEFAULT_ROWS = 8
 
-    def initialize(rows: DEFAULT_ROWS, **args)
-      @rows = format_rows(rows)
-      @base_input_args = args.merge(type: nil)
-      super(**@base_input_args)
+    attr_reader :name, :label, :error_message, :hint, :value, :id
+
+    def initialize(name:, label:, rows: DEFAULT_ROWS, id: nil, options: nil, type: nil)
+      @name = name
+      @id = id
+      @label = label
+      @rows = rows.to_i.zero? ? DEFAULT_ROWS : rows
+      @type = type
+
+      set_options(options)
+      type_deprecation
     end
 
-    def call
-      render CitizensAdviceComponents::Input.new(**base_input_args) do
-        content_tag(:textarea, value, class: "cads-textarea", **input_attributes)
-      end
+    private
+
+    def type_deprecation
+      return if @type.blank?
+
+      CitizensAdviceComponents.deprecator.warn(
+        "The type argument is deprecated, type is not a valid property of a <textarea>"
+      )
+    end
+
+    def set_options(options)
+      return if options.blank?
+
+      @error_message = options[:error_message]
+      @hint = options[:hint]
+      @optional = fetch_or_fallback_boolean(options[:optional], fallback: false)
+      @page_heading = fetch_or_fallback_boolean(options[:page_heading], fallback: false)
+
+      @value = options[:value]
+      @additional_attributes = options[:additional_attributes]
     end
 
     def format_rows(rows)
       rows.to_i.zero? ? DEFAULT_ROWS : rows
     end
 
+    def page_heading?
+      @page_heading
+    end
+
+    def optional?
+      @optional
+    end
+
+    def required?
+      !optional?
+    end
+
+    def error?
+      @error_message.present?
+    end
+
+    def hint?
+      @hint.present?
+    end
+
+    def general_id
+      return id if @id.present?
+
+      name
+    end
+
+    def label_id
+      "#{general_id}-label"
+    end
+
+    def input_id
+      "#{general_id}-input"
+    end
+
+    def error_id
+      "#{general_id}-error"
+    end
+
+    def hint_id
+      "#{general_id}-hint"
+    end
+
+    def described_by
+      ids = []
+      ids << error_id if error?
+      ids << hint_id if hint?
+      ids.present? ? ids.join(" ") : nil
+    end
+
     def base_input_attributes
-      super.merge(rows: @rows, value: nil)
+      {
+        type: (@type.to_s.dasherize if @type.present?),
+        id: input_id,
+        name: name,
+        rows: @rows,
+        "aria-required": required?,
+        "aria-invalid": error?,
+        "aria-describedby": described_by
+      }
+    end
+
+    def input_attributes
+      if @additional_attributes.present?
+        base_input_attributes.merge @additional_attributes
+      else
+        base_input_attributes
+      end
     end
   end
 end

--- a/engine/spec/components/citizens_advice_components/select_spec.rb
+++ b/engine/spec/components/citizens_advice_components/select_spec.rb
@@ -85,4 +85,23 @@ RSpec.describe CitizensAdviceComponents::Select, type: :component do
     it { is_expected.to have_css "select[autocomplete=name]" }
     it { is_expected.to have_css "select[data-additional=example]" }
   end
+
+  context "when deprecated type argument is provided" do
+    before do
+      allow(CitizensAdviceComponents.deprecator).to receive(:warn)
+
+      render_inline described_class.new(
+        select_options: select_options,
+        name: name.presence,
+        label: label.presence,
+        options: options,
+        type: :text
+      )
+    end
+
+    it "logs deprecation warning" do
+      expect(CitizensAdviceComponents.deprecator).to have_received(:warn)
+        .with(/type argument is deprecated/)
+    end
+  end
 end

--- a/engine/spec/components/citizens_advice_components/textarea_spec.rb
+++ b/engine/spec/components/citizens_advice_components/textarea_spec.rb
@@ -38,7 +38,6 @@ RSpec.describe CitizensAdviceComponents::Textarea, type: :component do
         name: "example-input[test]",
         id: "test-id",
         label: "Example input",
-        type: :text,
         options: { hint: "This is the hint text",
                    error_message: "Enter your name" }
       )
@@ -154,20 +153,6 @@ RSpec.describe CitizensAdviceComponents::Textarea, type: :component do
     it { is_expected.to have_css "textarea[aria-describedby='example-textarea-error example-textarea-hint']" }
   end
 
-  context "when a type is specified" do
-    before do
-      render_inline described_class.new(
-        name: "example-textarea",
-        label: "Example textarea",
-        type: :email
-      )
-    end
-
-    it "does not render the type attribute" do
-      expect(page).to have_no_css "textarea[type]"
-    end
-  end
-
   context "when additional attributes are provided" do
     before do
       render_inline described_class.new(
@@ -208,6 +193,23 @@ RSpec.describe CitizensAdviceComponents::Textarea, type: :component do
 
     it "renders the default number of rows" do
       expect(page).to have_css "textarea[rows=8]"
+    end
+  end
+
+  context "when deprecated type argument is provided" do
+    before do
+      allow(CitizensAdviceComponents.deprecator).to receive(:warn)
+
+      render_inline described_class.new(
+        name: "example-textarea",
+        label: "Example textarea",
+        type: :text
+      )
+    end
+
+    it "logs deprecation warning" do
+      expect(CitizensAdviceComponents.deprecator).to have_received(:warn)
+        .with(/type argument is deprecated/)
     end
   end
 end


### PR DESCRIPTION
A re-do of #3740 and #3741 to simplify the Textarea and Select component interfaces respectively with the key difference of logging a deprecation warning for the inherited `type` attribute rather than straight removing it to give time for consuming applications to update their code first.