### PR TITLE
Decouple cads_check_box from view component interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,11 @@
 - Allows `cads_text_field` and `cads_textarea` to be used without a model
 - Alias `cads_textarea` and `cads_text_area`
 
-**Fixes**
+**Fix**
 
-- Fixes missing Welsh translations for internal text for all form builder fields
-- Fixes missing aria-describedby attributes on all `cads_collection` fields
+- Fix missing welsh translation for "Optional" label on all `cads_collection` fields
+- Fix missing aria-describedby attributes on all `cads_collection` fields
+- Fix bug where `cads_check_box` would generate HTML IDs based on name instead e.g. `example_form[confirmation]-error` vs `example_form_confirmation-error`
 
 **Deprecations**
 

--- a/engine/app/helpers/citizens_advice_components/form_builder.rb
+++ b/engine/app/helpers/citizens_advice_components/form_builder.rb
@@ -115,6 +115,19 @@ module CitizensAdviceComponents
       ).render
     end
 
+    # Labelled check_box field
+    # https://api.rubyonrails.org/v3.2/classes/ActionView/Helpers/FormHelper.html#method-i-check_box
+    # f.cads_text_field(:example)
+    def cads_check_box(attribute, label: nil, **)
+      Elements::CheckBox.new(
+        self,
+        @template,
+        object,
+        attribute,
+        label: label, **
+      ).render
+    end
+
     # Button element
     # f.cads_button "Submit complaint", icon_right: :arrow_right
     def cads_button(button_text = "Save changes", **)
@@ -135,10 +148,6 @@ module CitizensAdviceComponents
         object,
         options
       ).render
-    end
-
-    def cads_check_box(attribute, label: nil, **)
-      Elements::CheckBox.new(@template, object, attribute, label: label, **).render
     end
   end
 end

--- a/engine/app/lib/citizens_advice_components/elements/check_box.rb
+++ b/engine/app/lib/citizens_advice_components/elements/check_box.rb
@@ -2,32 +2,84 @@
 
 module CitizensAdviceComponents
   module Elements
-    class CheckBox < Field
-      def render
-        safe_join([hidden_field, checkbox_field])
+    class CheckBox < Base
+      include Traits::Field
+      include ActionView::Context
+
+      delegate :content_tag, :tag, :safe_join, :link_to, :capture, to: :@template
+
+      attr_reader :template, :object, :attribute
+      attr_accessor :options
+
+      def initialize(builder, template, object, attribute, **kwargs)
+        super(builder, template, object)
+
+        @attribute = attribute
+        @options = kwargs
+        additional_attributes_deprecation
       end
 
-      private
+      protected
 
-      def checkbox_field
-        component = CitizensAdviceComponents::CheckboxSingle.new(
-          name: field_name,
-          id: field_id,
-          error_message: error_message
+      # Single checkboxes behave a little differently
+      # where they use form *group* markup mixed in
+      # with *field* markup. This is because they share
+      # markup with a group of checkboxes. This results
+      # in some slightly off markup which suggests a
+      # refactoring is needed eventually.
+      def render_content
+        tag.div(class: "cads-form-field__content") do
+          tag.div(class: "cads-form-group cads-form-group--checkbox cads-checkbox-single") do
+            safe_join([render_error_message, render_item])
+          end
+        end
+      end
+
+      def render_item
+        tag.div(class: "cads-form-group__item") do
+          render_check_box + render_check_box_label
+        end
+      end
+
+      def render_check_box
+        builder.check_box(
+          attribute,
+          class: class_names("cads-form-group__input"),
+          id: input_id,
+          required: false, # use aria-required over required attribute
+          "aria-required": required?,
+          "aria-invalid": error?,
+          "aria-describedby": described_by,
+          **check_box_options
         )
-        component.with_checkbox(label: label,
-                                value: "1",
-                                checked: current_value,
-                                additional_attributes: options[:additional_attributes])
-
-        component.render_in(@template)
       end
 
-      def hidden_field
-        tag.input(
-          type: "hidden",
-          name: field_name,
-          value: "0"
+      def render_check_box_label
+        builder.label(attribute, class: "cads-form-group__label", id: label_id, for: input_id) do |label_builder|
+          label.presence || label_builder.translation
+        end
+      end
+
+      def fieldset_classes
+        class_names(
+          "cads-form-group",
+          "cads-form-group--checkbox",
+          "cads-checkbox-single"
+        )
+      end
+
+      def check_box_options
+        # The default behaviour of text_field is to pass options on to the HTML element
+        # Extract any custom options that we don't want passing on and add expected defaults.
+        # For backwards compatability merge in additional_options hash
+        options_for_html.merge(options[:additional_attributes] || {})
+      end
+
+      def additional_attributes_deprecation
+        return if options[:additional_attributes].blank?
+
+        CitizensAdviceComponents.deprecator.warn(
+          "additional_attributes hash is deprecated, pass directly via options hash"
         )
       end
     end

--- a/engine/spec/helpers/citizens_advice_components/form_builder_cads_check_box_spec.rb
+++ b/engine/spec/helpers/citizens_advice_components/form_builder_cads_check_box_spec.rb
@@ -24,8 +24,6 @@ RSpec.describe CitizensAdviceComponents::FormBuilder do
           checked: true
         )
 
-        pending "Bug: checkbox generates IDs by name"
-
         expect(page).to have_field(
           "example_form[confirmation]",
           with: "1",
@@ -51,25 +49,12 @@ RSpec.describe CitizensAdviceComponents::FormBuilder do
 
       it "renders error message" do
         expect(page).to have_css(
-          "[id='example_form[confirmation]-error']",
-          text: "Confirmation can't be blank"
-        )
-
-        pending "Bug: checkbox generates IDs by name"
-
-        expect(page).to have_css(
           "#example_form_confirmation-error",
           text: "Confirmation can't be blank"
         )
       end
 
       it "sets aria-describedby" do
-        expect(page).to have_css(
-          "input[aria-describedby='example_form[confirmation]-error']"
-        )
-
-        pending "Bug: checkbox generates IDs by name"
-
         expect(page).to have_css(
           "input[aria-describedby='example_form_confirmation-error']"
         )


### PR DESCRIPTION
Extracted from #3837. Decouples the rendering of `cads_check_box` fields from the view component interface. Fixes a small internal bug with IDs in the process.