### PR TITLE
Configure dependabot cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,8 @@ updates:
     directory: "/"
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 7
 
   ##
   # Top-level package
@@ -15,6 +17,8 @@ updates:
     directory: "/"
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 7
     groups:
       # Group everything except major version updates and security vulnerabilities
       regular-updates:
@@ -29,6 +33,8 @@ updates:
     directory: "/engine"
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 7
     groups:
       # Group everything except major version updates and security vulnerabilities
       regular-updates:
@@ -43,6 +49,8 @@ updates:
     directory: "/demo"
     schedule:
       interval: monthly
+    cooldown:
+      default-days: 7
     groups:
       # Group everything except major version updates and security vulnerabilities
       regular-updates:
@@ -54,6 +62,8 @@ updates:
     directory: "/demo"
     schedule:
       interval: monthly
+    cooldown:
+      default-days: 7
     groups:
       # Group everything except major version updates and security vulnerabilities
       regular-updates:
@@ -72,6 +82,8 @@ updates:
     directory: "/website"
     schedule:
       interval: monthly
+    cooldown:
+      default-days: 7
     groups:
       # Group everything except major version updates and security vulnerabilities
       regular-updates:
@@ -83,6 +95,8 @@ updates:
     directory: "/website"
     schedule:
       interval: monthly
+    cooldown:
+      default-days: 7
     groups:
       # Group everything except major version updates and security vulnerabilities
       regular-updates:


### PR DESCRIPTION
Mirrors configuration on other repositories using a 7 day cooldown for all ecosystems.