### PR TITLE
Amend form builder aliases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 - Support custom `type` when using `cads_text_field`
 - Allows `cads_text_field` and `cads_textarea` to be used without a model
 - Alias `cads_textarea` and `cads_text_area`
+- Alias `cads_collection_checkboxes` and `cads_collection_check_boxes`
+- Alias `cads_checkbox` and `cads_check_box`
 
 **Deprecations**
 

--- a/engine/app/helpers/citizens_advice_components/form_builder.rb
+++ b/engine/app/helpers/citizens_advice_components/form_builder.rb
@@ -44,8 +44,8 @@ module CitizensAdviceComponents
     end
 
     # Labelled collection_select element
-    # https://api.rubyonrails.org/classes/ActionView/Helpers/FormBuilder.html#method-i-collection_select
-    # f.cads_collection_select(:my_argument, Locations.all)
+    # https://api.rubyonrails.org/classes/ActionView/Helpers/FormBuilder.html#method-i-collection_radio_buttons
+    # f.cads_collection_radio_buttons(:my_argument, Locations.all)
     def cads_collection_radio_buttons(
       attribute,
       collection_arg = nil,
@@ -68,9 +68,9 @@ module CitizensAdviceComponents
     end
 
     # Labelled collection_check_boxes element
-    # https ://api.rubyonrails.org/classes/ActionView/Helpers/FormBuilder.html#method-i-collection_select
+    # https://api.rubyonrails.org/classes/ActionView/Helpers/FormBuilder.html#method-i-collection_checkboxes
     # f.cads_collection_check_boxes(:my_argument, Locations.all, :id, :name)
-    def cads_collection_check_boxes(
+    def cads_collection_checkboxes(
       attribute,
       collection_arg = nil,
       value_method_arg = nil,
@@ -90,9 +90,10 @@ module CitizensAdviceComponents
         html_options
       ).render
     end
+    alias cads_collection_check_boxes cads_collection_checkboxes
 
     # Labelled collection_select element
-    # https ://api.rubyonrails.org/classes/ActionView/Helpers/FormBuilder.html#method-i-collection_select
+    # https://api.rubyonrails.org/classes/ActionView/Helpers/FormBuilder.html#method-i-collection_select
     # f.cads_collection_select(:my_argument, Locations.all, :id, :name)
     def cads_collection_select(
       attribute,
@@ -116,9 +117,9 @@ module CitizensAdviceComponents
     end
 
     # Labelled check_box field
-    # https://api.rubyonrails.org/v3.2/classes/ActionView/Helpers/FormHelper.html#method-i-check_box
-    # f.cads_text_field(:example)
-    def cads_check_box(attribute, label: nil, **)
+    # https://api.rubyonrails.org/classes/ActionView/Helpers/FormBuilder.html#method-i-checkbox
+    # f.cads_checkbox(:example)
+    def cads_checkbox(attribute, label: nil, **)
       Elements::CheckBox.new(
         self,
         @template,
@@ -127,6 +128,7 @@ module CitizensAdviceComponents
         label: label, **
       ).render
     end
+    alias cads_check_box cads_checkbox
 
     # Button element
     # f.cads_button "Submit complaint", icon_right: :arrow_right

--- a/engine/spec/helpers/citizens_advice_components/form_builder_cads_checkbox_spec.rb
+++ b/engine/spec/helpers/citizens_advice_components/form_builder_cads_checkbox_spec.rb
@@ -8,9 +8,9 @@ RSpec.describe CitizensAdviceComponents::FormBuilder do
   let(:model) { ExampleForm.valid_example }
   let(:builder) { form_builder_for(model) }
 
-  describe "#cads_check_box" do
+  describe "#cads_checkbox" do
     context "with default arguments" do
-      let(:field) { builder.cads_check_box(:confirmation) }
+      let(:field) { builder.cads_checkbox(:confirmation) }
 
       before do
         render_inline field
@@ -40,7 +40,7 @@ RSpec.describe CitizensAdviceComponents::FormBuilder do
 
     context "with validation errors" do
       let(:model) { ExampleForm.invalid_example }
-      let(:field) { builder.cads_check_box(:confirmation) }
+      let(:field) { builder.cads_checkbox(:confirmation) }
 
       before do
         model.valid? # trigger validation
@@ -59,6 +59,21 @@ RSpec.describe CitizensAdviceComponents::FormBuilder do
           "input[aria-describedby='example_form_confirmation-error']"
         )
       end
+    end
+  end
+
+  describe "#cads_check_box" do
+    let(:field) { builder.cads_checkbox(:confirmation) }
+
+    it "aliases #cads_checkbox" do
+      render_inline field
+
+      expect(page).to have_field(
+        "example_form[confirmation]",
+        with: "1",
+        type: :checkbox,
+        checked: true
+      )
     end
   end
 end

--- a/engine/spec/helpers/citizens_advice_components/form_builder_cads_collection_checkboxes_spec.rb
+++ b/engine/spec/helpers/citizens_advice_components/form_builder_cads_collection_checkboxes_spec.rb
@@ -15,10 +15,10 @@ RSpec.describe CitizensAdviceComponents::FormBuilder do
     ]
   end
 
-  describe "#cads_collection_check_boxes" do
+  describe "#cads_collection_checkboxes" do
     context "with default arguments" do
       let(:field) do
-        builder.cads_collection_check_boxes(:currency, example_options, :id, :name)
+        builder.cads_collection_checkboxes(:currency, example_options, :id, :name)
       end
 
       before do
@@ -93,7 +93,7 @@ RSpec.describe CitizensAdviceComponents::FormBuilder do
 
     context "with required parameter" do
       let(:field) do
-        builder.cads_collection_check_boxes(:currency, example_options, :id, :name, required: true)
+        builder.cads_collection_checkboxes(:currency, example_options, :id, :name, required: true)
       end
 
       it "labels the field group as required" do
@@ -105,7 +105,7 @@ RSpec.describe CitizensAdviceComponents::FormBuilder do
 
     context "with hint text" do
       let(:field) do
-        builder.cads_collection_check_boxes(:currency, example_options, :id, :name, hint: "Example hint")
+        builder.cads_collection_checkboxes(:currency, example_options, :id, :name, hint: "Example hint")
       end
 
       before do
@@ -123,7 +123,7 @@ RSpec.describe CitizensAdviceComponents::FormBuilder do
 
     context "with 'page_heading' parameter" do
       let(:field) do
-        builder.cads_collection_check_boxes(:currency, example_options, :id, :name, page_heading: true)
+        builder.cads_collection_checkboxes(:currency, example_options, :id, :name, page_heading: true)
       end
 
       it "wraps the legend text in a page heading" do
@@ -135,7 +135,7 @@ RSpec.describe CitizensAdviceComponents::FormBuilder do
     context "with validation errors" do
       let(:model) { ExampleForm.invalid_example }
       let(:field) do
-        builder.cads_collection_check_boxes(:currency, example_options, :id, :name)
+        builder.cads_collection_checkboxes(:currency, example_options, :id, :name)
       end
 
       before do
@@ -155,7 +155,7 @@ RSpec.describe CitizensAdviceComponents::FormBuilder do
 
       context "when there is hint text" do
         let(:field) do
-          builder.cads_collection_check_boxes(:currency, example_options, :id, :name, hint: "Example hint")
+          builder.cads_collection_checkboxes(:currency, example_options, :id, :name, hint: "Example hint")
         end
 
         it "sets multiple aria-describedby" do
@@ -166,7 +166,7 @@ RSpec.describe CitizensAdviceComponents::FormBuilder do
 
     context "with deprecated named attributes" do
       let(:field) do
-        builder.cads_collection_check_boxes(
+        builder.cads_collection_checkboxes(
           :currency,
           collection: example_options,
           text_method: :name,
@@ -180,6 +180,19 @@ RSpec.describe CitizensAdviceComponents::FormBuilder do
         render_inline field
         expect(CitizensAdviceComponents.deprecator).to have_received(:warn)
           .with(/collection, text_method, and value_method named parameters are deprecated/)
+      end
+    end
+  end
+
+  describe "#cads_collection_check_boxes" do
+    let(:field) { builder.cads_collection_check_boxes(:currency, example_options, :id, :name) }
+
+    it "aliases cads_collection_checkboxes" do
+      render_inline field
+
+      example_options.each do |option|
+        expect(page).to have_css "label", text: option.name
+        expect(page).to have_css "input[value='#{option.id}']"
       end
     end
   end

--- a/engine/spec/helpers/citizens_advice_components/form_builder_cads_textarea_spec.rb
+++ b/engine/spec/helpers/citizens_advice_components/form_builder_cads_textarea_spec.rb
@@ -8,9 +8,9 @@ RSpec.describe CitizensAdviceComponents::FormBuilder do
   let(:model) { ExampleForm.valid_example }
   let(:builder) { form_builder_for(model) }
 
-  describe "#cads_text_area" do
+  describe "#cads_textarea" do
     context "with default arguments" do
-      let(:field) { builder.cads_text_area(:address) }
+      let(:field) { builder.cads_textarea(:address) }
 
       before do
         render_inline field
@@ -56,7 +56,7 @@ RSpec.describe CitizensAdviceComponents::FormBuilder do
     end
 
     context "with required parameter" do
-      let(:field) { builder.cads_text_area(:address, required: true) }
+      let(:field) { builder.cads_textarea(:address, required: true) }
 
       it "includes aria-required attribute" do
         render_inline field
@@ -65,7 +65,7 @@ RSpec.describe CitizensAdviceComponents::FormBuilder do
     end
 
     context "with hint text" do
-      let(:field) { builder.cads_text_area(:address, hint: "Example hint") }
+      let(:field) { builder.cads_textarea(:address, hint: "Example hint") }
 
       before do
         render_inline field
@@ -81,7 +81,7 @@ RSpec.describe CitizensAdviceComponents::FormBuilder do
     end
 
     context "with 'rows' parameter" do
-      let(:field) { builder.cads_text_area(:address, rows: 10) }
+      let(:field) { builder.cads_textarea(:address, rows: 10) }
 
       it "renders the textarea with the correct number of rows" do
         render_inline field
@@ -90,7 +90,7 @@ RSpec.describe CitizensAdviceComponents::FormBuilder do
     end
 
     context "with 'page_heading' parameter" do
-      let(:field) { builder.cads_text_area(:address, page_heading: true) }
+      let(:field) { builder.cads_textarea(:address, page_heading: true) }
 
       it "wrap the label in a page heading" do
         render_inline field
@@ -100,7 +100,7 @@ RSpec.describe CitizensAdviceComponents::FormBuilder do
 
     context "with deprecated additional_attributes hash" do
       let(:field) do
-        builder.cads_text_area(
+        builder.cads_textarea(
           :name,
           additional_attributes: { autocomplete: "name", "data-additional": "example" }
         )
@@ -123,7 +123,7 @@ RSpec.describe CitizensAdviceComponents::FormBuilder do
 
     context "with additional_attributes" do
       let(:field) do
-        builder.cads_text_area(
+        builder.cads_textarea(
           :address,
           autocomplete: "name", "data-additional": "example"
         )
@@ -138,7 +138,7 @@ RSpec.describe CitizensAdviceComponents::FormBuilder do
 
     context "with validation errors" do
       let(:model) { ExampleForm.invalid_example }
-      let(:field) { builder.cads_text_area(:address) }
+      let(:field) { builder.cads_textarea(:address) }
 
       before do
         model.valid? # trigger validation
@@ -158,7 +158,7 @@ RSpec.describe CitizensAdviceComponents::FormBuilder do
       end
 
       context "when there is hint text" do
-        let(:field) { builder.cads_text_area(:address, hint: "Example hint") }
+        let(:field) { builder.cads_textarea(:address, hint: "Example hint") }
 
         it "sets multiple aria-describedby" do
           expect(page).to have_css "textarea[aria-describedby='example_form_address-error example_form_address-hint']"
@@ -168,12 +168,22 @@ RSpec.describe CitizensAdviceComponents::FormBuilder do
 
     context "with no form model" do
       let(:builder) { form_builder_for(nil) }
-      let(:field) { builder.cads_text_area(:address) }
+      let(:field) { builder.cads_textarea(:address) }
 
       it "can be used without a form model" do
         render_inline field
         expect(page).to have_css "textarea"
       end
+    end
+  end
+
+  describe "#cads_text_area" do
+    let(:field) { builder.cads_textarea(:address) }
+
+    it "aliases cads_textarea" do
+      render_inline field
+
+      expect(page).to have_css "textarea"
     end
   end
 end


### PR DESCRIPTION
Does a bit of clean up on the default naming for form builder methods to better match Rails defaults supporting available alises, e.g. `collection_checkboxes` by  with a `collection_check_boxes` aliaes.

Updates the spec naming to better match the default methods.