### PR TITLE
Decouple cads_textarea from view component interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,19 @@
 **New**
 
+- Allows `cads_text_field` and `cads_textarea` to be used without a model
 - Support custom `type` when using `cads_text_field`
-- Allows `cads_text_field` to be used without a model
+- Alias `cads_textarea` and `cads_text_area`
+- Allow passing additional attributes to `cads_textarea` e.g.
+
+  ```rb
+  cads_text_area(
+    :address,
+    autocomplete: "name",
+    "data-additional": "example"
+  )
+  ```
+
+  If using the previous named `additional_attributes` hash, this will log a deprecation warning and will be removed in a future version.
 
 ## v9.0.0
 

--- a/engine/app/helpers/citizens_advice_components/form_builder.rb
+++ b/engine/app/helpers/citizens_advice_components/form_builder.rb
@@ -15,9 +15,19 @@ module CitizensAdviceComponents
       ).render
     end
 
-    def cads_text_area(attribute, label: nil, hint: nil, required: false, **)
-      Elements::TextArea.new(@template, object, attribute, label: label, required: required, hint: hint, **).render
+    # Labelled text_area element
+    # https://api.rubyonrails.org/classes/ActionView/Helpers/FormBuilder.html#method-i-textarea
+    # f.cads_textarea(:address)
+    def cads_textarea(attribute, **options)
+      Elements::TextArea.new(
+        self,
+        @template,
+        object,
+        attribute,
+        options
+      ).render
     end
+    alias cads_text_area cads_textarea
 
     def cads_date_field(attribute, label: nil, hint: nil, required: false, **)
       Elements::DateInput.new(@template, object, attribute, label: label, required: required, hint: hint, **).render

--- a/engine/app/lib/citizens_advice_components/elements/text_area.rb
+++ b/engine/app/lib/citizens_advice_components/elements/text_area.rb
@@ -2,24 +2,52 @@
 
 module CitizensAdviceComponents
   module Elements
-    class TextArea < Field
-      def render
-        component = CitizensAdviceComponents::Textarea.new(
-          name: field_name,
-          id: field_id,
-          label: label,
-          rows: options[:rows],
-          options: {
-            hint: hint,
-            optional: optional,
-            value: current_value,
-            error_message: error_message,
-            additional_attributes: options[:additional_attributes],
-            page_heading: options[:page_heading].present?
-          }
-        )
+    class TextArea < Base
+      include Traits::Field
 
-        component.render_in(@template)
+      def initialize(builder, template, object, attribute, options)
+        super(builder, template, object)
+
+        @attribute = attribute
+        @options = options
+        additional_attributes_deprecation
+      end
+
+      private
+
+      def render_field
+        builder.text_area(
+          attribute,
+          class: "cads-textarea",
+          id: input_id,
+          rows: rows,
+          required: false, # use aria-required over required attribute
+          "aria-required": required?,
+          "aria-invalid": error?,
+          "aria-describedby": described_by,
+          **text_area_options
+        )
+      end
+
+      def text_area_options
+        # The default behaviour of text_field is to pass options on to the HTML element
+        # Extract any custom options that we don't want passing on and add expected defaults.
+        # For backwards compatability merge in additional_options hash
+        options_for_html
+          .without(:rows)
+          .merge(options[:additional_attributes] || {})
+      end
+
+      def additional_attributes_deprecation
+        return if options[:additional_attributes].blank?
+
+        CitizensAdviceComponents.deprecator.warn(
+          "additional_attributes hash is deprecated, pass directly via options hash"
+        )
+      end
+
+      def rows
+        options[:rows].to_i.zero? ? 8 : options[:rows]
       end
     end
   end

--- a/engine/spec/helpers/citizens_advice_components/form_builder_cads_text_area_spec.rb
+++ b/engine/spec/helpers/citizens_advice_components/form_builder_cads_text_area_spec.rb
@@ -108,8 +108,6 @@ RSpec.describe CitizensAdviceComponents::FormBuilder do
       end
 
       it "passes additional attributes through to element" do
-        pending "Not yet implemented"
-
         render_inline field
         expect(page).to have_css "textarea[autocomplete=name]"
         expect(page).to have_css "textarea[data-additional=example]"
@@ -166,8 +164,6 @@ RSpec.describe CitizensAdviceComponents::FormBuilder do
       let(:field) { builder.cads_text_area(:address) }
 
       it "can be used without a form model" do
-        pending "Not currently implemented"
-
         render_inline field
         expect(page).to have_css "textarea"
       end


### PR DESCRIPTION
Now that #3849 is in we can extract another step from #3837, this time to decouple the rendering of cads_textarea from the view component interface. Addresses a couple of pending tests in the process.