### PR TITLE
Experimental: Add character count to textareas

### DIFF
--- a/demo/app/assets/javascript/application.js
+++ b/demo/app/assets/javascript/application.js
@@ -5,6 +5,7 @@ import {
   initOnThisPage,
   initDisclosure,
   initErrorSummary,
+  initCharacterCount
 } from '@citizensadvice/design-system';
 
 initHeader();
@@ -13,3 +14,4 @@ initTargetedContent();
 initOnThisPage();
 initDisclosure();
 initErrorSummary();
+initCharacterCount();

--- a/demo/cypress/e2e/character-count.cy.js
+++ b/demo/cypress/e2e/character-count.cy.js
@@ -1,0 +1,88 @@
+describe("Character count", () => {
+  describe("english language", () => {
+    it("has a character counter", () => {
+      cy.visitComponentUrl("textarea/with_character_count");
+      cy.findByTestId("character-count").should(
+        "have.text",
+        "You have 1000 characters remaining",
+      );
+    });
+
+    it("counts characters as the user types", () => {
+      cy.visitComponentUrl("textarea/with_character_count");
+      cy.findByLabelText("Example input").type("Some initial text.");
+
+      cy.findByTestId("character-count").should(
+        "have.text",
+        "You have 982 characters remaining",
+      );
+    });
+
+    it("displays the amount over if exceeding the limit", () => {
+      cy.visitComponentUrl("textarea/with_character_count");
+
+      cy.findByLabelText("Example input").type(tooMuchText().trim(), {
+        delay: 0,
+      });
+
+      cy.findByTestId("character-count").should(
+        "have.text",
+        "You have 412 characters too many",
+      );
+    });
+  });
+
+  describe("welsh language", () => {
+    it("has a character counter", () => {
+      cy.visitComponentUrl("textarea/with_character_count?locale=cy");
+      cy.findByTestId("character-count").should(
+        "have.text",
+        "You have 1000 characters remaining (cy)",
+      );
+    });
+
+    it("counts characters as the user types", () => {
+      cy.visitComponentUrl("textarea/with_character_count?locale=cy");
+      cy.findByLabelText("Example input").type("Some initial text.");
+
+      cy.findByTestId("character-count").should(
+        "have.text",
+        "You have 982 characters remaining (cy)",
+      );
+    });
+
+    it("displays the amount over if exceeding the limit", () => {
+      cy.visitComponentUrl("textarea/with_character_count?locale=cy");
+
+      cy.findByLabelText("Example input").type(tooMuchText().trim(), {
+        delay: 0,
+      });
+
+      cy.findByTestId("character-count").should(
+        "have.text",
+        "You have 412 characters too many (cy)",
+      );
+    });
+  });
+
+  function tooMuchText() {
+    return `Alice was beginning to get very tired of sitting by her sister on the bank,
+      and of having nothing to do: once or twice she had peeped into the book her sister was reading,
+      but it had no pictures or conversations in it, “and what is the use of a book,” thought Alice
+      “without pictures or conversations?”
+
+      So she was considering in her own mind (as well as she could, for the hot day made her feel very
+      sleepy and stupid), whether the pleasure of making a daisy-chain would be worth the trouble of
+      getting up and picking the daisies, when suddenly a White Rabbit with pink eyes ran close by her.
+
+      There was nothing so very remarkable in that; nor did Alice think it so very much out of the way
+      to hear the Rabbit say to itself, “Oh dear! Oh dear! I shall be late!” (when she thought it over
+      afterwards, it occurred to her that she ought to have wondered at this, but at the time it all
+      seemed quite natural); but when the Rabbit actually took a watch out of its waistcoat-pocket,
+      and looked at it, and then hurried on, Alice started to her feet, for it flashed across her mind
+      that she had never before seen a rabbit with either a waistcoat-pocket, or a watch to take out of it,
+      and burning with curiosity, she ran across the field after it, and fortunately was just in time to see
+      it pop down a large rabbit-hole under the hedge.
+    `;
+  }
+});

--- a/demo/spec/components/previews/textarea_preview.rb
+++ b/demo/spec/components/previews/textarea_preview.rb
@@ -37,6 +37,19 @@ class TextareaPreview < ViewComponent::Preview
     )
   end
 
+  def with_character_count
+    render(
+      CitizensAdviceComponents::Textarea.new(
+        name: "example-input-character-count",
+        label: "Example input",
+        type: :text,
+        options: {
+          character_count: 1000
+        }
+      )
+    )
+  end
+
   def error
     render CitizensAdviceComponents::Textarea.new(
       name: "example-input-error",

--- a/engine/app/components/citizens_advice_components/textarea.html.erb
+++ b/engine/app/components/citizens_advice_components/textarea.html.erb
@@ -22,6 +22,11 @@
         <%= error_message %>
       </p>
     <% end %>
-    <%= content_tag(:textarea, value, class: "cads-textarea", **input_attributes) %>
+    <%= content_tag(:textarea, value, class: ["cads-textarea", ("js-cads-character-count" if character_count?)], **input_attributes) %>
+    <% if character_count? %>
+      <div id="<%= character_count_id %>" class="cads-character-count js-cads-character-count-fallback">
+        <%= t("citizens_advice_components.character_count.fallback", character_count: character_count) %>
+      </div>
+    <% end %>
   </div>
 </div>

--- a/engine/app/components/citizens_advice_components/textarea.rb
+++ b/engine/app/components/citizens_advice_components/textarea.rb
@@ -4,7 +4,7 @@ module CitizensAdviceComponents
   class Textarea < Base
     DEFAULT_ROWS = 8
 
-    attr_reader :name, :label, :error_message, :hint, :value, :id
+    attr_reader :name, :label, :error_message, :hint, :value, :id, :character_count
 
     def initialize(name:, label:, rows: DEFAULT_ROWS, id: nil, options: nil, type: nil)
       @name = name
@@ -34,6 +34,7 @@ module CitizensAdviceComponents
       @hint = options[:hint]
       @optional = fetch_or_fallback_boolean(options[:optional], fallback: false)
       @page_heading = fetch_or_fallback_boolean(options[:page_heading], fallback: false)
+      @character_count = options[:character_count]
 
       @value = options[:value]
       @additional_attributes = options[:additional_attributes]
@@ -41,6 +42,10 @@ module CitizensAdviceComponents
 
     def format_rows(rows)
       rows.to_i.zero? ? DEFAULT_ROWS : rows
+    end
+
+    def character_count?
+      @character_count.present?
     end
 
     def page_heading?
@@ -85,10 +90,15 @@ module CitizensAdviceComponents
       "#{general_id}-hint"
     end
 
+    def character_count_id
+      "#{general_id}-info"
+    end
+
     def described_by
       ids = []
       ids << error_id if error?
       ids << hint_id if hint?
+      ids << character_count_id if character_count?
       ids.present? ? ids.join(" ") : nil
     end
 
@@ -104,12 +114,29 @@ module CitizensAdviceComponents
       }
     end
 
+    def character_count_attributes
+      return {} unless character_count?
+
+      {
+        "data-character-count": character_count,
+        "data-character-count-over-limit": t("citizens_advice_components.character_count.over_limit"),
+        "data-character-count-remaining-zero": t("citizens_advice_components.character_count.remaining_zero"),
+        "data-character-count-remaining-one": t("citizens_advice_components.character_count.remaining_one"),
+        "data-character-count-remaining-other": t("citizens_advice_components.character_count.remaining_other")
+      }
+    end
+
+    def additional_attributes
+      return {} if @additional_attributes.blank?
+
+      @additional_attributes
+    end
+
     def input_attributes
-      if @additional_attributes.present?
-        base_input_attributes.merge @additional_attributes
-      else
-        base_input_attributes
-      end
+      base_input_attributes.merge(
+        character_count_attributes,
+        additional_attributes
+      )
     end
   end
 end

--- a/engine/app/lib/citizens_advice_components/elements/text_area.rb
+++ b/engine/app/lib/citizens_advice_components/elements/text_area.rb
@@ -25,8 +25,29 @@ module CitizensAdviceComponents
           "aria-required": required?,
           "aria-invalid": error?,
           "aria-describedby": described_by,
+          **character_count_attributes,
           **text_area_options
-        )
+        ) + render_character_count
+      end
+
+      def render_character_count
+        return unless character_count?
+
+        tag.div(id: character_count_id, class: "cads-character-count js-cads-character-count-fallback") do
+          I18n.t("citizens_advice_components.character_count.fallback", character_count: character_count)
+        end
+      end
+
+      def described_by
+        ids = []
+        ids << error_id if error?
+        ids << hint_id if hint.present?
+        ids << character_count_id if character_count?
+        ids.present? ? ids.join(" ") : nil
+      end
+
+      def character_count_id
+        "#{builder.field_id(attribute)}-info"
       end
 
       def text_area_options
@@ -35,7 +56,20 @@ module CitizensAdviceComponents
         # For backwards compatability merge in additional_options hash
         options_for_html
           .without(:rows)
+          .without(:character_count)
           .merge(options[:additional_attributes] || {})
+      end
+
+      def character_count_attributes
+        return {} unless character_count?
+
+        {
+          "data-character-count": character_count,
+          "data-character-count-over-limit": I18n.t("citizens_advice_components.character_count.over_limit"),
+          "data-character-count-remaining-zero": I18n.t("citizens_advice_components.character_count.remaining_zero"),
+          "data-character-count-remaining-one": I18n.t("citizens_advice_components.character_count.remaining_one"),
+          "data-character-count-remaining-other": I18n.t("citizens_advice_components.character_count.remaining_other")
+        }
       end
 
       def additional_attributes_deprecation
@@ -44,6 +78,14 @@ module CitizensAdviceComponents
         CitizensAdviceComponents.deprecator.warn(
           "additional_attributes hash is deprecated, pass directly via options hash"
         )
+      end
+
+      def character_count?
+        character_count.present?
+      end
+
+      def character_count
+        options[:character_count]
       end
 
       def rows

--- a/engine/config/locales/cy.yml
+++ b/engine/config/locales/cy.yml
@@ -24,6 +24,12 @@ cy:
       dropdown_aria_label_close: Cau llywio
     input:
       optional: dewisol
+    character_count:
+      fallback: You can enter up to %{character_count} characters (cy)
+      over_limit: You have CHARACTER_COUNT characters too many (cy)
+      remaining_zero: You have 0 characters remaining (cy)
+      remaining_one: You have 1 character remaining (cy)
+      remaining_other: You have CHARACTER_COUNT characters remaining (cy)
     date_input:
       year: Blwyddyn
       month: Mis

--- a/engine/config/locales/en.yml
+++ b/engine/config/locales/en.yml
@@ -24,6 +24,12 @@ en:
       dropdown_aria_label_close: Close navigation
     input:
       optional: optional
+    character_count:
+      fallback: You can enter up to %{character_count} characters
+      over_limit: You have CHARACTER_COUNT characters too many
+      remaining_zero: You have 0 characters remaining
+      remaining_one: You have 1 character remaining
+      remaining_other: You have CHARACTER_COUNT characters remaining
     date_input:
       year: Year
       month: Month

--- a/engine/spec/components/citizens_advice_components/textarea_spec.rb
+++ b/engine/spec/components/citizens_advice_components/textarea_spec.rb
@@ -196,6 +196,32 @@ RSpec.describe CitizensAdviceComponents::Textarea, type: :component do
     end
   end
 
+  context "when a character count is provided" do
+    before do
+      render_inline described_class.new(
+        name: "example-textarea",
+        label: "Example textarea",
+        options: { character_count: 500 }
+      )
+    end
+
+    it "passes the character count onto the component" do
+      expect(page).to have_css "textarea[data-character-count=500]"
+    end
+
+    it "displays a fallback character count message" do
+      expect(page).to have_text "You can enter up to 500 characters"
+    end
+
+    context "when welsh language" do
+      around { |example| I18n.with_locale(:cy) { example.run } }
+
+      it "displays a welsh language fallback character count message" do
+        expect(page).to have_text "You can enter up to 500 characters (cy)"
+      end
+    end
+  end
+
   context "when deprecated type argument is provided" do
     before do
       allow(CitizensAdviceComponents.deprecator).to receive(:warn)

--- a/engine/spec/helpers/citizens_advice_components/form_builder_cads_text_area_spec.rb
+++ b/engine/spec/helpers/citizens_advice_components/form_builder_cads_text_area_spec.rb
@@ -98,6 +98,30 @@ RSpec.describe CitizensAdviceComponents::FormBuilder do
       end
     end
 
+    context "when a character count is provided" do
+      let(:field) { builder.cads_text_area(:address, character_count: 500) }
+
+      before do
+        render_inline field
+      end
+
+      it "passes the character count onto the component" do
+        expect(page).to have_css "textarea[data-character-count=500]"
+      end
+
+      it "displays a fallback character count message" do
+        expect(page).to have_text "You can enter up to 500 characters"
+      end
+
+      context "when welsh language" do
+        around { |example| I18n.with_locale(:cy) { example.run } }
+
+        it "displays a welsh language fallback character count message" do
+          expect(page).to have_text "You can enter up to 500 characters (cy)"
+        end
+      end
+    end
+
     context "with deprecated additional_attributes hash" do
       let(:field) do
         builder.cads_text_area(
@@ -121,11 +145,12 @@ RSpec.describe CitizensAdviceComponents::FormBuilder do
       end
     end
 
-    context "with additional_attributes" do
+    context "with additional attributes" do
       let(:field) do
         builder.cads_text_area(
           :address,
-          autocomplete: "name", "data-additional": "example"
+          autocomplete: "name",
+          "data-additional": "example"
         )
       end
 

--- a/lib/character-count/character-count.js
+++ b/lib/character-count/character-count.js
@@ -1,0 +1,193 @@
+function getMaxCountFor(inputEl) {
+  // We don't use the maxlength attribute as:
+  //
+  // 1. This truncates text when pasting, causing data-loss
+  // 2. Products may prefer to treat character counts as an
+  //    enhancement, or to implement a slightly higher
+  //    actual limit server side.
+  //
+  // https://adamsilver.io/blog/dont-use-the-maxlength-attribute-to-stop-users-from-exceeding-the-limit/
+  const maxCountAttr = inputEl.getAttribute("data-character-count");
+  const maxCount = maxCountAttr ? parseInt(maxCountAttr, 10) : Infinity;
+  return maxCount;
+}
+
+function getI18nFor(inputEl) {
+  const getData = (name) =>
+    inputEl.getAttribute(`data-character-count-${name}`);
+
+  return {
+    overLimit:
+      getData("over-limit") || "You have CHARACTER_COUNT characters too many",
+    remainingZero:
+      getData("remaining-zero") || "You have 0 characters remaining",
+    remainingOne: getData("remaining-one") || "You have 1 character remaining",
+    remainingOther:
+      getData("remaining-other") ||
+      "You have CHARACTER_COUNT character remaining",
+  };
+}
+
+function buildMessageFor(elementCache, currentCount) {
+  if (currentCount < 0) {
+    return elementCache.i18n.overLimit.replace(
+      "CHARACTER_COUNT",
+      Math.abs(currentCount),
+    );
+  }
+
+  if (currentCount === 0) {
+    return elementCache.i18n.remainingZero;
+  }
+
+  if (currentCount === 1) {
+    return elementCache.i18n.remainingOne;
+  }
+
+  return elementCache.i18n.remainingOther.replace(
+    "CHARACTER_COUNT",
+    currentCount,
+  );
+}
+
+function buildCounterEl() {
+  // Create a visible element which is live updated on every keystroke,
+  // and a *screen reader* specific element which is updated less frequently.
+  // https://dav-idc.com/making-a-character-count-component-more-accessible/
+  return `<div class="cads-character-count js-cads-character-count-visible"
+    aria-hidden=true data-testid="character-count"
+  ></div>
+  <div class="cads-character-count-sr cads-visually-hidden js-cads-character-count-sr"
+    aria-live="polite"
+  ></div>`;
+}
+
+function updateVisibleCountMessage(elementCache, maxCount) {
+  const newCount = maxCount - (elementCache.input.value || "").length;
+  elementCache.counterVisible.textContent = buildMessageFor(
+    elementCache,
+    newCount,
+  );
+  elementCache.counterVisible.setAttribute(
+    "data-character-count-state",
+    newCount < 0 ? "invalid" : "valid",
+  );
+}
+
+function updateScreenReaderCountMessage(elementCache, maxCount) {
+  const newCount = maxCount - (elementCache.input.value || "").length;
+  elementCache.counterScreenReader.textContent = buildMessageFor(
+    elementCache,
+    newCount,
+  );
+}
+
+function updateCountMessage(elementCache, maxCount) {
+  updateVisibleCountMessage(elementCache, maxCount);
+  updateScreenReaderCountMessage(elementCache, maxCount);
+}
+
+function updateIfValueChanged(elementCache, maxCount, lastInputValue) {
+  if (elementCache.input.value !== lastInputValue) {
+    lastInputValue = elementCache.input.value;
+    updateCountMessage(elementCache, maxCount);
+  }
+}
+
+function handleKeyup(elementCache, maxCount, lastInputTimestamp) {
+  updateVisibleCountMessage(elementCache, maxCount);
+  lastInputTimestamp = Date.now();
+  return lastInputTimestamp;
+}
+
+function handleFocus(
+  elementCache,
+  maxCount,
+  lastInputTimestamp,
+  lastInputValue,
+  valueChecker,
+) {
+  valueChecker = window.setInterval(() => {
+    if (!lastInputTimestamp || Date.now() - 500 >= lastInputTimestamp) {
+      updateIfValueChanged(elementCache, maxCount, lastInputValue);
+    }
+  }, 1000);
+
+  return valueChecker;
+}
+
+// Cancel value checking on blur
+function handleBlur(valueChecker) {
+  if (valueChecker) {
+    window.clearInterval(valueChecker);
+  }
+}
+
+function init(inputEl) {
+  let lastInputTimestamp, lastInputValue, valueChecker;
+
+  // Base the parent on the closest form-field
+  const parentEl = inputEl.closest(".cads-form-field");
+
+  if (!parentEl) {
+    return;
+  }
+
+  const maxCount = getMaxCountFor(inputEl);
+
+  // Mark fallback character count text as visibly hidden
+  // https://dav-idc.com/making-a-character-count-component-more-accessible/
+  const fallback = parentEl.querySelector(".js-cads-character-count-fallback");
+  fallback.classList.add("cads-visually-hidden");
+
+  inputEl.insertAdjacentHTML("afterend", buildCounterEl());
+
+  const elementCache = {
+    input: inputEl,
+    i18n: getI18nFor(inputEl),
+    fallback: parentEl.querySelector(".js-cads-character-count-fallback"),
+    counterVisible: parentEl.querySelector(".js-cads-character-count-visible"),
+    counterScreenReader: parentEl.querySelector(".js-cads-character-count-sr"),
+  };
+
+  //Attach event listeners to dynamically update remaining characters
+  inputEl.addEventListener("keyup", () =>
+    handleKeyup(elementCache, maxCount, lastInputTimestamp),
+  );
+
+  // // Bind focus/blur events to start/stop polling
+  inputEl.addEventListener("focus", () =>
+    handleFocus(
+      elementCache,
+      maxCount,
+      lastInputTimestamp,
+      lastInputValue,
+      valueChecker,
+    ),
+  );
+
+  inputEl.addEventListener("blur", () => handleBlur(valueChecker));
+
+  // When the page is restored after navigating 'back' in some browsers the
+  // state of form controls is not restored until *after* the DOMContentLoaded
+  // event is fired, so we need to sync after the pageshow event.
+  window.addEventListener("pageshow", () =>
+    updateCountMessage(elementCache, maxCount),
+  );
+
+  // Initialize the character count
+  updateCountMessage(elementCache, maxCount);
+}
+
+/**
+ * Character counter component. Based on:
+ * 1. https://github.com/alphagov/govuk-frontend/blob/main/packages/govuk-frontend/src/govuk/components/character-count/character-count.mjs
+ * 2. https://dav-idc.com/making-a-character-count-component-more-accessible/
+ * 3. https://adamsilver.io/blog/dont-use-the-maxlength-attribute-to-stop-users-from-exceeding-the-limit/
+ */
+export default function initCharacterCount() {
+  const els = document.querySelectorAll(".js-cads-character-count");
+  els.forEach((inputEl) => {
+    init(inputEl);
+  });
+}

--- a/lib/character-count/index.js
+++ b/lib/character-count/index.js
@@ -1,0 +1,4 @@
+import initCharacterCount from "./character-count";
+
+export { initCharacterCount };
+export default initCharacterCount;

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -6,4 +6,5 @@ declare module "@citizensadvice/design-system" {
   export function initNavigation(): void;
   export function initOnThisPage(): void;
   export function initTargetedContent(): void;
+  export function initCharacterCount(): void;
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -5,6 +5,7 @@ import { initGreedyNav } from "./greedy-nav";
 import { initNavigation } from "./navigation";
 import { initOnThisPage } from "./on-this-page";
 import { initTargetedContent } from "./targeted-content";
+import { initCharacterCount } from "./character-count";
 
 export {
   initDisclosure,
@@ -14,4 +15,5 @@ export {
   initNavigation,
   initOnThisPage,
   initTargetedContent,
+  initCharacterCount,
 };

--- a/scss/6-components/forms/text-area.scss
+++ b/scss/6-components/forms/text-area.scss
@@ -23,3 +23,15 @@
     line-height: 1.75rem;
   }
 }
+
+/** @define character-count */
+.cads-character-count {
+  margin-top: $cads-spacing-2;
+  color: $cads-palette__dark-grey;
+  text-align: right;
+
+  &[data-character-count-state="invalid"] {
+    color: $cads-language__warning-colour;
+    font-weight: $cads-font-weight__bold;
+  }
+}

--- a/website/app/assets/javascript/standalone.js
+++ b/website/app/assets/javascript/standalone.js
@@ -7,7 +7,8 @@ import {
   initTargetedContent,
   initDisclosure,
   initOnThisPage,
-} from "@citizensadvice/design-system";
+  initCharacterCount,
+} from '@citizensadvice/design-system';
 
 try {
   initHeader();
@@ -15,6 +16,7 @@ try {
   initTargetedContent();
   initDisclosure();
   initOnThisPage();
+  initCharacterCount();
 } catch (error) {
   document.querySelector("html").classList.add("no-js");
   throw error;

--- a/website/app/assets/javascript/theme.js
+++ b/website/app/assets/javascript/theme.js
@@ -4,6 +4,7 @@ import {
   initTargetedContent,
   initDisclosure,
   initOnThisPage,
+  initCharacterCount
 } from "@citizensadvice/design-system";
 
 import initCodeCopy from "./components/code-copy";
@@ -16,6 +17,7 @@ try {
   initTargetedContent();
   initDisclosure();
   initOnThisPage();
+  initCharacterCount();
   initCodeCopy();
   initSampleCode();
   initComponentExamples();

--- a/website/content/components/textarea.md
+++ b/website/content/components/textarea.md
@@ -24,6 +24,10 @@ title: Textarea
 
 <%= render(ExampleComponent.new(:textarea, :with_error_message)) %>
 
+### With character count
+
+<%= render(ExampleComponent.new(:textarea, :with_character_count)) %>
+
 ### With value
 
 <%= render(ExampleComponent.new(:textarea, :with_value)) %>

--- a/website/content/examples/textarea/with_character_count.html.erb
+++ b/website/content/examples/textarea/with_character_count.html.erb
@@ -1,0 +1,9 @@
+---
+title: with character count
+---
+
+<%= render(CitizensAdviceComponents::Textarea.new(
+  name: "example-textarea-character-count",
+  label: "Example textarea (with character count)",
+  options: { character_count: 500 }
+)) %>


### PR DESCRIPTION
Fresh version of https://github.com/citizensadvice/design-system/pull/3708

## Background

We currently have a basic character counter in use on the referrals application. It's general enough and we have an open issue (#1691) that suggests it's worth making this available through the design system itself.

## Changes

Adds the scaffolding for a character count component supported by textareas. Takes care to follow the same accessibility patterns as the GOV.UK equivalent which has recently undergone some major accessibility improvements[^1].

This version also differs from the current version in our products in that it doesn't use `maxlength` as the limit. This is deliberate to avoid data-loss when pasting text[^2].

As a result this version has the following additional states:

1. A no-js fallback state
2. A error state when exceeding the character limit
3. A screen-reader only version of the character count which updates at a slower rate.

[^1]: https://dav-idc.com/making-a-character-count-component-more-accessible/
[^2]: https://adamsilver.io/blog/dont-use-the-maxlength-attribute-to-stop-users-from-exceeding-the-limit/