### PR TITLE
Set i18n_customize_full_message by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 **New**
 
-
+- Set `i18n_customize_full_message` by default
 - **Feature parity for Rails form builder components**:
 
   This release introduces some preparatory work to bring feature parity to the Rails form builder components and the original view component interfaces. This is preparation for a _future_ release which will make the form builder interfaces the default going fowards and eventuall deprecate the view component interfaces. If you have not yet moved your forms over to use Rails form builder methods this release should make it easier to do so.

--- a/demo/config/application.rb
+++ b/demo/config/application.rb
@@ -25,8 +25,6 @@ module Demo
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 8.1
 
-    config.active_model.i18n_customize_full_message = true
-
     config.view_component.show_previews = true
     config.view_component.previews.default_layout = "component_preview"
     config.view_component.previews.controller = "PreviewController"

--- a/engine/lib/citizens_advice_components/engine.rb
+++ b/engine/lib/citizens_advice_components/engine.rb
@@ -24,6 +24,25 @@ module CitizensAdviceComponents
       }
     end
 
+    # Our form builder uses the full_message method for displaying error messages.
+    # The Rails format is "%{attribute} %{message}" e.g. Name can't be blank
+    #
+    # We prefer a more plain english format, e.g. Enter your full name
+    #
+    # To allow customising this fully we require i18n_customize_full_message to be enabled.
+    # This then allows you to override the format in your locale files to something like this:
+    # en:
+    #   activemodel:
+    #     errors:
+    #       models:
+    #         person:
+    #           format: "%{message}"
+    #           attributes:
+    #             first_name:
+    #               blank: Enter your first name
+    # https://guides.rubyonrails.org/configuring.html#config-active-model-i18n-customize-full-message
+    config.active_model.i18n_customize_full_message = true
+
     # Ensure that application level configuration settings apply to
     # library specific deprecation warnings.
     # https://api.rubyonrails.org/classes/ActiveSupport/Deprecation.html


### PR DESCRIPTION
Extracted from #3920.

Our form builder uses the `full_message` method for displaying error messages.

The Rails format is `"%{attribute} %{message}"` e.g. Name can't be blank. We prefer a more plain english format, e.g. Enter your full name. To allow customising this fully we require `i18n_customize_full_message` to be enabled. This then allows you to override the format in your locale files to something like this:

```
en:
  activemodel:
    errors:
      models:
        person:
          format: "%{message}"
          attributes:
            first_name:
              blank: Enter your first name
```

See https://guides.rubyonrails.org/configuring.html#config-active-model-i18n-customize-full-message