### PR TITLE
Define new base class for form builder fields

### DIFF
--- a/engine/app/lib/citizens_advice_components/elements/base.rb
+++ b/engine/app/lib/citizens_advice_components/elements/base.rb
@@ -1,80 +1,22 @@
 # frozen_string_literal: true
 
-require "active_support/core_ext/module/delegation"
-
 module CitizensAdviceComponents
   module Elements
     class Base
       include CitizensAdviceComponents::FetchOrFallbackHelper
-      include ActionView::Context
+      include ActionView::Helpers::TagHelper
+      include FetchOrFallbackHelper
 
-      delegate :content_tag, :tag, :safe_join, :link_to, :capture, to: :@template
+      attr_reader :builder, :template, :object
 
-      attr_reader :template, :object, :attribute
-      attr_accessor :options
-
-      def initialize(template, object, attribute, **kwargs)
+      def initialize(
+        builder,
+        template,
+        object
+      )
+        @builder = builder
         @template = template
         @object = object
-        @attribute = attribute
-
-        @options = kwargs.with_defaults(default_options)
-      end
-
-      def render
-        # NO OP
-      end
-
-      private
-
-      def current_value
-        object.send(attribute)
-      end
-
-      def default_options
-        {}
-      end
-
-      def error_message
-        object.errors.full_messages_for(attribute)&.first
-      end
-
-      def object_name
-        object.to_model.model_name.singular
-      end
-
-      def field_name
-        template.field_name(object_name, attribute)
-      end
-
-      def field_id
-        template.field_id(object_name, attribute)
-      end
-
-      def label
-        options[:label] || object.class.human_attribute_name(attribute)
-      end
-
-      def hint
-        options[:hint]
-      end
-
-      def optional
-        !!!options[:required]
-      end
-
-      def error?
-        error_message.present?
-      end
-
-      def error_marker
-        return "" unless error?
-
-        tag.div(class: "cads-form-field__error-marker")
-      end
-
-      def form_field_classes
-        class_names("cads-form-field", "cads-form-field--has-error": error?)
       end
     end
   end

--- a/engine/app/lib/citizens_advice_components/elements/button.rb
+++ b/engine/app/lib/citizens_advice_components/elements/button.rb
@@ -2,7 +2,7 @@
 
 module CitizensAdviceComponents
   module Elements
-    class Button < Base
+    class Button < Field
       def initialize(template, object, button_text: nil, **)
         super(template, object, nil, **)
 

--- a/engine/app/lib/citizens_advice_components/elements/check_box.rb
+++ b/engine/app/lib/citizens_advice_components/elements/check_box.rb
@@ -2,7 +2,7 @@
 
 module CitizensAdviceComponents
   module Elements
-    class CheckBox < Base
+    class CheckBox < Field
       def render
         safe_join([hidden_field, checkbox_field])
       end

--- a/engine/app/lib/citizens_advice_components/elements/collections/base.rb
+++ b/engine/app/lib/citizens_advice_components/elements/collections/base.rb
@@ -3,7 +3,7 @@
 module CitizensAdviceComponents
   module Elements
     module Collections
-      class Base < CitizensAdviceComponents::Elements::Base
+      class Base < CitizensAdviceComponents::Elements::Field
         include ActionView::Helpers::FormOptionsHelper
 
         private

--- a/engine/app/lib/citizens_advice_components/elements/date_input.rb
+++ b/engine/app/lib/citizens_advice_components/elements/date_input.rb
@@ -2,7 +2,7 @@
 
 module CitizensAdviceComponents
   module Elements
-    class DateInput < Base
+    class DateInput < Field
       include ActionView::Helpers::TagHelper
 
       def render

--- a/engine/app/lib/citizens_advice_components/elements/error_summary.rb
+++ b/engine/app/lib/citizens_advice_components/elements/error_summary.rb
@@ -2,7 +2,7 @@
 
 module CitizensAdviceComponents
   module Elements
-    class ErrorSummary < Base
+    class ErrorSummary < Field
       def render
         component = CitizensAdviceComponents::ErrorSummary.new
         component.with_errors(error_messages)

--- a/engine/app/lib/citizens_advice_components/elements/field.rb
+++ b/engine/app/lib/citizens_advice_components/elements/field.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+require "active_support/core_ext/module/delegation"
+
+module CitizensAdviceComponents
+  module Elements
+    class Field
+      include CitizensAdviceComponents::FetchOrFallbackHelper
+      include ActionView::Context
+
+      delegate :content_tag, :tag, :safe_join, :link_to, :capture, to: :@template
+
+      attr_reader :template, :object, :attribute
+      attr_accessor :options
+
+      def initialize(template, object, attribute, **kwargs)
+        @template = template
+        @object = object
+        @attribute = attribute
+
+        @options = kwargs.with_defaults(default_options)
+      end
+
+      def render
+        # NO OP
+      end
+
+      private
+
+      def current_value
+        object.send(attribute)
+      end
+
+      def default_options
+        {}
+      end
+
+      def error_message
+        object.errors.full_messages_for(attribute)&.first
+      end
+
+      def object_name
+        object.to_model.model_name.singular
+      end
+
+      def field_name
+        template.field_name(object_name, attribute)
+      end
+
+      def field_id
+        template.field_id(object_name, attribute)
+      end
+
+      def label
+        options[:label] || object.class.human_attribute_name(attribute)
+      end
+
+      def hint
+        options[:hint]
+      end
+
+      def optional
+        !!!options[:required]
+      end
+
+      def error?
+        error_message.present?
+      end
+
+      def error_marker
+        return "" unless error?
+
+        tag.div(class: "cads-form-field__error-marker")
+      end
+
+      def form_field_classes
+        class_names("cads-form-field", "cads-form-field--has-error": error?)
+      end
+    end
+  end
+end

--- a/engine/app/lib/citizens_advice_components/elements/text_area.rb
+++ b/engine/app/lib/citizens_advice_components/elements/text_area.rb
@@ -2,7 +2,7 @@
 
 module CitizensAdviceComponents
   module Elements
-    class TextArea < Base
+    class TextArea < Field
       def render
         component = CitizensAdviceComponents::Textarea.new(
           name: field_name,

--- a/engine/app/lib/citizens_advice_components/elements/text_input.rb
+++ b/engine/app/lib/citizens_advice_components/elements/text_input.rb
@@ -2,7 +2,7 @@
 
 module CitizensAdviceComponents
   module Elements
-    class TextInput < Base
+    class TextInput < Field
       def render
         component = CitizensAdviceComponents::TextInput.new(
           name: field_name,


### PR DESCRIPTION
Preparatory change extracted from #3837 to introduce a new (unused) minimal Base class designed for cleaner inheritance for form builder methods.

Renames the current one `Field` to better reflect the current behaviour.