### PR TITLE
Scope website pages controller to top-level paths

### DIFF
--- a/website/app/controllers/pages_controller.rb
+++ b/website/app/controllers/pages_controller.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+# This controller is intended for top-level pages like /accessibility
+# for new sections add a dedicated controller and model for your content
 class PagesController < ApplicationController
   def show
     @page = Page.find(params[:slug])

--- a/website/config/routes.rb
+++ b/website/config/routes.rb
@@ -7,6 +7,6 @@ Rails.application.routes.draw do
   resources :components, only: %i[index show], param: :slug
   get "/examples", to: "examples#index", as: :examples
   get "/examples/:category/:slug", to: "examples#show", as: :example
-  get "/*slug", to: "pages#show", as: :page, format: :html
+  get "/:slug", to: "pages#show", as: :page, format: :html
   match "/404", to: "errors#not_found", via: :all
 end


### PR DESCRIPTION
Quick quality of life change prompted by #3850 to limit the pages controller to top-level paths, just to help our future selves.