### PR TITLE
Define sections in shared helper

### DIFF
--- a/website/app/components/app_header_component.html.erb
+++ b/website/app/components/app_header_component.html.erb
@@ -1,6 +1,6 @@
 <%= render CitizensAdviceComponents::Header.new do |c| %>
-  <%- c.with_logo(title: title) do %>
-    <a href="/" title="<%= title %>" class="docs-logo">
+  <%- c.with_logo(title: t("global.title")) do %>
+    <a href="/" title="<%= t("global.title") %>" class="docs-logo">
       <svg viewBox="0 0 284 52" xmlns="http://www.w3.org/2000/svg">
         <path d="M48.9997 24.3939C48.9997 39.4659 36.1697 51.9999 23.0087 51.9999C23.0087 51.9999 24.5213 47.997 24.5 47.997C10.972 47.997 0 38.0058 0 24.421C0 10.934 10.969 0 24.5 0C38.031 0 49 10.934 49 24.421" />
         <path d="M79.9531 26.6719C79.9531 30.4323 78.8802 33.3125 76.7344 35.3125C74.599 37.3125 71.5104 38.3125 67.4688 38.3125H61V15.4688H68.1719C71.901 15.4688 74.7969 16.4531 76.8594 18.4219C78.9219 20.3906 79.9531 23.1406 79.9531 26.6719ZM74.9219 26.7969C74.9219 21.8906 72.7552 19.4375 68.4219 19.4375H65.8438V34.3125H67.9219C72.5885 34.3125 74.9219 31.8073 74.9219 26.7969Z" />
@@ -20,10 +20,5 @@
   <% end %>
 <% end %>
 <%= render CitizensAdviceComponents::Navigation.new(
-  links: [
-    { url: guides_path, title: t("sections.guides") },
-    { url: foundations_path, title: t("sections.foundations") },
-    { url: components_path, title: t("sections.components") },
-    { url: page_path("accessibility"), title: t("sections.accessibility") }
-  ]
+  links: navigation_sections
 ) %>

--- a/website/app/components/app_header_component.rb
+++ b/website/app/components/app_header_component.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
 class AppHeaderComponent < ViewComponent::Base
-  def title
-    "Citizens Advice Design System"
-  end
+  include SectionsHelper
 end

--- a/website/app/controllers/application_controller.rb
+++ b/website/app/controllers/application_controller.rb
@@ -8,6 +8,6 @@ class ApplicationController < ActionController::Base
   protected
 
   def cads_default_breadcrumbs
-    [{ title: t("sections.home"), url: home_path }]
+    [{ title: t("global.home"), url: home_path }]
   end
 end

--- a/website/app/controllers/components_controller.rb
+++ b/website/app/controllers/components_controller.rb
@@ -8,7 +8,7 @@ class ComponentsController < ApplicationController
   def show
     @component = Component.find(params[:slug])
     cads_add_breadcrumb title: @component.title
-    set_meta_tags title: [t("sections.components"), @component.title]
+    set_meta_tags title: [t("sections.components.title"), @component.title]
   end
 
   private
@@ -18,6 +18,6 @@ class ComponentsController < ApplicationController
   end
 
   def set_breadcrumbs
-    cads_add_breadcrumb title: t("sections.components"), url: components_path
+    cads_add_breadcrumb title: t("sections.components.title"), url: components_path
   end
 end

--- a/website/app/controllers/foundations_controller.rb
+++ b/website/app/controllers/foundations_controller.rb
@@ -8,7 +8,7 @@ class FoundationsController < ApplicationController
   def show
     @foundation = Foundation.find(params[:slug])
     cads_add_breadcrumb title: @foundation.title
-    set_meta_tags title: [t("sections.foundations"), @foundation.title]
+    set_meta_tags title: [t("sections.foundations.title"), @foundation.title]
   end
 
   private
@@ -18,6 +18,6 @@ class FoundationsController < ApplicationController
   end
 
   def set_breadcrumbs
-    cads_add_breadcrumb title: t("sections.foundations"), url: foundations_path
+    cads_add_breadcrumb title: t("sections.foundations.title"), url: foundations_path
   end
 end

--- a/website/app/controllers/guides_controller.rb
+++ b/website/app/controllers/guides_controller.rb
@@ -8,7 +8,7 @@ class GuidesController < ApplicationController
   def show
     @guide = Guide.find(params[:slug])
     cads_add_breadcrumb title: @guide.title
-    set_meta_tags title: [t("sections.guides"), @guide.title]
+    set_meta_tags title: [t("sections.guides.title"), @guide.title]
   end
 
   private
@@ -18,6 +18,6 @@ class GuidesController < ApplicationController
   end
 
   def set_breadcrumbs
-    cads_add_breadcrumb title: t("sections.guides"), url: guides_path
+    cads_add_breadcrumb title: t("sections.guides.title"), url: guides_path
   end
 end

--- a/website/app/controllers/patterns_controller.rb
+++ b/website/app/controllers/patterns_controller.rb
@@ -8,7 +8,7 @@ class PatternsController < ApplicationController
   def show
     @pattern = Pattern.find(params[:slug])
     cads_add_breadcrumb title: @pattern.title
-    set_meta_tags title: [t("sections.patterns"), @pattern.title]
+    set_meta_tags title: [t("sections.patterns.title"), @pattern.title]
   end
 
   private
@@ -18,6 +18,6 @@ class PatternsController < ApplicationController
   end
 
   def set_breadcrumbs
-    cads_add_breadcrumb title: t("sections.patterns"), url: patterns_path
+    cads_add_breadcrumb title: t("sections.patterns.title"), url: patterns_path
   end
 end

--- a/website/app/helpers/sections_helper.rb
+++ b/website/app/helpers/sections_helper.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module SectionsHelper
+  def navigation_sections
+    [
+      { url: guides_path, title: t("sections.guides.title"), description: t("sections.guides.description") },
+      { url: foundations_path, title: t("sections.foundations.title"), description: t("sections.foundations.description") },
+      { url: components_path, title: t("sections.components.title"), description: t("sections.components.description") },
+      { url: patterns_path, title: t("sections.patterns.title"), description: t("sections.patterns.description") },
+      { url: page_path("accessibility"), title: t("sections.accessibility.title"), description: t("sections.accessibility.description") }
+    ]
+  end
+end

--- a/website/app/views/components/index.html.erb
+++ b/website/app/views/components/index.html.erb
@@ -1,6 +1,6 @@
 <%= render CitizensAdviceComponents::PageContent.new do |c| %>
   <% c.with_main do %>
-    <h1 class="cads-page-title"><%= title t("sections.components") %></h1>
+    <h1 class="cads-page-title"><%= title t("sections.components.title") %></h1>
     <div class="text-list">
       <ul class="text-list__links">
         <% @components.each do |component| %>

--- a/website/app/views/components/show.html.erb
+++ b/website/app/views/components/show.html.erb
@@ -12,7 +12,7 @@
   <% c.with_sidebar do %>
     <%= render CitizensAdviceComponents::SectionLinks.new(
       title: "In this section",
-      section_title: t("sections.components"),
+      section_title: t("sections.components.title"),
       section_title_url: components_path
     ) do |section_links|
       section_links.with_section_links(@components.map do |component|

--- a/website/app/views/foundations/index.html.erb
+++ b/website/app/views/foundations/index.html.erb
@@ -1,6 +1,6 @@
 <%= render CitizensAdviceComponents::PageContent.new do |c| %>
   <% c.with_main do %>
-    <h1 class="cads-page-title"><%= title t("sections.foundations") %></h1>
+    <h1 class="cads-page-title"><%= title t("sections.foundations.title") %></h1>
     <div class="text-list">
       <ul class="text-list__links">
         <% @foundations.each do |foundation| %>

--- a/website/app/views/foundations/show.html.erb
+++ b/website/app/views/foundations/show.html.erb
@@ -10,7 +10,7 @@
   <% c.with_sidebar do %>
     <%= render CitizensAdviceComponents::SectionLinks.new(
       title: "In this section",
-      section_title: t("sections.foundations"),
+      section_title: t("sections.foundations.title"),
       section_title_url: foundations_path
     ) do |section_links|
       section_links.with_section_links(@foundations.map do |foundation|

--- a/website/app/views/guides/index.html.erb
+++ b/website/app/views/guides/index.html.erb
@@ -1,6 +1,6 @@
 <%= render CitizensAdviceComponents::PageContent.new do |c| %>
   <% c.with_main do %>
-    <h1 class="cads-page-title"><%= title t("sections.guides") %></h1>
+    <h1 class="cads-page-title"><%= title t("sections.guides.title") %></h1>
     <div class="text-list">
       <ul class="text-list__links">
         <% @guides.each do |guide| %>

--- a/website/app/views/home/index.html.erb
+++ b/website/app/views/home/index.html.erb
@@ -2,20 +2,10 @@
   <% c.with_main do %>
     <h1 class="cads-page-title"><%= t("global.title") %></h1>
     <div class="cads-prose">
-      <h2><%= link_to t("sections.guides"), guides_path %></h2>
-      <p>Guides on how to use the Citizens Advice Design System in your product.</p>
-
-      <h2><%= link_to t("sections.foundations"), foundations_path %></h2>
-      <p>Foundations including colours, fonts, spacing, icons, and borders.</p>
-
-      <h2><%= link_to t("sections.components"), components_path %></h2>
-      <p>Documentation for each component in the design system e.g. targeted content.</p>
-
-      <h2><%= link_to t("sections.patterns"), patterns_path %></h2>
-      <p>Documentation for each pattern in the design system - for example, asking for names.</p>
-
-      <h2><%= link_to t("sections.accessibility"), page_path("accessibility") %></h2>
-      <p>Accessibility guidance and general accessibility information.</p>
+      <% navigation_sections.each do |section| %>
+        <h2><%= link_to section[:title], section[:url] %></h2>
+        <p><%= section[:description] %></p>
+      <% end %>
     </div>
   <% end %>
 <% end %>

--- a/website/app/views/patterns/index.html.erb
+++ b/website/app/views/patterns/index.html.erb
@@ -1,6 +1,6 @@
 <%= render CitizensAdviceComponents::PageContent.new do |c| %>
   <% c.with_main do %>
-    <h1 class="cads-page-title"><%= title t("sections.patterns") %></h1>
+    <h1 class="cads-page-title"><%= title t("sections.patterns.title") %></h1>
     <div class="cads-prose-direct-descendants">
       <p>Patterns are groups of components that form a reusable solution to a design problem. Use them to help users complete a specific task or navigate a page type.</p>
       <p>Each pattern in this section includes:</p>

--- a/website/config/locales/en.yml
+++ b/website/config/locales/en.yml
@@ -1,10 +1,20 @@
 en:
   global:
     title: "Citizens Advice Design System"
-  sections:
     home: Home
-    guides: Guides
-    patterns: Patterns
-    foundations: Foundations
-    components: Components
-    accessibility: Accessibility
+  sections:
+    guides:
+      title: Guides
+      description: Guides on how to use the Citizens Advice Design System in your product.
+    foundations:
+      title: Foundations
+      description: Foundations including colours, fonts, spacing, icons, and borders.
+    components:
+      title: Components
+      description: Documentation for each component in the design system e.g. targeted content.
+    patterns:
+      title: Patterns
+      description: Documentation for each pattern in the design system - for example, asking for names.
+    accessibility:
+      title: Accessibility
+      description: Accessibility guidance and general accessibility information.


### PR DESCRIPTION
Realised the wonderful new patterns section is missing from the top navigation. If this is intentional then we can close this, but assuming it should be figured we might as well share this definition somehow.