### PR TITLE
Fix erb_lint in rake tasks

### DIFF
--- a/engine/Rakefile
+++ b/engine/Rakefile
@@ -16,7 +16,7 @@ RuboCop::RakeTask.new
 
 desc "Run ERB Lint"
 task :erb_lint do
-  `erb_lint --lint-all`
+  system "erb_lint --lint-all"
 end
 
 desc "Sync fonts between npm source and engine"

--- a/website/Rakefile
+++ b/website/Rakefile
@@ -14,7 +14,7 @@ RuboCop::RakeTask.new
 
 desc "Run ERB Lint"
 task :erb_lint do
-  `bin/erb_lint --lint-all`
+  system "bin/erb_lint --lint-all"
 end
 
 task lint: %i[rubocop erb_lint]


### PR DESCRIPTION
Turns out backticks only capture STDOUT, not STDERR which is no use for a lint task, so switch to `system` instead.