### PR TITLE
Refactor cads_button

### DIFF
--- a/engine/app/helpers/citizens_advice_components/form_builder.rb
+++ b/engine/app/helpers/citizens_advice_components/form_builder.rb
@@ -35,8 +35,15 @@ module CitizensAdviceComponents
       Elements::Collections::Select.new(@template, object, attribute, label: label, hint: hint, required: required, **).render
     end
 
+    # Button element
+    # f.cads_button "Submit complaint", icon_right: :arrow_right
     def cads_button(button_text = "Save changes", **)
-      Elements::Button.new(@template, object, button_text: button_text, **).render
+      Elements::Button.new(
+        self,
+        @template,
+        object,
+        button_text: button_text, **
+      ).render
     end
 
     def cads_error_summary

--- a/engine/app/lib/citizens_advice_components/elements/button.rb
+++ b/engine/app/lib/citizens_advice_components/elements/button.rb
@@ -2,13 +2,20 @@
 
 module CitizensAdviceComponents
   module Elements
-    class Button < Field
-      def initialize(template, object, button_text: nil, **)
-        super(template, object, nil, **)
+    class Button < Base
+      include ActionView::Context
+
+      attr_reader :builder, :template, :object, :options
+
+      def initialize(builder, template, object, button_text: nil, **kwargs)
+        super(builder, template, object)
 
         @button_text = button_text
-        @icon_left = options[:icon_left]
-        @icon_right = options[:icon_right]
+
+        @options = kwargs.with_defaults(default_options)
+
+        @icon_left = @options[:icon_left]
+        @icon_right = @options[:icon_right]
 
         @options.except!(:icon_left, :icon_right)
       end


### PR DESCRIPTION
Extracted from #3837. Very small refactor to decouple the button element from `Field`, instead using the new simplified `Base` class.