### PR TITLE
Docs: Fix patterns section title

### DIFF
--- a/website/app/views/patterns/show.html.erb
+++ b/website/app/views/patterns/show.html.erb
@@ -12,7 +12,7 @@
   <% c.with_sidebar do %>
     <%= render CitizensAdviceComponents::SectionLinks.new(
       title: "In this section",
-      section_title: t("sections.patterns"),
+      section_title: t("sections.patterns.title"),
       section_title_url: patterns_path
     ) do |section_links|
       section_links.with_section_links(@patterns.map do |pattern|


### PR DESCRIPTION
When #3852 went in I missed a spot where the title needed updating.

Before:

<img width="384" height="340" alt="Screenshot 2025-11-06 at 09 31 15" src="https://github.com/user-attachments/assets/8e8ee2a5-613e-4008-9826-4213f0c0ccd5" />

After:

<img width="184" height="184" alt="Screenshot 2025-11-06 at 09 34 19" src="https://github.com/user-attachments/assets/6606a21c-138f-4c60-a5f4-789607941bbc" />

