### PR TITLE
Remove deprecations for v10 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@
 
   ViewComponent 4 is essentially a long-term-support version now and there are security fixes that are only available in the 4.x branch.
 
+- Remove named parameters for `cads_collection` fields
+
+  All `cads_collection` fields have been updated to solely use the Rails native equivalents e.g.
+
+  ```rb
+  cads_collection_radio_buttons(attribute, collection, value_method, text_method, options = {}, html_options = {}
+  ```
+
+**Deprecations**
+
 - Deprecate form components in favour of form builder
 
   Moves the following view components under a `CitizensAdviceComponents::Legacy` namespace:
@@ -88,7 +98,7 @@
 
   If using the previous named `additional_attributes` hash, this will log a deprecation warning and will be removed in a future version.
 
-- Deprecate named parameters for `cads_colleciton` fields
+- Deprecate named parameters for `cads_collection` fields
 
   All `cads_collection` fields have been updated to support equivalent arguments to the Rails native equivalents e.g.
 
@@ -96,7 +106,7 @@
   cads_collection_radio_buttons(attribute, collection, value_method, text_method, options = {}, html_options = {}
   ```
 
-  The previous arguments using named paramters are still supported but a deprecation warning will be logged and will
+  The previous arguments using named parameters are still supported but a deprecation warning will be logged and will
   be removed in a future major version.
 
 **Fix**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@
   cads_collection_radio_buttons(attribute, collection, value_method, text_method, options = {}, html_options = {}
   ```
 
+- Remove `additional_attributes` named parameter from `cads_text_field`, `cads_text_area`, and `cads_check_box`.
+
+  Only support passing attributes on like the Rails native equivalents for fields.
+
 **Deprecations**
 
 - Deprecate form components in favour of form builder

--- a/engine/app/components/citizens_advice_components/legacy/form_group.rb
+++ b/engine/app/components/citizens_advice_components/legacy/form_group.rb
@@ -21,8 +21,6 @@ module CitizensAdviceComponents
         @optional = fetch_or_fallback_boolean(options[:optional], fallback: false)
         @legend_heading = fetch_or_fallback_boolean(options[:legend_heading], fallback: false)
         @page_heading = fetch_or_fallback_boolean(options[:page_heading], fallback: false)
-
-        legend_heading_deprecation
       end
 
       def extra_fieldset_classes
@@ -37,14 +35,6 @@ module CitizensAdviceComponents
 
       def common_fieldset_classes
         %w[cads-form-group]
-      end
-
-      def legend_heading_deprecation
-        return if @legend_heading.blank?
-
-        CitizensAdviceComponents.deprecator.warn(
-          "The legend_heading option is deprecated, use page_heading instead"
-        )
       end
 
       def render?

--- a/engine/app/components/citizens_advice_components/legacy/select.rb
+++ b/engine/app/components/citizens_advice_components/legacy/select.rb
@@ -14,7 +14,6 @@ module CitizensAdviceComponents
         @type = type
 
         set_options(options)
-        type_deprecation
       end
 
       def render_select_options
@@ -22,14 +21,6 @@ module CitizensAdviceComponents
       end
 
       private
-
-      def type_deprecation
-        return if @type.blank?
-
-        CitizensAdviceComponents.deprecator.warn(
-          "The type argument is deprecated, type is not a valid property of a <select>"
-        )
-      end
 
       def set_options(options)
         return if options.blank?

--- a/engine/app/components/citizens_advice_components/legacy/textarea.rb
+++ b/engine/app/components/citizens_advice_components/legacy/textarea.rb
@@ -15,18 +15,9 @@ module CitizensAdviceComponents
         @type = type
 
         set_options(options)
-        type_deprecation
       end
 
       private
-
-      def type_deprecation
-        return if @type.blank?
-
-        CitizensAdviceComponents.deprecator.warn(
-          "The type argument is deprecated, type is not a valid property of a <textarea>"
-        )
-      end
 
       def set_options(options)
         return if options.blank?

--- a/engine/app/helpers/citizens_advice_components/form_builder.rb
+++ b/engine/app/helpers/citizens_advice_components/form_builder.rb
@@ -48,9 +48,9 @@ module CitizensAdviceComponents
     # f.cads_collection_radio_buttons(:my_argument, Locations.all)
     def cads_collection_radio_buttons(
       attribute,
-      collection_arg = nil,
-      value_method_arg = nil,
-      text_method_arg = nil,
+      collection,
+      value_method,
+      text_method,
       options = {},
       html_options = {}
     )
@@ -59,9 +59,9 @@ module CitizensAdviceComponents
         @template,
         object,
         attribute,
-        collection_arg,
-        value_method_arg,
-        text_method_arg,
+        collection,
+        value_method,
+        text_method,
         options,
         html_options
       ).render
@@ -72,9 +72,9 @@ module CitizensAdviceComponents
     # f.cads_collection_check_boxes(:my_argument, Locations.all, :id, :name)
     def cads_collection_checkboxes(
       attribute,
-      collection_arg = nil,
-      value_method_arg = nil,
-      text_method_arg = nil,
+      collection,
+      value_method,
+      text_method,
       options = {},
       html_options = {}
     )
@@ -83,9 +83,9 @@ module CitizensAdviceComponents
         @template,
         object,
         attribute,
-        collection_arg,
-        value_method_arg,
-        text_method_arg,
+        collection,
+        value_method,
+        text_method,
         options,
         html_options
       ).render
@@ -97,9 +97,9 @@ module CitizensAdviceComponents
     # f.cads_collection_select(:my_argument, Locations.all, :id, :name)
     def cads_collection_select(
       attribute,
-      collection_arg = nil,
-      value_method_arg = nil,
-      text_method_arg = nil,
+      collection,
+      value_method,
+      text_method,
       options = {},
       html_options = {}
     )
@@ -108,9 +108,9 @@ module CitizensAdviceComponents
         @template,
         object,
         attribute,
-        collection_arg,
-        value_method_arg,
-        text_method_arg,
+        collection,
+        value_method,
+        text_method,
         options,
         html_options
       ).render

--- a/engine/app/lib/citizens_advice_components/elements/check_box.rb
+++ b/engine/app/lib/citizens_advice_components/elements/check_box.rb
@@ -16,7 +16,6 @@ module CitizensAdviceComponents
 
         @attribute = attribute
         @options = kwargs
-        additional_attributes_deprecation
       end
 
       protected
@@ -50,7 +49,7 @@ module CitizensAdviceComponents
           "aria-required": required?,
           "aria-invalid": error?,
           "aria-describedby": described_by,
-          **check_box_options
+          **options_for_html
         )
       end
 
@@ -65,21 +64,6 @@ module CitizensAdviceComponents
           "cads-form-group",
           "cads-form-group--checkbox",
           "cads-checkbox-single"
-        )
-      end
-
-      def check_box_options
-        # The default behaviour of text_field is to pass options on to the HTML element
-        # Extract any custom options that we don't want passing on and add expected defaults.
-        # For backwards compatability merge in additional_options hash
-        options_for_html.merge(options[:additional_attributes] || {})
-      end
-
-      def additional_attributes_deprecation
-        return if options[:additional_attributes].blank?
-
-        CitizensAdviceComponents.deprecator.warn(
-          "additional_attributes hash is deprecated, pass directly via options hash"
         )
       end
     end

--- a/engine/app/lib/citizens_advice_components/elements/collection_check_boxes.rb
+++ b/engine/app/lib/citizens_advice_components/elements/collection_check_boxes.rb
@@ -13,7 +13,7 @@ module CitizensAdviceComponents
         template,
         object,
         attribute,
-        collection_or_options,
+        collection,
         value_method,
         text_method,
         options = {},
@@ -22,32 +22,11 @@ module CitizensAdviceComponents
         super(builder, template, object)
 
         @attribute = attribute
-
-        # The standard Rails collection_radio_buttons method accepts collection,
-        # text_method, and value_method as positional arguments followed by an options
-        # and separate html_options hash. Our original component accepted named arguments.
-        #
-        # If collection is a hash then we have the older named arguments format so we
-        # need to extract our expected paramters out of the hash. Otherwise use the new defaults.
-        if collection_or_options.is_a? Hash
-          collection_params_deprecation
-
-          @collection = collection_or_options[:collection]
-          @text_method = collection_or_options[:text_method]
-          @value_method = collection_or_options[:value_method]
-
-          @options = collection_or_options.without(:collection, :text_method, :value_method)
-          @html_options = {} # html_options not supported in this format
-        else
-          @collection = collection_or_options
-          @text_method = text_method
-          @value_method = value_method
-
-          @options = options
-          @html_options = html_options
-        end
-
-        additional_attributes_deprecation
+        @collection = collection
+        @text_method = text_method
+        @value_method = value_method
+        @options = options
+        @html_options = html_options
       end
 
       protected
@@ -81,20 +60,6 @@ module CitizensAdviceComponents
           check_box_builder.check_box(class: "cads-form-group__input", id: id),
           check_box_builder.label(class: "cads-form-group__label", for: id) { check_box_builder.text }
         ])
-      end
-
-      def collection_params_deprecation
-        CitizensAdviceComponents.deprecator.warn(
-          "collection, text_method, and value_method named parameters are deprecated, pass as positional parameter"
-        )
-      end
-
-      def additional_attributes_deprecation
-        return if options[:additional_attributes].blank?
-
-        CitizensAdviceComponents.deprecator.warn(
-          "additional_attributes hash is deprecated, pass directly via options hash"
-        )
       end
     end
   end

--- a/engine/app/lib/citizens_advice_components/elements/collection_radio_buttons.rb
+++ b/engine/app/lib/citizens_advice_components/elements/collection_radio_buttons.rb
@@ -13,7 +13,7 @@ module CitizensAdviceComponents
         template,
         object,
         attribute,
-        collection_or_options,
+        collection,
         value_method,
         text_method,
         options = {},
@@ -22,32 +22,11 @@ module CitizensAdviceComponents
         super(builder, template, object)
 
         @attribute = attribute
-
-        # The standard Rails collection_radio_buttons method accepts collection,
-        # text_method, and value_method as positional arguments followed by an options
-        # and separate html_options hash. Our original component accepted named arguments.
-        #
-        # If collection is a hash then we have the older named arguments format so we
-        # need to extract our expected paramters out of the hash. Otherwise use the new defaults.
-        if collection_or_options.is_a? Hash
-          collection_params_deprecation
-
-          @collection = collection_or_options[:collection]
-          @text_method = collection_or_options[:text_method]
-          @value_method = collection_or_options[:value_method]
-
-          @options = collection_or_options.without(:collection, :text_method, :value_method)
-          @html_options = {} # html_options not supported in this format
-        else
-          @collection = collection_or_options
-          @text_method = text_method
-          @value_method = value_method
-
-          @options = options
-          @html_options = html_options
-        end
-
-        additional_attributes_deprecation
+        @collection = collection
+        @text_method = text_method
+        @value_method = value_method
+        @options = options
+        @html_options = html_options
       end
 
       protected
@@ -83,20 +62,6 @@ module CitizensAdviceComponents
           radio_builder.radio_button(class: "cads-form-group__input", id: id),
           radio_builder.label(class: "cads-form-group__label", for: id) { radio_builder.text }
         ])
-      end
-
-      def collection_params_deprecation
-        CitizensAdviceComponents.deprecator.warn(
-          "collection, text_method, and value_method named parameters are deprecated, pass as positional parameter"
-        )
-      end
-
-      def additional_attributes_deprecation
-        return if options[:additional_attributes].blank?
-
-        CitizensAdviceComponents.deprecator.warn(
-          "additional_attributes hash is deprecated, pass directly via options hash"
-        )
       end
 
       def size

--- a/engine/app/lib/citizens_advice_components/elements/collection_select.rb
+++ b/engine/app/lib/citizens_advice_components/elements/collection_select.rb
@@ -12,7 +12,7 @@ module CitizensAdviceComponents
         template,
         object,
         attribute,
-        collection_or_options,
+        collection,
         value_method,
         text_method,
         options = {},
@@ -21,32 +21,11 @@ module CitizensAdviceComponents
         super(builder, template, object)
 
         @attribute = attribute
-
-        # The standard Rails collection_radio_buttons method accepts collection,
-        # text_method, and value_method as positional arguments followed by an options
-        # and separate html_options hash. Our original component accepted named arguments.
-        #
-        # If collection is a hash then we have the older named arguments format so we
-        # need to extract our expected paramters out of the hash. Otherwise use the new defaults.
-        if collection_or_options.is_a? Hash
-          collection_params_deprecation
-
-          @collection = collection_or_options[:collection]
-          @text_method = collection_or_options[:text_method]
-          @value_method = collection_or_options[:value_method]
-
-          @options = collection_or_options.without(:collection, :text_method, :value_method)
-          @html_options = {} # html_options not supported in this format
-        else
-          @collection = collection_or_options
-          @text_method = text_method
-          @value_method = value_method
-
-          @options = options
-          @html_options = html_options
-        end
-
-        additional_attributes_deprecation
+        @collection = collection
+        @text_method = text_method
+        @value_method = value_method
+        @options = options
+        @html_options = html_options
       end
 
       protected
@@ -77,21 +56,7 @@ module CitizensAdviceComponents
           "aria-required": required?,
           "aria-invalid": error?,
           "aria-describedby": described_by
-        }.merge(options[:additional_attributes] || {}))
-      end
-
-      def collection_params_deprecation
-        CitizensAdviceComponents.deprecator.warn(
-          "collection, text_method, and value_method named parameters are deprecated, pass as positional parameter"
-        )
-      end
-
-      def additional_attributes_deprecation
-        return if options[:additional_attributes].blank?
-
-        CitizensAdviceComponents.deprecator.warn(
-          "additional_attributes hash is deprecated, pass directly via options hash"
-        )
+        })
       end
     end
   end

--- a/engine/app/lib/citizens_advice_components/elements/text_area.rb
+++ b/engine/app/lib/citizens_advice_components/elements/text_area.rb
@@ -10,7 +10,6 @@ module CitizensAdviceComponents
 
         @attribute = attribute
         @options = options
-        additional_attributes_deprecation
       end
 
       private
@@ -25,24 +24,7 @@ module CitizensAdviceComponents
           "aria-required": required?,
           "aria-invalid": error?,
           "aria-describedby": described_by,
-          **text_area_options
-        )
-      end
-
-      def text_area_options
-        # The default behaviour of text_field is to pass options on to the HTML element
-        # Extract any custom options that we don't want passing on and add expected defaults.
-        # For backwards compatability merge in additional_options hash
-        options_for_html
-          .without(:rows)
-          .merge(options[:additional_attributes] || {})
-      end
-
-      def additional_attributes_deprecation
-        return if options[:additional_attributes].blank?
-
-        CitizensAdviceComponents.deprecator.warn(
-          "additional_attributes hash is deprecated, pass directly via options hash"
+          **options_for_html.without(:rows)
         )
       end
 

--- a/engine/app/lib/citizens_advice_components/elements/text_field.rb
+++ b/engine/app/lib/citizens_advice_components/elements/text_field.rb
@@ -17,7 +17,6 @@ module CitizensAdviceComponents
 
         @attribute = attribute
         @options = options
-        additional_attributes_deprecation
       end
 
       private
@@ -31,25 +30,7 @@ module CitizensAdviceComponents
           "aria-required": required?,
           "aria-invalid": error?,
           "aria-describedby": described_by,
-
-          **text_field_options
-        )
-      end
-
-      def text_field_options
-        # The default behaviour of text_field is to pass options on to the HTML element
-        # Extract any custom options that we don't want passing on and add expected defaults.
-        # For backwards compatability merge in additional_options hash
-        options_for_html
-          .without(:width)
-          .merge(options[:additional_attributes] || {})
-      end
-
-      def additional_attributes_deprecation
-        return if options[:additional_attributes].blank?
-
-        CitizensAdviceComponents.deprecator.warn(
-          "additional_attributes hash is deprecated, pass directly via options hash"
+          **options_for_html.without(:width)
         )
       end
 

--- a/engine/app/lib/citizens_advice_components/elements/traits/field.rb
+++ b/engine/app/lib/citizens_advice_components/elements/traits/field.rb
@@ -78,7 +78,9 @@ module CitizensAdviceComponents
         end
 
         def options_for_html
-          options.without(:label, :hint, :required, :page_heading, :additional_attributes)
+          # The default behaviour of fields is to pass options on to the HTML element
+          # Extract any custom options that we don't want passing on and add expected defaults.
+          options.without(:label, :hint, :required, :page_heading)
         end
       end
     end

--- a/engine/app/lib/citizens_advice_components/elements/traits/field_group.rb
+++ b/engine/app/lib/citizens_advice_components/elements/traits/field_group.rb
@@ -74,7 +74,9 @@ module CitizensAdviceComponents
         end
 
         def options_for_html
-          options.without(:label, :hint, :required, :page_heading, :additional_attributes)
+          # The default behaviour of fields is to pass options on to the HTML element
+          # Extract any custom options that we don't want passing on and add expected defaults.
+          options.without(:label, :hint, :required, :page_heading)
         end
 
         def input_id

--- a/engine/spec/components/citizens_advice_components/legacy/checkbox_group_spec.rb
+++ b/engine/spec/components/citizens_advice_components/legacy/checkbox_group_spec.rb
@@ -161,8 +161,6 @@ RSpec.describe CitizensAdviceComponents::Legacy::CheckboxGroup, type: :component
 
   context "when deprecated legend_heading option is provided" do
     before do
-      allow(CitizensAdviceComponents.deprecator).to receive(:warn)
-
       render_inline described_class.new(
         legend: "Checkbox group field",
         name: "checkboxes",
@@ -170,11 +168,6 @@ RSpec.describe CitizensAdviceComponents::Legacy::CheckboxGroup, type: :component
       ) do |c|
         c.with_inputs(sample_inputs)
       end
-    end
-
-    it "logs deprecation warning" do
-      expect(CitizensAdviceComponents.deprecator).to have_received(:warn)
-        .with(/legend_heading option is deprecated/)
     end
   end
 

--- a/engine/spec/components/citizens_advice_components/legacy/checkbox_group_spec.rb
+++ b/engine/spec/components/citizens_advice_components/legacy/checkbox_group_spec.rb
@@ -159,18 +159,6 @@ RSpec.describe CitizensAdviceComponents::Legacy::CheckboxGroup, type: :component
     it { is_expected.to have_css "legend h1.cads-page-title", text: "Checkbox group field" }
   end
 
-  context "when deprecated legend_heading option is provided" do
-    before do
-      render_inline described_class.new(
-        legend: "Checkbox group field",
-        name: "checkboxes",
-        options: { legend_heading: true }
-      ) do |c|
-        c.with_inputs(sample_inputs)
-      end
-    end
-  end
-
   private
 
   def sample_inputs

--- a/engine/spec/components/citizens_advice_components/legacy/radio_group_spec.rb
+++ b/engine/spec/components/citizens_advice_components/legacy/radio_group_spec.rb
@@ -132,8 +132,6 @@ RSpec.describe CitizensAdviceComponents::Legacy::RadioGroup, type: :component do
 
   context "when deprecated legend_heading option is provided" do
     before do
-      allow(CitizensAdviceComponents.deprecator).to receive(:warn)
-
       render_inline described_class.new(
         legend: "Radio group field",
         name: "radio-group",
@@ -141,11 +139,6 @@ RSpec.describe CitizensAdviceComponents::Legacy::RadioGroup, type: :component do
       ) do |c|
         c.with_inputs(sample_inputs)
       end
-    end
-
-    it "logs deprecation warning" do
-      expect(CitizensAdviceComponents.deprecator).to have_received(:warn)
-        .with(/legend_heading option is deprecated/)
     end
   end
 

--- a/engine/spec/components/citizens_advice_components/legacy/radio_group_spec.rb
+++ b/engine/spec/components/citizens_advice_components/legacy/radio_group_spec.rb
@@ -130,18 +130,6 @@ RSpec.describe CitizensAdviceComponents::Legacy::RadioGroup, type: :component do
     it { is_expected.to have_css "legend h1.cads-page-title", text: "Radio group field" }
   end
 
-  context "when deprecated legend_heading option is provided" do
-    before do
-      render_inline described_class.new(
-        legend: "Radio group field",
-        name: "radio-group",
-        options: { legend_heading: true }
-      ) do |c|
-        c.with_inputs(sample_inputs)
-      end
-    end
-  end
-
   describe "layout options" do
     context "when an invalid layout option is passed" do
       before do

--- a/engine/spec/components/citizens_advice_components/legacy/select_spec.rb
+++ b/engine/spec/components/citizens_advice_components/legacy/select_spec.rb
@@ -85,16 +85,4 @@ RSpec.describe CitizensAdviceComponents::Legacy::Select, type: :component do
     it { is_expected.to have_css "select[autocomplete=name]" }
     it { is_expected.to have_css "select[data-additional=example]" }
   end
-
-  context "when deprecated type argument is provided" do
-    before do
-      render_inline described_class.new(
-        select_options: select_options,
-        name: name.presence,
-        label: label.presence,
-        options: options,
-        type: :text
-      )
-    end
-  end
 end

--- a/engine/spec/components/citizens_advice_components/legacy/select_spec.rb
+++ b/engine/spec/components/citizens_advice_components/legacy/select_spec.rb
@@ -88,8 +88,6 @@ RSpec.describe CitizensAdviceComponents::Legacy::Select, type: :component do
 
   context "when deprecated type argument is provided" do
     before do
-      allow(CitizensAdviceComponents.deprecator).to receive(:warn)
-
       render_inline described_class.new(
         select_options: select_options,
         name: name.presence,
@@ -97,11 +95,6 @@ RSpec.describe CitizensAdviceComponents::Legacy::Select, type: :component do
         options: options,
         type: :text
       )
-    end
-
-    it "logs deprecation warning" do
-      expect(CitizensAdviceComponents.deprecator).to have_received(:warn)
-        .with(/type argument is deprecated/)
     end
   end
 end

--- a/engine/spec/components/citizens_advice_components/legacy/textarea_spec.rb
+++ b/engine/spec/components/citizens_advice_components/legacy/textarea_spec.rb
@@ -195,14 +195,4 @@ RSpec.describe CitizensAdviceComponents::Legacy::Textarea, type: :component do
       expect(page).to have_css "textarea[rows=8]"
     end
   end
-
-  context "when deprecated type argument is provided" do
-    before do
-      render_inline described_class.new(
-        name: "example-textarea",
-        label: "Example textarea",
-        type: :text
-      )
-    end
-  end
 end

--- a/engine/spec/components/citizens_advice_components/legacy/textarea_spec.rb
+++ b/engine/spec/components/citizens_advice_components/legacy/textarea_spec.rb
@@ -198,18 +198,11 @@ RSpec.describe CitizensAdviceComponents::Legacy::Textarea, type: :component do
 
   context "when deprecated type argument is provided" do
     before do
-      allow(CitizensAdviceComponents.deprecator).to receive(:warn)
-
       render_inline described_class.new(
         name: "example-textarea",
         label: "Example textarea",
         type: :text
       )
-    end
-
-    it "logs deprecation warning" do
-      expect(CitizensAdviceComponents.deprecator).to have_received(:warn)
-        .with(/type argument is deprecated/)
     end
   end
 end

--- a/engine/spec/helpers/citizens_advice_components/form_builder_cads_collection_checkboxes_spec.rb
+++ b/engine/spec/helpers/citizens_advice_components/form_builder_cads_collection_checkboxes_spec.rb
@@ -181,25 +181,6 @@ RSpec.describe CitizensAdviceComponents::FormBuilder do
         end
       end
     end
-
-    context "with deprecated named attributes" do
-      let(:field) do
-        builder.cads_collection_checkboxes(
-          :currency,
-          collection: example_options,
-          text_method: :name,
-          value_method: :id
-        )
-      end
-
-      before { allow(CitizensAdviceComponents.deprecator).to receive(:warn) }
-
-      it "logs deprecation warning" do
-        render_inline field
-        expect(CitizensAdviceComponents.deprecator).to have_received(:warn)
-          .with(/collection, text_method, and value_method named parameters are deprecated/)
-      end
-    end
   end
 
   describe "#cads_collection_check_boxes" do

--- a/engine/spec/helpers/citizens_advice_components/form_builder_cads_collection_radio_buttons_spec.rb
+++ b/engine/spec/helpers/citizens_advice_components/form_builder_cads_collection_radio_buttons_spec.rb
@@ -245,24 +245,5 @@ RSpec.describe CitizensAdviceComponents::FormBuilder do
         end
       end
     end
-
-    context "with deprecated named attributes" do
-      let(:field) do
-        builder.cads_collection_radio_buttons(
-          :currency,
-          collection: example_options,
-          text_method: :name,
-          value_method: :id
-        )
-      end
-
-      before { allow(CitizensAdviceComponents.deprecator).to receive(:warn) }
-
-      it "logs deprecation warning" do
-        render_inline field
-        expect(CitizensAdviceComponents.deprecator).to have_received(:warn)
-          .with(/collection, text_method, and value_method named parameters are deprecated/)
-      end
-    end
   end
 end

--- a/engine/spec/helpers/citizens_advice_components/form_builder_cads_collection_select_spec.rb
+++ b/engine/spec/helpers/citizens_advice_components/form_builder_cads_collection_select_spec.rb
@@ -126,29 +126,6 @@ RSpec.describe CitizensAdviceComponents::FormBuilder do
       end
     end
 
-    context "when deprecated additional_attributes has is provided" do
-      let(:field) do
-        builder.cads_collection_select(
-          :currency, example_options, :id, :name,
-          additional_attributes: { autocomplete: "name", "data-additional": "example" }
-        )
-      end
-
-      before { allow(CitizensAdviceComponents.deprecator).to receive(:warn) }
-
-      it "passes additional attributes through to element" do
-        render_inline field
-        expect(page).to have_css "select[autocomplete=name]"
-        expect(page).to have_css "select[data-additional=example]"
-      end
-
-      it "logs deprecation warning" do
-        render_inline field
-        expect(CitizensAdviceComponents.deprecator).to have_received(:warn)
-          .with(/additional_attributes hash is deprecated/)
-      end
-    end
-
     context "with validation errors" do
       let(:model) { ExampleForm.invalid_example }
       let(:field) do
@@ -180,25 +157,6 @@ RSpec.describe CitizensAdviceComponents::FormBuilder do
         it "sets multiple aria-describedby" do
           expect(page).to have_css "select[aria-describedby='example_form_currency-error example_form_currency-hint']"
         end
-      end
-    end
-
-    context "with deprecated named attributes" do
-      let(:field) do
-        builder.cads_collection_select(
-          :currency,
-          collection: example_options,
-          text_method: :name,
-          value_method: :id
-        )
-      end
-
-      before { allow(CitizensAdviceComponents.deprecator).to receive(:warn) }
-
-      it "logs deprecation warning" do
-        render_inline field
-        expect(CitizensAdviceComponents.deprecator).to have_received(:warn)
-          .with(/collection, text_method, and value_method named parameters are deprecated/)
       end
     end
   end

--- a/engine/spec/helpers/citizens_advice_components/form_builder_cads_text_field_spec.rb
+++ b/engine/spec/helpers/citizens_advice_components/form_builder_cads_text_field_spec.rb
@@ -114,29 +114,6 @@ RSpec.describe CitizensAdviceComponents::FormBuilder do
       end
     end
 
-    context "with deprecated additional_attributes hash" do
-      let(:field) do
-        builder.cads_text_field(
-          :name,
-          additional_attributes: { autocomplete: "name", "data-additional": "example" }
-        )
-      end
-
-      before { allow(CitizensAdviceComponents.deprecator).to receive(:warn) }
-
-      it "logs deprecation warning" do
-        render_inline field
-        expect(CitizensAdviceComponents.deprecator).to have_received(:warn)
-          .with(/additional_attributes hash is deprecated/)
-      end
-
-      it "passes via additional_attributes for backwards compatability" do
-        render_inline field
-        expect(page).to have_css "input[autocomplete=name]"
-        expect(page).to have_css "input[data-additional=example]"
-      end
-    end
-
     context "with additional attributes" do
       let(:field) do
         builder.cads_text_field(

--- a/engine/spec/helpers/citizens_advice_components/form_builder_cads_textarea_spec.rb
+++ b/engine/spec/helpers/citizens_advice_components/form_builder_cads_textarea_spec.rb
@@ -98,29 +98,6 @@ RSpec.describe CitizensAdviceComponents::FormBuilder do
       end
     end
 
-    context "with deprecated additional_attributes hash" do
-      let(:field) do
-        builder.cads_textarea(
-          :name,
-          additional_attributes: { autocomplete: "name", "data-additional": "example" }
-        )
-      end
-
-      before { allow(CitizensAdviceComponents.deprecator).to receive(:warn) }
-
-      it "logs deprecation warning" do
-        render_inline field
-        expect(CitizensAdviceComponents.deprecator).to have_received(:warn)
-          .with(/additional_attributes hash is deprecated/)
-      end
-
-      it "passes via additional_attributes for backwards compatability" do
-        render_inline field
-        expect(page).to have_css "textarea[autocomplete=name]"
-        expect(page).to have_css "textarea[data-additional=example]"
-      end
-    end
-
     context "with additional_attributes" do
       let(:field) do
         builder.cads_textarea(


### PR DESCRIPTION
- Remove deprecated collection params
- Remove additional_attributes named parameter from field methods
- Remove deprecator warnings from legacy components