### PR TITLE
Refactor cads_error_summary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 **New**
 
 - Support custom `type` when using `cads_text_field`
+- Support `heading_level` option when using `cads_error_summary`
 
 ## v9.0.0
 

--- a/engine/app/helpers/citizens_advice_components/form_builder.rb
+++ b/engine/app/helpers/citizens_advice_components/form_builder.rb
@@ -39,8 +39,15 @@ module CitizensAdviceComponents
       Elements::Button.new(@template, object, button_text: button_text, **).render
     end
 
-    def cads_error_summary
-      Elements::ErrorSummary.new(@template, object, :unused).render
+    # Custom method to display a list of errors where validation errors are present
+    # f.cads_error_summary
+    def cads_error_summary(options = {})
+      Elements::ErrorSummary.new(
+        self,
+        @template,
+        object,
+        options
+      ).render
     end
 
     def cads_check_box(attribute, label: nil, **)

--- a/engine/app/lib/citizens_advice_components/elements/error_summary.rb
+++ b/engine/app/lib/citizens_advice_components/elements/error_summary.rb
@@ -2,27 +2,63 @@
 
 module CitizensAdviceComponents
   module Elements
-    class ErrorSummary < Field
-      def render
-        component = CitizensAdviceComponents::ErrorSummary.new
-        component.with_errors(error_messages)
+    class ErrorSummary < Base
+      attr_reader :builder, :template, :object
+      attr_accessor :options
 
-        component.render_in(@template)
+      def initialize(builder, template, object, options)
+        super(builder, template, object)
+
+        @options = options.with_defaults({ heading_level: 2 })
+      end
+
+      def render
+        return unless object.errors.any?
+
+        tag.div(
+          class: "cads-error-summary js-error-summary",
+          "data-testid": "error-summary",
+          "aria-labelledby": "error-summary-title",
+          "aria-live": "assertive",
+          role: "alert",
+          tabindex: "0",
+          autofocus: autofocus?
+        ) do
+          render_heading + render_error_messages
+        end
       end
 
       private
 
-      def error_messages
-        object.errors.group_by_attribute.map do |attr, errors|
-          {
-            href: "##{field_id_for(attr)}-input",
-            message: errors.first.full_message
-          }
+      def render_heading
+        content_tag(
+          :"h#{heading_level}",
+          id: "error-summary-title",
+          class: "cads-error-summary__title"
+        ) do
+          I18n.t("citizens_advice_components.error_summary.title")
         end
       end
 
-      def field_id_for(attribute)
-        @template.field_id(object_name, attribute)
+      def render_error_messages
+        tag.ul(class: "cads-error-summary__list") do
+          items = object.errors.group_by_attribute.map do |attribute, errors|
+            tag.li do
+              tag.a(href: "##{builder.field_id(attribute)}-input", class: "js-error-summary-link") do
+                errors.first.full_message
+              end
+            end
+          end
+          safe_join(items)
+        end
+      end
+
+      def autofocus?
+        fetch_or_fallback_boolean(options[:autofocus], fallback: true)
+      end
+
+      def heading_level
+        options[:heading_level].to_i.clamp(2, 6)
       end
     end
   end

--- a/engine/spec/helpers/citizens_advice_components/form_builder_cads_error_summary_spec.rb
+++ b/engine/spec/helpers/citizens_advice_components/form_builder_cads_error_summary_spec.rb
@@ -56,7 +56,6 @@ RSpec.describe CitizensAdviceComponents::FormBuilder do
       let(:error_summary) { builder.cads_error_summary(heading_level: 3) }
 
       it "renders title with correct heading level" do
-        pending "Not yet implemented"
         model.valid? # Trigger validations
         render_inline error_summary
         expect(page).to have_css "h3", text: "There is a problem"


### PR DESCRIPTION
Builds on from https://github.com/citizensadvice/design-system/pull/3849

Updates the error summary component to decouple rendering from the view component interface. In the process add missing support for the `heading_level` option.