### PR TITLE
Grouped collection select refactored

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## Unreleased
+
+### 24 June 2026
+
+**New**
+
+- Add `cads_grouped_collection_select` to `FormBuilder` to support rendering grouped option collections
+
 ## v9.3.0
 
 ### 19 May 2026

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,3 @@
-## Unreleased
-
-### 24 June 2026
-
 **New**
 
 - Add `cads_grouped_collection_select` to `FormBuilder` to support rendering grouped option collections

--- a/engine/app/helpers/citizens_advice_components/form_builder.rb
+++ b/engine/app/helpers/citizens_advice_components/form_builder.rb
@@ -116,6 +116,31 @@ module CitizensAdviceComponents
       ).render
     end
 
+    def cads_grouped_collection_select(
+      attribute,
+      collection,
+      group_method,
+      group_label_method,
+      option_key_method,
+      option_value_method,
+      options = {},
+      html_options = {}
+    )
+      Elements::GroupedCollectionSelect.new(
+        self,
+        @template,
+        object,
+        attribute,
+        collection,
+        group_method,
+        group_label_method,
+        option_key_method,
+        option_value_method,
+        options,
+        html_options
+      ).render
+    end
+
     # Labelled check_box field
     # https://api.rubyonrails.org/classes/ActionView/Helpers/FormBuilder.html#method-i-checkbox
     # f.cads_checkbox(:example)

--- a/engine/app/lib/citizens_advice_components/elements/grouped_collection_select.rb
+++ b/engine/app/lib/citizens_advice_components/elements/grouped_collection_select.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+module CitizensAdviceComponents
+  module Elements
+    class GroupedCollectionSelect < Base
+      include Traits::Field
+
+      attr_reader :collection, :group_method, :group_label_method, :option_key_method, :option_value_method
+
+      def initialize(
+        builder,
+        template,
+        object,
+        attribute,
+        collection,
+        group_method,
+        group_label_method,
+        option_key_method,
+        option_value_method,
+        options = {},
+        html_options = {}
+      )
+        super(builder, template, object)
+
+        @attribute = attribute
+        @collection = collection
+        @group_method = group_method
+        @group_label_method = group_label_method
+        @option_key_method = option_key_method
+        @option_value_method = option_value_method
+        @options = options
+        @html_options = html_options
+      end
+
+      protected
+
+      def page_heading?
+        false
+      end
+
+      def render_field
+        builder.grouped_collection_select(
+          attribute,
+          collection,
+          group_method,
+          group_label_method,
+          option_key_method,
+          option_value_method,
+          options,
+          html_options
+        )
+      end
+
+      private
+
+      def html_options
+        @html_options.with_defaults({
+          id: input_id,
+          class: class_names("cads-select", "cads-input"),
+          required: false,
+          "aria-required": required?,
+          "aria-invalid": error?,
+          "aria-describedby": described_by
+        }.merge(options[:additional_attributes] || {}))
+      end
+    end
+  end
+end

--- a/engine/spec/helpers/citizens_advice_components/form_builder_cads_error_summary_spec.rb
+++ b/engine/spec/helpers/citizens_advice_components/form_builder_cads_error_summary_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe CitizensAdviceComponents::FormBuilder do
 
       it "renders a list for error messages" do
         expect(page).to have_css ".cads-error-summary"
-        expect(page).to have_css "li a", count: 5
+        expect(page).to have_css "li a", count: 6
       end
 
       it "renders messages with links to the associated input" do

--- a/engine/spec/helpers/citizens_advice_components/form_builder_cads_grouped_collection_select_spec.rb
+++ b/engine/spec/helpers/citizens_advice_components/form_builder_cads_grouped_collection_select_spec.rb
@@ -1,0 +1,224 @@
+# frozen_string_literal: true
+
+RSpec.describe CitizensAdviceComponents::FormBuilder do
+  include FormBuilderTestHelpers
+
+  subject { page }
+
+  let(:model) { ExampleForm.valid_example }
+  let(:builder) { form_builder_for(model) }
+  let(:example_options) do
+    [
+      FormOptionGroup.new("Africa", [
+        FormOption.new(name: "South Africa", id: "ZA"),
+        FormOption.new(name: "Somalia", id: "SO")
+      ]),
+      FormOptionGroup.new("Europe", [
+        FormOption.new(name: "Denmark", id: "DE"),
+        FormOption.new(name: "Finland", id: "FI")
+      ])
+    ]
+  end
+
+  describe "#cads_grouped_collection_select" do
+    context "with no form model" do
+      let(:builder) { form_builder_for(nil) }
+      let(:field) do
+        builder.cads_grouped_collection_select(
+          :country,
+          example_options,
+          :options,
+          :name,
+          :id,
+          :name,
+          label: "Country"
+        )
+      end
+
+      it "can be used without a form model" do
+        render_inline field
+
+        expect(page).to have_css('select optgroup[label="Africa"]')
+        expect(page).to have_css('select optgroup[label="Europe"]')
+
+        expect(page).to have_select("country", with_options: [
+          "South Africa",
+          "Somalia",
+          "Denmark",
+          "Finland"
+        ])
+      end
+    end
+
+    context "with default arguments" do
+      let(:field) do
+        builder.cads_grouped_collection_select(
+          :country,
+          example_options,
+          :options,
+          :name,
+          :id,
+          :name
+        )
+      end
+
+      before do
+        render_inline field
+      end
+
+      it "renders expected options and values" do
+        expect(page).to have_css('select optgroup[label="Africa"]')
+        expect(page).to have_css('select optgroup[label="Europe"]')
+
+        expect(page).to have_select("example_form[country]", selected: "Denmark", with_options: [
+          "South Africa",
+          "Somalia",
+          "Denmark",
+          "Finland"
+        ])
+      end
+
+      it "links the label to the input" do
+        expect(page).to have_css "label[for=example_form_country-input]"
+      end
+
+      it "adds the correct id to the input" do
+        expect(page).to have_css "#example_form_country-input"
+      end
+
+      it "does not have an aria-describedby attribute by default" do
+        expect(page).to have_no_css "select[aria-describedby]"
+      end
+
+      it "does not add required to the input" do
+        expect(page).to have_no_css "select[required]"
+      end
+
+      it "labels the field as optional" do
+        expect(page).to have_text "Country (optional)", normalize_ws: true
+      end
+
+      context "when in Cymraeg" do
+        around { |example| I18n.with_locale(:cy) { example.run } }
+
+        it { is_expected.to have_text "(dewisol)" }
+      end
+    end
+
+    context "with required parameter" do
+      let(:field) do
+        builder.cads_grouped_collection_select(
+          :country,
+          example_options,
+          :options,
+          :name,
+          :id,
+          :name,
+          required: true
+        )
+      end
+
+      it "includes aria-required attribute" do
+        render_inline field
+        expect(page).to have_css "select[aria-required=true]"
+      end
+    end
+
+    context "with hint text" do
+      let(:field) do
+        builder.cads_grouped_collection_select(
+          :country,
+          example_options,
+          :options,
+          :name,
+          :id,
+          :name,
+          hint: "Example hint"
+        )
+      end
+
+      before do
+        render_inline field
+      end
+
+      it "includes the hint text" do
+        expect(page).to have_text "Example hint"
+      end
+
+      it "sets aria-describedby" do
+        expect(page).to have_css "select[aria-describedby=example_form_country-hint]"
+      end
+    end
+
+    context "when html options are provided" do
+      let(:field) do
+        builder.cads_grouped_collection_select(
+          :country,
+          example_options,
+          :options,
+          :name,
+          :id,
+          :name,
+          {},
+          autocomplete: "name",
+          "data-additional": "example"
+        )
+      end
+
+      it "passes additional attributes through to element" do
+        render_inline field
+        expect(page).to have_css "select[autocomplete=name]"
+        expect(page).to have_css "select[data-additional=example]"
+      end
+    end
+
+    context "with validation errors" do
+      let(:model) { ExampleForm.invalid_example }
+      let(:field) do
+        builder.cads_grouped_collection_select(
+          :country,
+          example_options,
+          :options,
+          :name,
+          :id,
+          :name
+        )
+      end
+
+      before do
+        model.valid? # trigger validation
+        render_inline field
+      end
+
+      it "renders error message" do
+        expect(page).to have_css "#example_form_country-error", text: "Country is not included in the list"
+      end
+
+      it "sets aria-invalid" do
+        expect(page).to have_css "select[aria-invalid=true]"
+      end
+
+      it "sets aria-describedby" do
+        expect(page).to have_css "select[aria-describedby='example_form_country-error']"
+      end
+
+      context "when there is hint text" do
+        let(:field) do
+          builder.cads_grouped_collection_select(
+            :country,
+            example_options,
+            :options,
+            :name,
+            :id,
+            :name,
+            hint: "Example hint"
+          )
+        end
+
+        it "sets multiple aria-describedby" do
+          expect(page).to have_css "select[aria-describedby='example_form_country-error example_form_country-hint']"
+        end
+      end
+    end
+  end
+end

--- a/engine/spec/support/examples.rb
+++ b/engine/spec/support/examples.rb
@@ -18,10 +18,23 @@ class ExampleForm
 
   validates :name, presence: true
   validates :address, presence: true
-  validates :country, inclusion: { in: %w[GBP EUR USD] }
-  validates :currency, inclusion: { in: %w[ZA SO DK FI] }
+  validates :country, inclusion: { in: %w[ZA SO DE FI] }
+  validates :currency, inclusion: { in: %w[GBP EUR USD] }
   validates :date_of_purchase, comparison: { less_than: Time.zone.today }
   validates :confirmation, presence: true
+
+  def country_groups
+    [
+      FormOptionGroup.new("Africa", [
+        FormOption.new(name: "South Africa", id: "ZA"),
+        FormOption.new(name: "Somalia", id: "SO")
+      ]),
+      FormOptionGroup.new("Europe", [
+        FormOption.new(name: "Denmark", id: "DE"),
+        FormOption.new(name: "Finland", id: "FI")
+      ])
+    ]
+  end
 
   def self.valid_example
     new(

--- a/engine/spec/support/examples.rb
+++ b/engine/spec/support/examples.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 FormOption = Data.define(:id, :name)
+FormOptionGroup = Data.define(:name, :options)
 DateLike = Data.define(:day, :month, :year)
 
 class ExampleForm
@@ -9,6 +10,7 @@ class ExampleForm
 
   attribute :name
   attribute :address
+  attribute :country, :string
   attribute :currency, :string
   attribute :date_of_purchase, :date
   attribute :confirmation, :boolean
@@ -16,7 +18,8 @@ class ExampleForm
 
   validates :name, presence: true
   validates :address, presence: true
-  validates :currency, inclusion: { in: %w[GBP EUR USD] }
+  validates :country, inclusion: { in: %w[GBP EUR USD] }
+  validates :currency, inclusion: { in: %w[ZA SO DK FI] }
   validates :date_of_purchase, comparison: { less_than: Time.zone.today }
   validates :confirmation, presence: true
 
@@ -25,6 +28,7 @@ class ExampleForm
       name: "Example name",
       address: "Example address",
       currency: "GBP",
+      country: "DE",
       date_of_purchase: Date.new(2023, 1, 1),
       confirmation: true,
       date_like_value: DateLike.new(year: 2026, month: 11, day: 20)
@@ -36,6 +40,7 @@ class ExampleForm
       name: nil,
       address: nil,
       currency: "INVALID",
+      country: "INVALID",
       date_of_purchase: Time.zone.tomorrow,
       confirmation: nil
     )


### PR DESCRIPTION
This PR implements a new grouped collection select helper (`cads_grouped_collection_select`) within the core `FormBuilder` engine. Also this PR is focusing only the engine implementation.